### PR TITLE
Fix zombie hallway games enter functionality

### DIFF
--- a/games/zombie-hallway-v1/index.html
+++ b/games/zombie-hallway-v1/index.html
@@ -5,8 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Zombie Hallway FPS (v1)</title>
   <link rel="stylesheet" href="style.css" />
-  <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/examples/js/controls/PointerLockControls.js"></script>
+  <script type="module" src="main.js"></script>
 </head>
 <body>
   <div id="overlay" class="overlay">
@@ -22,6 +21,5 @@
     <div id="ammo" class="bar">Ammo: 60</div>
   </div>
   <div id="crosshair">+</div>
-  <script src="main.js"></script>
 </body>
 </html>

--- a/games/zombie-hallway-v1/main.js
+++ b/games/zombie-hallway-v1/main.js
@@ -1,3 +1,6 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+import { PointerLockControls } from 'https://unpkg.com/three@0.158.0/examples/jsm/controls/PointerLockControls.js';
+
 const PLAYER_SPEED = 12;
 const PLAYER_SPRINT = 18;
 const PLAYER_HEIGHT = 1.8;
@@ -72,7 +75,7 @@ function init() {
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
 
-  controls = new THREE.PointerLockControls(camera, renderer.domElement);
+  controls = new PointerLockControls(camera, renderer.domElement);
   renderer.domElement.addEventListener('click', () => controls.lock());
 
   const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1.1);

--- a/games/zombie-hallway-v2/index.html
+++ b/games/zombie-hallway-v2/index.html
@@ -5,8 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Zombie Hallway FPS (v2)</title>
   <link rel="stylesheet" href="style.css" />
-  <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/examples/js/controls/PointerLockControls.js"></script>
+  <script type="module" src="main.js"></script>
 </head>
 <body>
   <div id="start" class="overlay">
@@ -24,6 +23,5 @@
   </div>
   <div id="crosshair">+</div>
   <div id="damageFlash" class="damage"></div>
-  <script src="main.js"></script>
 </body>
 </html>

--- a/games/zombie-hallway-v2/main.js
+++ b/games/zombie-hallway-v2/main.js
@@ -1,3 +1,6 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+import { PointerLockControls } from 'https://unpkg.com/three@0.158.0/examples/jsm/controls/PointerLockControls.js';
+
 const PLAYER_SPEED = 12;
 const PLAYER_SPRINT = 18;
 const PLAYER_HEIGHT = 1.8;
@@ -78,7 +81,7 @@ function init() {
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
 
-  controls = new THREE.PointerLockControls(camera, renderer.domElement);
+  controls = new PointerLockControls(camera, renderer.domElement);
   renderer.domElement.addEventListener('click', () => controls.lock());
 
   scene.add(new THREE.HemisphereLight(0xffffff, 0x555555, 1.1));


### PR DESCRIPTION
Update both zombie-hallway-v1 and zombie-hallway-v2 games to use ES module imports instead of legacy script loading. The old approach used incorrect paths for PointerLockControls (/examples/js/) which don't exist in Three.js r158+.

Changes:
- Convert HTML to use type="module" script loading
- Add ES module imports for THREE and PointerLockControls
- Update PointerLockControls instantiation to use imported class
- Remove duplicate script tags

This fixes the "Enter Hallway" button functionality that was broken due to PointerLockControls not loading properly.

## Summary
Explain what changed and why.

## AI Changes
- [ ] If AI-assisted: explain changes line-by-line or attach diff with comments.

## Checklist
- [ ] Reproducible: `matlab/run_all.m` (or Python pipeline) completes
- [ ] Tests pass (MATLAB + Python)
- [ ] Large binaries tracked via LFS
- [ ] Env files updated
- [ ] No secrets added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrate both zombie-hallway games to ES module-based Three.js and PointerLockControls, updating HTML script loading and control instantiation.
> 
> - **Games**:
>   - **`games/zombie-hallway-v1`**:
>     - HTML: switch to `type="module"` script (`main.js`); remove legacy CDN scripts and duplicate script tag.
>     - JS: add ES module imports for `three` and `PointerLockControls`; instantiate controls via `new PointerLockControls(...)`.
>   - **`games/zombie-hallway-v2`**:
>     - HTML: switch to `type="module"` script (`main.js`); remove legacy CDN scripts and duplicate script tag.
>     - JS: add ES module imports for `three` and `PointerLockControls`; instantiate controls via `new PointerLockControls(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f39e620f00200f9f2b3a8f2686fe2974ae185e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->