### PR TITLE
feat(ci): Implement unified CI/CD workflow following best practices

### DIFF
--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -76,7 +76,7 @@ jobs:
         echo "🔍 Running MyPy type checker..."
         if [ -f mypy.ini ]; then
           mypy . --config-file mypy.ini
-        elif [ -f pyproject.toml ] && grep -q "tool\.mypy" pyproject.toml; then
+        elif [ -f pyproject.toml ] && grep -qE '^\s*\[tool\.mypy\]' pyproject.toml; then
           mypy .
         else
           # ✅ Non-strict fallback to avoid conflicts
@@ -194,13 +194,13 @@ jobs:
         pip install bandit==1.7.7
         # ✅ Exclude test directories, target source code only
         if [ -d python/src ]; then
-          bandit -r python/src --exclude '**/tests/**' -f json -o bandit-report.json
+          bandit -r python/src --exclude 'python/tests,**/tests/**' -f json -o bandit-report.json
         elif [ -d python ]; then
-          bandit -r python --exclude '**/tests/**' -f json -o bandit-report.json
+          bandit -r python --exclude 'tests,**/tests/**' -f json -o bandit-report.json
         elif [ -d src ]; then
-          bandit -r src --exclude '**/tests/**' -f json -o bandit-report.json
+          bandit -r src --exclude 'tests,**/tests/**' -f json -o bandit-report.json
         else
-          bandit -r . --exclude '**/tests/**' -f json -o bandit-report.json
+          bandit -r . --exclude 'tests,**/tests/**' -f json -o bandit-report.json
         fi
 
     - name: Upload Bandit results


### PR DESCRIPTION
## Summary

This PR implements the unified CI/CD workflow following all best practices outlined in `Repository_Management/UNIFIED_CI_APPROACH.md`.

## Changes

- ✅ Pinned tool versions for reproducibility
- ✅ Updated GitHub Actions to latest versions
- ✅ Comprehensive source directory detection
- ✅ Proper pytest exit code preservation
- ✅ Conditional coverage file uploads
- ✅ Enhanced security and documentation checks

Implements recommendations from: `Repository_Management/UNIFIED_CI_APPROACH.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Overhauls the PR quality workflow with pinned tool versions, smarter lint/type/format/test/coverage handling, conditional Codecov upload, and adds Bandit security and pydocstyle documentation checks.
> 
> - **CI Workflow (`.github/workflows/pr-quality-check.yml`)**:
>   - **Quality Check**:
>     - Pin versions for `ruff`, `mypy`, `black`, `pytest`, `pytest-cov`; expand pip cache key.
>     - Detect quality-check script in multiple paths; respect `ruff.toml`; smarter MyPy config detection with non-strict fallback.
>     - Black targets source/test dirs explicitly.
>     - Test runner auto-detects coverage target, preserves exit codes, supports subdir `pytest.ini`.
>     - Add coverage existence check; conditionally upload to Codecov with wildcard `**/coverage.xml` and token support.
>   - **Security Check**:
>     - Set up Python; run pinned `bandit` with test dirs excluded; continue-on-error; upload artifact, ignore missing.
>   - **Documentation Check**:
>     - Set up Python; pin `pydocstyle`; check only source dirs; basic README presence check; continue-on-error.
>   - **General**: enable `strategy.fail-fast`; normalize `fetch-depth: 0`; minor branch config comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b4d26142fea7d4cfbd9e6c8a04dc90e5f601780. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->