### PR TITLE
Add Peanut Butter Panic game from Playground repository

### DIFF
--- a/Doom/parent-doom-game/README.md
+++ b/Doom/parent-doom-game/README.md
@@ -1,0 +1,70 @@
+# Doom-like FPS Game
+
+A classic first-person shooter game built with HTML5 Canvas and JavaScript, featuring raycasting rendering (the same technique used in the original Doom).
+
+## Features
+
+- **3D Raycasting Engine**: Real-time 3D rendering using raycasting algorithm
+- **First-Person Controls**:
+  - WASD for movement
+  - Mouse for looking around
+  - Click to shoot
+  - E to open doors
+- **Enemy AI**: Enemies track and attack the player with new variants (dinosaurs, demons, raiders)
+- **Combat System**: Health, ammo, and damage mechanics
+- **Map Overlay**: Toggleable minimap to help with navigation
+- **Weapon Handling**: Ability to holster and re-draw your weapon
+- **Interactive Environment**: Doors that can be opened
+- **Win/Lose Conditions**: Eliminate all enemies to reach the exit and win
+
+## How to Play
+
+1. Open `index.html` in a modern web browser
+2. Click "START GAME"
+3. Use WASD to move, mouse to look around
+4. Click to shoot enemies (you have 50 bullets)
+5. Press E to open doors (gray walls)
+6. Kill all enemies to unlock the exit (green wall)
+7. Don't let your health reach 0!
+
+## Game Elements
+
+- **Brown Walls**: Solid obstacles
+- **Gray Walls**: Doors (press E to open)
+- **Green Wall**: Exit (only accessible after killing all enemies)
+- **Enemies**: Demons, dinosaurs, and raiders that chase and shoot at you
+- **Health**: Starts at 100, decreases when enemies attack
+- **Ammo**: Starts at 50 bullets
+
+## Technical Details
+
+- Built with vanilla JavaScript and HTML5 Canvas
+- Implements raycasting for 3D perspective
+- Real-time enemy AI with pathfinding
+- Collision detection
+- Weapon animations and recoil
+- HUD display
+
+## Controls Summary
+
+| Key | Action |
+|-----|--------|
+| W | Move forward |
+| S | Move backward |
+| A | Strafe left |
+| D | Strafe right |
+| Mouse | Look around |
+| Click | Shoot |
+| E | Open door |
+| H | Holster/draw weapon |
+| M | Toggle minimap |
+
+## Tips
+
+- Conserve ammo - you only have 50 bullets for 4 enemies
+- Each enemy takes multiple shots to kill
+- Keep moving to avoid enemy fire
+- Enemies deal varied damage based on their type
+- Use doors strategically to control enemy approach
+
+Enjoy the game!

--- a/Doom/parent-doom-game/game.js
+++ b/Doom/parent-doom-game/game.js
@@ -1,0 +1,854 @@
+// Game constants
+const SCREEN_WIDTH = 1024;
+const SCREEN_HEIGHT = 768;
+const TILE_SIZE = 64;
+const FOV = Math.PI / 3; // 60 degrees
+const MAX_DEPTH = 40;
+const NUM_RAYS = SCREEN_WIDTH / 2;
+
+const PLAYER_PISTOL_DAMAGE = 10;
+const ZOMBIE_DAMAGE = 10;
+const ZOMBIE_HEALTH = 80;
+const ATTACK_RANGE = 70;
+const FIREBALL_DAMAGE = 15;
+const FIREBALL_SPEED = 2.4;
+const FIREBALL_COOLDOWN = 2200;
+
+// Game map (1 = wall, 0 = empty, 2 = door, 3 = exit)
+const mapLayout = [
+    '111111111111111111111111111111111111111111111111',
+    '100000000000000000000000000000000000000000000001',
+    '100000001111100000000000000111111000000000000001',
+    '100000001111100000000100000111111000000000000001',
+    '100000001111100000011100000111111000000000000001',
+    '100000000000000111000000000000000000011110000001',
+    '100000000000000000000000000000000000000000000001',
+    '100000000001111000000000000000000001111000000001',
+    '100011100000000000000111100000000000000001111001',
+    '100000000000000000000000000000000000000000000001',
+    '100000000000000000000001111000000000000000000031',
+    '111111111111111111111111111111111111111111111111'
+];
+
+const map = mapLayout.map(row => row.split('').map(Number));
+const MAP_HEIGHT = map.length;
+const MAP_WIDTH = map[0].length;
+
+// Game state
+let gameState = {
+    running: false,
+    won: false,
+    gameOver: false
+};
+
+// Player
+const player = {
+    x: 2 * TILE_SIZE,
+    y: 2 * TILE_SIZE,
+    angle: 0,
+    speed: 0,
+    strafeSpeed: 0,
+    rotationSpeed: 0,
+    health: 100,
+    maxHealth: 100,
+    ammo: 120,
+    kills: 0
+};
+
+// Enemies
+const enemyTypes = {
+    zombie: {
+        color: '#6b8a6f',
+        speed: 1.4,
+        damage: ZOMBIE_DAMAGE,
+        attackCooldown: 900,
+        sprite: 'Zombie',
+        scale: 1,
+        fireball: null
+    },
+    boss: {
+        color: '#8c3f3f',
+        speed: 1.1,
+        damage: 15,
+        attackCooldown: 800,
+        sprite: 'Boss',
+        scale: 2,
+        fireball: { damage: FIREBALL_DAMAGE, speed: FIREBALL_SPEED, cooldown: FIREBALL_COOLDOWN }
+    }
+};
+
+const enemies = [
+    { x: 6 * TILE_SIZE, y: 6 * TILE_SIZE, type: 'zombie' },
+    { x: 12 * TILE_SIZE, y: 5 * TILE_SIZE, type: 'zombie' },
+    { x: 18 * TILE_SIZE, y: 8 * TILE_SIZE, type: 'zombie' },
+    { x: 26 * TILE_SIZE, y: 5 * TILE_SIZE, type: 'zombie' },
+    { x: 32 * TILE_SIZE, y: 7 * TILE_SIZE, type: 'zombie' },
+    { x: 38 * TILE_SIZE, y: 4 * TILE_SIZE, type: 'zombie' },
+    { x: 44 * TILE_SIZE, y: 6 * TILE_SIZE, type: 'boss' }
+].map(enemy => ({
+    ...enemy,
+    health: enemy.type === 'boss' ? ZOMBIE_HEALTH * 2 : ZOMBIE_HEALTH,
+    maxHealth: enemy.type === 'boss' ? ZOMBIE_HEALTH * 2 : ZOMBIE_HEALTH,
+    angle: 0,
+    lastAttack: 0,
+    lastFireball: 0,
+    mouthOpen: false,
+    mouthTimer: 0,
+    eyeRotation: 0,
+    droolOffset: 0,
+    legPhase: 0
+}));
+
+const projectiles = [];
+
+// Input handling
+const keys = {};
+
+// Weapon state
+const weapon = {
+    bobOffset: 0,
+    shootAnimOffset: 0,
+    isShooting: false,
+    lastShot: 0,
+    shootCooldown: 300,
+    isHolstered: false,
+    aiming: false
+};
+
+let minimapVisible = true;
+let currentFov = FOV;
+
+// Canvas setup
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+canvas.width = SCREEN_WIDTH;
+canvas.height = SCREEN_HEIGHT;
+
+// Start screen
+const startScreen = document.getElementById('startScreen');
+const startButton = document.getElementById('startButton');
+
+startButton.addEventListener('click', () => {
+    startScreen.style.display = 'none';
+    gameState.running = true;
+    canvas.requestPointerLock();
+    gameLoop();
+});
+
+// Event listeners
+document.addEventListener('keydown', (e) => {
+    const key = e.key.toLowerCase();
+    keys[key] = true;
+
+    if (key === 'e') {
+        openDoor();
+    }
+
+    if (key === 'h') {
+        weapon.isHolstered = !weapon.isHolstered;
+    }
+
+    if (key === 'm') {
+        minimapVisible = !minimapVisible;
+    }
+});
+
+document.addEventListener('keyup', (e) => {
+    keys[e.key.toLowerCase()] = false;
+});
+
+document.addEventListener('mousemove', (e) => {
+    if (document.pointerLockElement === canvas) {
+        player.angle += e.movementX * 0.002;
+    }
+});
+
+canvas.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+});
+
+canvas.addEventListener('mousedown', (e) => {
+    if (gameState.running && !gameState.gameOver && !gameState.won) {
+        canvas.requestPointerLock();
+
+        if (e.button === 0) {
+            weapon.aiming = true;
+            currentFov = FOV * 0.85;
+        }
+
+        if (e.button === 2) {
+            shoot();
+        }
+    }
+});
+
+document.addEventListener('mouseup', (e) => {
+    if (e.button === 0) {
+        weapon.aiming = false;
+        currentFov = FOV;
+    }
+});
+
+// Helper functions
+function castRay(rayAngle, originX = player.x, originY = player.y) {
+    const rayX = Math.cos(rayAngle);
+    const rayY = Math.sin(rayAngle);
+
+    let distanceToWall = 0;
+    let hitWall = false;
+    let wallType = 0;
+    let side = 0; // 0 = vertical, 1 = horizontal
+
+    while (!hitWall && distanceToWall < MAX_DEPTH) {
+        distanceToWall += 0.1;
+
+        const testX = originX + rayX * distanceToWall * TILE_SIZE;
+        const testY = originY + rayY * distanceToWall * TILE_SIZE;
+
+        const mapX = Math.floor(testX / TILE_SIZE);
+        const mapY = Math.floor(testY / TILE_SIZE);
+
+        if (mapX < 0 || mapX >= MAP_WIDTH || mapY < 0 || mapY >= MAP_HEIGHT) {
+            hitWall = true;
+            distanceToWall = MAX_DEPTH;
+        } else if (map[mapY][mapX] > 0) {
+            hitWall = true;
+            wallType = map[mapY][mapX];
+
+            // Determine which side was hit
+            const blockMidX = mapX * TILE_SIZE + TILE_SIZE / 2;
+            const blockMidY = mapY * TILE_SIZE + TILE_SIZE / 2;
+
+            const dx = testX - blockMidX;
+            const dy = testY - blockMidY;
+
+            side = Math.abs(dx) > Math.abs(dy) ? 0 : 1;
+        }
+    }
+
+    return { distance: distanceToWall, wallType, side };
+}
+
+function hasLineOfSight(originX, originY, targetX, targetY) {
+    const angle = Math.atan2(targetY - originY, targetX - originX);
+    const ray = castRay(angle, originX, originY);
+    const distanceToTarget = Math.hypot(targetX - originX, targetY - originY) / TILE_SIZE;
+    return ray.distance >= distanceToTarget - 0.1;
+}
+
+function drawWalls() {
+    // Sky
+    ctx.fillStyle = '#2a2a3e';
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT / 2);
+
+    // Floor
+    ctx.fillStyle = '#3d3d3d';
+    ctx.fillRect(0, SCREEN_HEIGHT / 2, SCREEN_WIDTH, SCREEN_HEIGHT / 2);
+
+    // Cast rays
+    for (let x = 0; x < NUM_RAYS; x++) {
+        const rayAngle = (player.angle - currentFov / 2) + (x / NUM_RAYS) * currentFov;
+        const ray = castRay(rayAngle);
+
+        const distance = ray.distance * Math.cos(rayAngle - player.angle); // Fix fisheye
+        const wallHeight = (TILE_SIZE / distance) * 277;
+
+        // Wall color based on type and side
+        let color;
+        if (ray.wallType === 1) {
+            color = ray.side === 0 ? '#8B4513' : '#654321';
+        } else if (ray.wallType === 2) {
+            color = ray.side === 0 ? '#4a4a4a' : '#333333'; // Door
+        } else if (ray.wallType === 3) {
+            color = ray.side === 0 ? '#00ff00' : '#00cc00'; // Exit
+        }
+
+        // Draw wall slice
+        const drawX = x * (SCREEN_WIDTH / NUM_RAYS);
+        const drawY = (SCREEN_HEIGHT - wallHeight) / 2;
+
+        ctx.fillStyle = color;
+        ctx.fillRect(drawX, drawY, SCREEN_WIDTH / NUM_RAYS + 1, wallHeight);
+
+        // Add darkness based on distance
+        const darkness = Math.min(distance / MAX_DEPTH, 0.7);
+        ctx.fillStyle = `rgba(0, 0, 0, ${darkness})`;
+        ctx.fillRect(drawX, drawY, SCREEN_WIDTH / NUM_RAYS + 1, wallHeight);
+    }
+}
+
+function drawEnemySprite(spriteX, spriteY, spriteSize, enemy) {
+    const type = enemyTypes[enemy.type];
+    const bodyWidth = spriteSize * 0.6;
+    const bodyHeight = spriteSize;
+    const headSize = spriteSize * 0.4;
+    const centerX = spriteX + spriteSize / 2;
+    const bodyX = centerX - bodyWidth / 2;
+    const bodyY = spriteY + spriteSize * 0.05;
+
+    // Legs with speed-synced stride
+    const legStride = Math.sin(enemy.legPhase) * spriteSize * 0.08;
+    const legWidth = spriteSize * 0.18;
+    const legHeight = spriteSize * 0.45;
+    const legY = bodyY + bodyHeight * 0.55;
+
+    ctx.fillStyle = '#2a2a2a';
+    ctx.fillRect(centerX - bodyWidth * 0.45 + legStride, legY, legWidth, legHeight);
+    ctx.fillRect(centerX + bodyWidth * 0.25 - legStride, legY, legWidth, legHeight);
+
+    ctx.fillStyle = type.color;
+    ctx.fillRect(bodyX, bodyY + headSize * 0.8, bodyWidth, bodyHeight * 0.6);
+
+    ctx.fillStyle = '#2a1c1c';
+    ctx.fillRect(bodyX, bodyY + bodyHeight * 0.65, bodyWidth, bodyHeight * 0.1);
+
+    ctx.fillStyle = '#d9d9d9';
+    ctx.fillRect(centerX - headSize / 2, bodyY, headSize, headSize);
+
+    // Eyes with spinning pupils
+    const eyeRadius = headSize * 0.12;
+    const pupilRadius = eyeRadius * 0.6;
+    const eyeYOffset = headSize * 0.25;
+    const eyeSpacing = headSize * 0.18;
+
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.arc(centerX - eyeSpacing, bodyY + eyeYOffset, eyeRadius, 0, Math.PI * 2);
+    ctx.arc(centerX + eyeSpacing, bodyY + eyeYOffset, eyeRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    const pupilAngle = enemy.eyeRotation;
+    const pupilOffset = eyeRadius * 0.4;
+    const pupilXOffset = Math.cos(pupilAngle) * pupilOffset;
+    const pupilYOffset = Math.sin(pupilAngle) * pupilOffset;
+
+    ctx.fillStyle = '#222222';
+    ctx.beginPath();
+    ctx.arc(centerX - eyeSpacing + pupilXOffset, bodyY + eyeYOffset + pupilYOffset, pupilRadius, 0, Math.PI * 2);
+    ctx.arc(centerX + eyeSpacing + pupilXOffset, bodyY + eyeYOffset + pupilYOffset, pupilRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Mouth animation
+    const mouthWidth = headSize * 0.7;
+    const mouthHeight = enemy.mouthOpen ? headSize * 0.3 : headSize * 0.12;
+    const mouthX = centerX - mouthWidth / 2;
+    const mouthY = bodyY + headSize * 0.65;
+
+    ctx.fillStyle = '#b42a2a';
+    ctx.fillRect(mouthX, mouthY, mouthWidth, mouthHeight);
+
+    ctx.fillStyle = '#eeeeee';
+    const toothWidth = mouthWidth / 6;
+    const toothHeight = mouthHeight * 0.6;
+    for (let i = 0; i < 6; i++) {
+        ctx.fillRect(mouthX + i * toothWidth, mouthY, toothWidth * 0.6, toothHeight);
+    }
+
+    // Drool
+    ctx.strokeStyle = '#7ed6ff';
+    ctx.lineWidth = Math.max(2, spriteSize * 0.01);
+    const droolLength = mouthHeight * 1.2 + (enemy.droolOffset % 10);
+    ctx.beginPath();
+    ctx.moveTo(mouthX + mouthWidth * 0.1, mouthY + mouthHeight);
+    ctx.lineTo(mouthX + mouthWidth * 0.1, mouthY + mouthHeight + droolLength);
+    ctx.moveTo(mouthX + mouthWidth * 0.9, mouthY + mouthHeight);
+    ctx.lineTo(mouthX + mouthWidth * 0.9, mouthY + mouthHeight + droolLength * 0.8);
+    ctx.stroke();
+
+    // Claws or weapons indicator
+    ctx.fillStyle = '#f4f4f4';
+    ctx.fillRect(centerX - bodyWidth * 0.45, bodyY + bodyHeight * 0.6, bodyWidth * 0.15, bodyHeight * 0.2);
+    ctx.fillRect(centerX + bodyWidth * 0.3, bodyY + bodyHeight * 0.6, bodyWidth * 0.15, bodyHeight * 0.2);
+}
+
+function drawEnemies() {
+    // Sort enemies by distance (far to near)
+    const sortedEnemies = enemies
+        .filter(enemy => enemy.health > 0)
+        .map(enemy => {
+            const dx = enemy.x - player.x;
+            const dy = enemy.y - player.y;
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            const angle = Math.atan2(dy, dx) - player.angle;
+            return { enemy, distance, angle };
+        })
+        .sort((a, b) => b.distance - a.distance);
+
+    sortedEnemies.forEach(({ enemy, distance, angle }) => {
+        // Normalize angle to -PI to PI
+        let normalizedAngle = angle;
+        while (normalizedAngle > Math.PI) normalizedAngle -= 2 * Math.PI;
+        while (normalizedAngle < -Math.PI) normalizedAngle += 2 * Math.PI;
+
+        // Check if enemy is in FOV
+        if (Math.abs(normalizedAngle) < currentFov / 2 + 0.5) {
+            if (!hasLineOfSight(player.x, player.y, enemy.x, enemy.y)) {
+                return;
+            }
+
+            const type = enemyTypes[enemy.type];
+            const spriteSize = (TILE_SIZE / distance) * 277 * type.scale;
+            const spriteX = SCREEN_WIDTH / 2 + (normalizedAngle / currentFov) * SCREEN_WIDTH - spriteSize / 2;
+            const spriteY = SCREEN_HEIGHT / 2 - spriteSize / 2;
+
+            drawEnemySprite(spriteX, spriteY, spriteSize, enemy);
+
+            // Draw health bar
+            const healthBarWidth = spriteSize;
+            const healthBarHeight = 5;
+            const healthPercent = enemy.health / enemy.maxHealth;
+
+            ctx.fillStyle = '#ff0000';
+            ctx.fillRect(spriteX, spriteY - 10, healthBarWidth, healthBarHeight);
+            ctx.fillStyle = '#00ff00';
+            ctx.fillRect(spriteX, spriteY - 10, healthBarWidth * healthPercent, healthBarHeight);
+        }
+    });
+}
+
+function drawProjectiles() {
+    const sortedProjectiles = projectiles
+        .map(projectile => {
+            const dx = projectile.x - player.x;
+            const dy = projectile.y - player.y;
+            const distance = Math.max(0.1, Math.sqrt(dx * dx + dy * dy));
+            const angle = Math.atan2(dy, dx) - player.angle;
+            return { projectile, distance, angle };
+        })
+        .sort((a, b) => b.distance - a.distance);
+
+    sortedProjectiles.forEach(({ projectile, distance, angle }) => {
+        let normalizedAngle = angle;
+        while (normalizedAngle > Math.PI) normalizedAngle -= 2 * Math.PI;
+        while (normalizedAngle < -Math.PI) normalizedAngle += 2 * Math.PI;
+
+        if (
+            Math.abs(normalizedAngle) < currentFov / 2 + 0.5 &&
+            hasLineOfSight(player.x, player.y, projectile.x, projectile.y)
+        ) {
+            const spriteSize = (TILE_SIZE / distance) * 90;
+            const spriteX =
+                SCREEN_WIDTH / 2 + (normalizedAngle / currentFov) * SCREEN_WIDTH - spriteSize / 2;
+            const spriteY = SCREEN_HEIGHT / 2 - spriteSize / 2;
+
+            const gradient = ctx.createRadialGradient(
+                spriteX + spriteSize / 2,
+                spriteY + spriteSize / 2,
+                spriteSize * 0.1,
+                spriteX + spriteSize / 2,
+                spriteY + spriteSize / 2,
+                spriteSize * 0.6
+            );
+
+            gradient.addColorStop(0, '#ffcc66');
+            gradient.addColorStop(0.5, '#ff6600');
+            gradient.addColorStop(1, 'rgba(0,0,0,0)');
+
+            ctx.fillStyle = gradient;
+            ctx.beginPath();
+            ctx.arc(spriteX + spriteSize / 2, spriteY + spriteSize / 2, spriteSize / 2, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    });
+}
+
+function drawWeapon() {
+    if (weapon.isHolstered) {
+        return;
+    }
+
+    const aimLift = weapon.aiming ? 25 : 0;
+    const weaponY =
+        SCREEN_HEIGHT - 200 + Math.sin(weapon.bobOffset) * 10 + weapon.shootAnimOffset - aimLift;
+    const weaponX = SCREEN_WIDTH / 2 - 50 + (weapon.aiming ? 8 : 0);
+
+    // Draw simple gun
+    ctx.fillStyle = '#444';
+    ctx.fillRect(weaponX, weaponY, 100, 200);
+
+    ctx.fillStyle = '#666';
+    ctx.fillRect(weaponX + 20, weaponY, 60, 150);
+
+    ctx.fillStyle = '#222';
+    ctx.fillRect(weaponX + 35, weaponY, 30, 80);
+
+    // Muzzle flash
+    if (weapon.shootAnimOffset < 0) {
+        ctx.fillStyle = '#ffff00';
+        ctx.fillRect(weaponX + 25, weaponY - 20, 50, 20);
+    }
+}
+
+function drawHUD() {
+    // Health
+    ctx.fillStyle = '#ff0000';
+    ctx.font = '24px Courier New';
+    ctx.fillText(`HEALTH: ${Math.max(0, player.health)}`, 20, 30);
+
+    // Ammo
+    ctx.fillStyle = '#ffff00';
+    ctx.fillText(`AMMO: ${player.ammo}`, 20, 60);
+
+    // Kills
+    ctx.fillStyle = '#00ff00';
+    ctx.fillText(`KILLS: ${player.kills}/${enemies.length}`, 20, 90);
+
+    // Weapon state
+    ctx.fillStyle = weapon.isHolstered ? '#ffaa00' : '#00ff00';
+    const holsterText = weapon.isHolstered ? 'HOLSTERED' : 'READY';
+    ctx.fillText(`GUN: ${holsterText}`, 20, 120);
+
+    // Crosshair
+    ctx.strokeStyle = '#00ff00';
+    ctx.lineWidth = 2;
+    const crosshairSize = weapon.aiming ? 6 : 10;
+    ctx.beginPath();
+    ctx.moveTo(SCREEN_WIDTH / 2 - crosshairSize, SCREEN_HEIGHT / 2);
+    ctx.lineTo(SCREEN_WIDTH / 2 + crosshairSize, SCREEN_HEIGHT / 2);
+    ctx.moveTo(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 - crosshairSize);
+    ctx.lineTo(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + crosshairSize);
+    ctx.stroke();
+}
+
+function updatePlayer(deltaTime) {
+    // Movement
+    player.speed = 0;
+    player.strafeSpeed = 0;
+
+    if (keys['w']) player.speed = 3;
+    if (keys['s']) player.speed = -3;
+    if (keys['a']) player.strafeSpeed = -3;
+    if (keys['d']) player.strafeSpeed = 3;
+
+    // Calculate new position
+    const newX = player.x + Math.cos(player.angle) * player.speed + Math.cos(player.angle + Math.PI / 2) * player.strafeSpeed;
+    const newY = player.y + Math.sin(player.angle) * player.speed + Math.sin(player.angle + Math.PI / 2) * player.strafeSpeed;
+
+    // Collision detection
+    const mapX = Math.floor(newX / TILE_SIZE);
+    const mapY = Math.floor(newY / TILE_SIZE);
+
+    if (map[mapY] && map[mapY][mapX] === 0) {
+        player.x = newX;
+        player.y = newY;
+    }
+
+    // Check for exit
+    if (map[mapY] && map[mapY][mapX] === 3 && player.kills === enemies.length) {
+        gameState.won = true;
+    }
+
+    // Weapon bobbing
+    if (player.speed !== 0 || player.strafeSpeed !== 0) {
+        weapon.bobOffset += weapon.aiming ? 0.08 : 0.15;
+    }
+
+    // Weapon shoot animation
+    if (weapon.shootAnimOffset < 0) {
+        weapon.shootAnimOffset += 5;
+    }
+}
+
+function updateEnemies(deltaTime) {
+    const currentTime = Date.now();
+
+    enemies.forEach(enemy => {
+        if (enemy.health <= 0) return;
+
+        const type = enemyTypes[enemy.type];
+        const dx = player.x - enemy.x;
+        const dy = player.y - enemy.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        const angleToPlayer = Math.atan2(dy, dx);
+
+        enemy.eyeRotation += deltaTime * 10;
+        enemy.droolOffset = (enemy.droolOffset + deltaTime * 40) % 20;
+
+        const seesPlayer =
+            distance < 900 && hasLineOfSight(enemy.x, enemy.y, player.x, player.y);
+        let movement = 0;
+
+        if (seesPlayer) {
+            enemy.mouthTimer += deltaTime;
+            if (enemy.mouthTimer > 0.25) {
+                enemy.mouthOpen = !enemy.mouthOpen;
+                enemy.mouthTimer = 0;
+            }
+
+            const newX = enemy.x + Math.cos(angleToPlayer) * type.speed;
+            const newY = enemy.y + Math.sin(angleToPlayer) * type.speed;
+
+            const mapX = Math.floor(newX / TILE_SIZE);
+            const mapY = Math.floor(newY / TILE_SIZE);
+
+            if (map[mapY] && map[mapY][mapX] === 0) {
+                movement = Math.sqrt((newX - enemy.x) ** 2 + (newY - enemy.y) ** 2);
+                enemy.x = newX;
+                enemy.y = newY;
+            }
+
+            const attackReach = ATTACK_RANGE + (enemy.type === 'boss' ? 10 : 0);
+            if (distance < attackReach && currentTime - enemy.lastAttack > type.attackCooldown) {
+                player.health -= type.damage;
+                enemy.lastAttack = currentTime;
+
+                if (player.health <= 0) {
+                    gameState.gameOver = true;
+                }
+            }
+
+            if (type.fireball && currentTime - enemy.lastFireball > type.fireball.cooldown) {
+                projectiles.push({
+                    x: enemy.x,
+                    y: enemy.y,
+                    angle: angleToPlayer,
+                    speed: type.fireball.speed,
+                    damage: type.fireball.damage
+                });
+                enemy.lastFireball = currentTime;
+            }
+        } else if (currentTime % 1500 < 40) {
+            const wanderAngle = (enemy.x + enemy.y + currentTime * 0.0005) % (Math.PI * 2);
+            const newX = enemy.x + Math.cos(wanderAngle) * type.speed * 0.4;
+            const newY = enemy.y + Math.sin(wanderAngle) * type.speed * 0.4;
+
+            const mapX = Math.floor(newX / TILE_SIZE);
+            const mapY = Math.floor(newY / TILE_SIZE);
+
+            if (map[mapY] && map[mapY][mapX] === 0) {
+                movement = Math.sqrt((newX - enemy.x) ** 2 + (newY - enemy.y) ** 2);
+                enemy.x = newX;
+                enemy.y = newY;
+            }
+        }
+
+        enemy.legPhase += movement * 0.2;
+    });
+}
+
+function updateProjectiles(deltaTime) {
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+        const projectile = projectiles[i];
+        projectile.x += Math.cos(projectile.angle) * projectile.speed * TILE_SIZE * deltaTime;
+        projectile.y += Math.sin(projectile.angle) * projectile.speed * TILE_SIZE * deltaTime;
+
+        const mapX = Math.floor(projectile.x / TILE_SIZE);
+        const mapY = Math.floor(projectile.y / TILE_SIZE);
+
+        if (
+            mapX < 0 ||
+            mapX >= MAP_WIDTH ||
+            mapY < 0 ||
+            mapY >= MAP_HEIGHT ||
+            (map[mapY] && map[mapY][mapX] > 0)
+        ) {
+            projectiles.splice(i, 1);
+            continue;
+        }
+
+        const distanceToPlayer = Math.hypot(projectile.x - player.x, projectile.y - player.y);
+        if (distanceToPlayer < 24) {
+            player.health -= projectile.damage;
+            projectiles.splice(i, 1);
+
+            if (player.health <= 0) {
+                gameState.gameOver = true;
+            }
+        }
+    }
+}
+
+function shoot() {
+    const currentTime = Date.now();
+
+    if (weapon.isHolstered) return;
+    if (currentTime - weapon.lastShot < weapon.shootCooldown) return;
+    if (player.ammo <= 0) return;
+
+    player.ammo--;
+    weapon.lastShot = currentTime;
+    weapon.shootAnimOffset = -30;
+
+    // Check if we hit an enemy
+    const centerRay = castRay(player.angle);
+
+    enemies.forEach(enemy => {
+        if (enemy.health <= 0) return;
+
+        const dx = enemy.x - player.x;
+        const dy = enemy.y - player.y;
+        const distance = Math.sqrt(dx * dx + dy * dy) / TILE_SIZE;
+        const angle = Math.atan2(dy, dx);
+
+        let angleDiff = angle - player.angle;
+        while (angleDiff > Math.PI) angleDiff -= 2 * Math.PI;
+        while (angleDiff < -Math.PI) angleDiff += 2 * Math.PI;
+
+        const aimAllowance =
+            (weapon.aiming ? 0.1 : 0.2) + Math.max(0, 0.05 - distance * 0.002);
+
+        // Check if enemy is in crosshair and visible
+        if (
+            Math.abs(angleDiff) < aimAllowance &&
+            distance < centerRay.distance &&
+            hasLineOfSight(player.x, player.y, enemy.x, enemy.y)
+        ) {
+            enemy.health -= PLAYER_PISTOL_DAMAGE;
+
+            if (enemy.health <= 0) {
+                player.kills++;
+            }
+        }
+    });
+}
+
+function openDoor() {
+    const doorCheckDist = 1.5;
+    const checkX = player.x + Math.cos(player.angle) * TILE_SIZE * doorCheckDist;
+    const checkY = player.y + Math.sin(player.angle) * TILE_SIZE * doorCheckDist;
+
+    const mapX = Math.floor(checkX / TILE_SIZE);
+    const mapY = Math.floor(checkY / TILE_SIZE);
+
+    if (map[mapY] && map[mapY][mapX] === 2) {
+        map[mapY][mapX] = 0; // Open door
+    }
+}
+
+function drawGameOver() {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    ctx.fillStyle = '#ff0000';
+    ctx.font = '64px Courier New';
+    ctx.textAlign = 'center';
+    ctx.fillText('GAME OVER', SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2);
+
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '24px Courier New';
+    ctx.fillText('Refresh to try again', SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + 50);
+    ctx.textAlign = 'left';
+}
+
+function drawMinimap() {
+    if (!minimapVisible) return;
+
+    const mapScale = 4;
+    const minimapWidth = MAP_WIDTH * mapScale;
+    const minimapHeight = MAP_HEIGHT * mapScale;
+    const offset = 20;
+
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+    ctx.fillRect(
+        SCREEN_WIDTH - minimapWidth - offset - 10,
+        offset - 10,
+        minimapWidth + 20,
+        minimapHeight + 20
+    );
+
+    for (let y = 0; y < MAP_HEIGHT; y++) {
+        for (let x = 0; x < MAP_WIDTH; x++) {
+            const tile = map[y][x];
+            if (tile === 1) {
+                ctx.fillStyle = '#6b4b3e';
+            } else if (tile === 2) {
+                ctx.fillStyle = '#9d9d9d';
+            } else if (tile === 3) {
+                ctx.fillStyle = '#00cc44';
+            } else {
+                ctx.fillStyle = '#1b1b1b';
+            }
+
+            ctx.fillRect(
+                SCREEN_WIDTH - minimapWidth - offset + x * mapScale,
+                offset + y * mapScale,
+                mapScale,
+                mapScale
+            );
+        }
+    }
+
+    // Player
+    ctx.fillStyle = '#ffff00';
+    ctx.fillRect(
+        SCREEN_WIDTH - minimapWidth - offset + (player.x / TILE_SIZE) * mapScale - 2,
+        offset + (player.y / TILE_SIZE) * mapScale - 2,
+        4,
+        4
+    );
+
+    // Player direction
+    ctx.strokeStyle = '#ffff00';
+    ctx.beginPath();
+    ctx.moveTo(
+        SCREEN_WIDTH - minimapWidth - offset + (player.x / TILE_SIZE) * mapScale,
+        offset + (player.y / TILE_SIZE) * mapScale
+    );
+    ctx.lineTo(
+        SCREEN_WIDTH - minimapWidth - offset + ((player.x / TILE_SIZE) + Math.cos(player.angle)) * mapScale,
+        offset + ((player.y / TILE_SIZE) + Math.sin(player.angle)) * mapScale
+    );
+    ctx.stroke();
+
+    // Enemies
+    enemies.forEach(enemy => {
+        if (enemy.health <= 0) return;
+        ctx.fillStyle = enemyTypes[enemy.type].color;
+        ctx.fillRect(
+            SCREEN_WIDTH - minimapWidth - offset + (enemy.x / TILE_SIZE) * mapScale - 2,
+            offset + (enemy.y / TILE_SIZE) * mapScale - 2,
+            4,
+            4
+        );
+    });
+}
+
+function drawWin() {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    ctx.fillStyle = '#00ff00';
+    ctx.font = '64px Courier New';
+    ctx.textAlign = 'center';
+    ctx.fillText('YOU WIN!', SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2);
+
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '24px Courier New';
+    ctx.fillText('All enemies eliminated!', SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + 50);
+    ctx.textAlign = 'left';
+}
+
+// Main game loop
+let lastTime = Date.now();
+
+function gameLoop() {
+    if (!gameState.running) return;
+
+    const currentTime = Date.now();
+    const deltaTime = (currentTime - lastTime) / 1000;
+    lastTime = currentTime;
+
+    // Clear canvas
+    ctx.clearRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    if (!gameState.gameOver && !gameState.won) {
+        // Update
+        updatePlayer(deltaTime);
+        updateEnemies(deltaTime);
+        updateProjectiles(deltaTime);
+
+        // Draw
+        drawWalls();
+        drawEnemies();
+        drawProjectiles();
+        drawWeapon();
+        drawHUD();
+        drawMinimap();
+    } else if (gameState.gameOver) {
+        drawGameOver();
+    } else if (gameState.won) {
+        drawWin();
+    }
+
+    requestAnimationFrame(gameLoop);
+}

--- a/Doom/parent-doom-game/index.html
+++ b/Doom/parent-doom-game/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Doom-like FPS Game</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            background: #000;
+            overflow: hidden;
+            font-family: 'Courier New', monospace;
+        }
+
+        #gameCanvas {
+            display: block;
+            margin: 0 auto;
+            background: #000;
+            image-rendering: pixelated;
+            image-rendering: crisp-edges;
+        }
+
+        #startScreen {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.9);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            color: #ff0000;
+            z-index: 1000;
+        }
+
+        #startScreen h1 {
+            font-size: 64px;
+            margin-bottom: 20px;
+            text-shadow: 0 0 10px #ff0000;
+        }
+
+        #startScreen p {
+            font-size: 18px;
+            margin: 10px;
+            color: #fff;
+        }
+
+        #startScreen button {
+            margin-top: 30px;
+            padding: 15px 40px;
+            font-size: 24px;
+            background: #ff0000;
+            color: #fff;
+            border: none;
+            cursor: pointer;
+            font-family: 'Courier New', monospace;
+            text-transform: uppercase;
+        }
+
+        #startScreen button:hover {
+            background: #cc0000;
+        }
+
+        .controls {
+            color: #888;
+            font-size: 14px;
+        }
+    </style>
+</head>
+<body>
+    <div id="startScreen">
+        <h1>DOOM-LIKE</h1>
+        <p class="controls">WASD - Move</p>
+        <p class="controls">Mouse - Look Around</p>
+        <p class="controls">Left Click - Aim</p>
+        <p class="controls">Right Click - Fire</p>
+        <p class="controls">E - Open Doors</p>
+        <p class="controls">H - Holster/Draw Weapon</p>
+        <p class="controls">M - Toggle Minimap</p>
+        <p style="margin-top: 20px; color: #ff0000;">Kill all enemies to win!</p>
+        <button id="startButton">START GAME</button>
+    </div>
+    <canvas id="gameCanvas"></canvas>
+
+    <script src="game.js"></script>
+</body>
+</html>

--- a/Doom/zombie-doom-game/README.md
+++ b/Doom/zombie-doom-game/README.md
@@ -1,0 +1,72 @@
+# Doom-like FPS Game
+
+A classic first-person shooter game built with HTML5 Canvas and JavaScript, featuring raycasting rendering (the same technique used in the original Doom).
+
+## Features
+
+- **3D Raycasting Engine**: Real-time 3D rendering using raycasting algorithm
+- **First-Person Controls**:
+  - WASD for movement (hold **Shift** to sprint)
+  - Mouse for looking around (left click aims, right click fires)
+  - E to open doors
+- **Enemy AI**: Enemies track and attack the player with new variants (dinosaurs, demons, raiders)
+- **Combat System**: Health, ammo, pistol/rifle loadout, and damage mechanics
+- **Map Overlay**: Toggleable minimap to help with navigation
+- **Weapon Handling**: Ability to holster and re-draw your weapon
+- **Zombie Flavor**: Zombie-themed jump scare overlay when you die
+- **Interactive Environment**: Doors that can be opened
+- **Win/Lose Conditions**: Eliminate all enemies to reach the exit and win
+
+## How to Play
+
+1. Open `index.html` in a modern web browser
+2. Click "START GAME"
+3. Use WASD to move, mouse to look around, hold Shift to sprint
+4. Left click to aim, right click to fire (pistol starts with 120 ammo, rifle with 90)
+5. Press E to open doors (gray walls)
+6. Kill all enemies to unlock the exit (green wall)
+7. Don't let your health reach 0!
+
+## Game Elements
+
+- **Brown Walls**: Solid obstacles
+- **Gray Walls**: Doors (press E to open)
+- **Green Wall**: Exit (only accessible after killing all enemies)
+- **Enemies**: Demons, dinosaurs, and raiders that chase and shoot at you
+- **Health**: Starts at 100, decreases when enemies attack
+- **Ammo**: Starts at 120 pistol rounds and 90 rifle rounds
+
+## Technical Details
+
+- Built with vanilla JavaScript and HTML5 Canvas
+- Implements raycasting for 3D perspective
+- Real-time enemy AI with pathfinding
+- Collision detection
+- Weapon animations and recoil
+- HUD display
+
+## Controls Summary
+
+| Key | Action |
+|-----|--------|
+| W | Move forward |
+| S | Move backward |
+| A | Strafe left |
+| D | Strafe right |
+| Mouse | Look around |
+| Left Click | Aim |
+| Right Click | Shoot |
+| E | Open door |
+| H | Holster/draw weapon |
+| M | Toggle minimap |
+| 1 / 2 | Switch pistol / rifle |
+
+## Tips
+
+- Conserve ammo - pistol has 120 rounds and rifle has 90, but bosses soak damage
+- Each enemy takes multiple shots to kill
+- Keep moving to avoid enemy fire
+- Enemies deal varied damage based on their type
+- Use doors strategically to control enemy approach
+
+Enjoy the game!

--- a/Doom/zombie-doom-game/game.js
+++ b/Doom/zombie-doom-game/game.js
@@ -1,0 +1,901 @@
+// Game constants
+const SCREEN_WIDTH = 1024;
+const SCREEN_HEIGHT = 768;
+const TILE_SIZE = 64;
+const FOV = Math.PI / 3; // 60 degrees
+const MAX_DEPTH = 40;
+const NUM_RAYS = SCREEN_WIDTH / 2;
+
+const PLAYER_PISTOL_DAMAGE = 10;
+const PLAYER_RIFLE_DAMAGE = 18;
+const RIFLE_COOLDOWN = 180;
+const ZOMBIE_DAMAGE = 10;
+const ZOMBIE_HEALTH = 80;
+const ATTACK_RANGE = 70;
+const FIREBALL_DAMAGE = 15;
+const FIREBALL_SPEED = 2.4;
+const FIREBALL_COOLDOWN = 2200;
+
+// Game map (1 = wall, 0 = empty, 2 = door, 3 = exit)
+const mapLayout = [
+    '111111111111111111111111111111111111111111111111',
+    '100000000000000000000000000000000000000000000001',
+    '100000001111100000000000000111111000000000000001',
+    '100000001111100000000100000111111000000000000001',
+    '100000001111100000011100000111111000000000000001',
+    '100000000000000111000000000000000000011110000001',
+    '100000000000000000000000000000000000000000000001',
+    '100000000001111000000000000000000001111000000001',
+    '100011100000000000000111100000000000000001111001',
+    '100000000000000000000000000000000000000000000001',
+    '100000000000000000000001111000000000000000000031',
+    '111111111111111111111111111111111111111111111111'
+];
+
+const map = mapLayout.map(row => row.split('').map(Number));
+const MAP_HEIGHT = map.length;
+const MAP_WIDTH = map[0].length;
+
+// Game state
+let gameState = {
+    running: false,
+    won: false,
+    gameOver: false
+};
+
+// Player
+const player = {
+    x: 2 * TILE_SIZE,
+    y: 2 * TILE_SIZE,
+    angle: 0,
+    speed: 0,
+    strafeSpeed: 0,
+    rotationSpeed: 0,
+    health: 100,
+    maxHealth: 100,
+    pistolAmmo: 120,
+    rifleAmmo: 90,
+    kills: 0
+};
+
+// Enemies
+const enemyTypes = {
+    zombie: {
+        color: '#6b8a6f',
+        speed: 1.4,
+        damage: ZOMBIE_DAMAGE,
+        attackCooldown: 900,
+        sprite: 'Zombie',
+        scale: 1,
+        fireball: null
+    },
+    boss: {
+        color: '#8c3f3f',
+        speed: 1.1,
+        damage: 15,
+        attackCooldown: 800,
+        sprite: 'Boss',
+        scale: 2,
+        fireball: { damage: FIREBALL_DAMAGE, speed: FIREBALL_SPEED, cooldown: FIREBALL_COOLDOWN }
+    }
+};
+
+const enemies = [
+    { x: 6 * TILE_SIZE, y: 6 * TILE_SIZE, type: 'zombie' },
+    { x: 12 * TILE_SIZE, y: 5 * TILE_SIZE, type: 'zombie' },
+    { x: 18 * TILE_SIZE, y: 8 * TILE_SIZE, type: 'zombie' },
+    { x: 26 * TILE_SIZE, y: 5 * TILE_SIZE, type: 'zombie' },
+    { x: 32 * TILE_SIZE, y: 7 * TILE_SIZE, type: 'zombie' },
+    { x: 38 * TILE_SIZE, y: 4 * TILE_SIZE, type: 'zombie' },
+    { x: 44 * TILE_SIZE, y: 6 * TILE_SIZE, type: 'boss' }
+].map(enemy => ({
+    ...enemy,
+    health: enemy.type === 'boss' ? ZOMBIE_HEALTH * 2 : ZOMBIE_HEALTH,
+    maxHealth: enemy.type === 'boss' ? ZOMBIE_HEALTH * 2 : ZOMBIE_HEALTH,
+    angle: 0,
+    lastAttack: 0,
+    lastFireball: 0,
+    mouthOpen: false,
+    mouthTimer: 0,
+    eyeRotation: 0,
+    droolOffset: 0,
+    legPhase: 0
+}));
+
+const projectiles = [];
+
+// Input handling
+const keys = {};
+
+// Weapon state
+const weapon = {
+    bobOffset: 0,
+    shootAnimOffset: 0,
+    isShooting: false,
+    lastShot: { pistol: 0, rifle: 0 },
+    cooldown: { pistol: 300, rifle: RIFLE_COOLDOWN },
+    damage: { pistol: PLAYER_PISTOL_DAMAGE, rifle: PLAYER_RIFLE_DAMAGE },
+    current: 'pistol',
+    isHolstered: false,
+    aiming: false
+};
+
+let minimapVisible = true;
+let currentFov = FOV;
+
+// Canvas setup
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+canvas.width = SCREEN_WIDTH;
+canvas.height = SCREEN_HEIGHT;
+
+// Start screen
+const startScreen = document.getElementById('startScreen');
+const startButton = document.getElementById('startButton');
+const jumpScare = document.getElementById('jumpscare');
+let jumpScareShown = false;
+
+startButton.addEventListener('click', () => {
+    startScreen.style.display = 'none';
+    gameState.running = true;
+    canvas.requestPointerLock();
+    gameLoop();
+});
+
+// Event listeners
+document.addEventListener('keydown', (e) => {
+    const key = e.key.toLowerCase();
+    keys[key] = true;
+
+    if (key === 'e') {
+        openDoor();
+    }
+
+    if (key === 'h') {
+        weapon.isHolstered = !weapon.isHolstered;
+    }
+
+    if (key === 'm') {
+        minimapVisible = !minimapVisible;
+    }
+
+    if (key === '1') {
+        weapon.current = 'pistol';
+    }
+
+    if (key === '2') {
+        weapon.current = 'rifle';
+    }
+});
+
+document.addEventListener('keyup', (e) => {
+    keys[e.key.toLowerCase()] = false;
+});
+
+document.addEventListener('mousemove', (e) => {
+    if (document.pointerLockElement === canvas) {
+        player.angle += e.movementX * 0.002;
+    }
+});
+
+canvas.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+});
+
+canvas.addEventListener('mousedown', (e) => {
+    if (gameState.running && !gameState.gameOver && !gameState.won) {
+        canvas.requestPointerLock();
+
+        if (e.button === 0) {
+            weapon.aiming = true;
+            currentFov = FOV * 0.85;
+        }
+
+        if (e.button === 2) {
+            shoot();
+        }
+    }
+});
+
+document.addEventListener('mouseup', (e) => {
+    if (e.button === 0) {
+        weapon.aiming = false;
+        currentFov = FOV;
+    }
+});
+
+function triggerJumpScare() {
+    if (jumpScareShown) return;
+    jumpScareShown = true;
+    jumpScare.style.display = 'flex';
+    try {
+        const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        const osc = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+        osc.frequency.value = 160;
+        gain.gain.value = 0.25;
+        osc.connect(gain).connect(audioCtx.destination);
+        osc.start();
+        gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.6);
+        osc.stop(audioCtx.currentTime + 0.65);
+    } catch (err) {
+        console.warn('Audio unavailable for jumpscare', err);
+    }
+}
+
+function handlePlayerDeath() {
+    if (gameState.gameOver) return;
+    gameState.gameOver = true;
+    triggerJumpScare();
+}
+
+// Helper functions
+function castRay(rayAngle, originX = player.x, originY = player.y) {
+    const rayX = Math.cos(rayAngle);
+    const rayY = Math.sin(rayAngle);
+
+    let distanceToWall = 0;
+    let hitWall = false;
+    let wallType = 0;
+    let side = 0; // 0 = vertical, 1 = horizontal
+
+    while (!hitWall && distanceToWall < MAX_DEPTH) {
+        distanceToWall += 0.1;
+
+        const testX = originX + rayX * distanceToWall * TILE_SIZE;
+        const testY = originY + rayY * distanceToWall * TILE_SIZE;
+
+        const mapX = Math.floor(testX / TILE_SIZE);
+        const mapY = Math.floor(testY / TILE_SIZE);
+
+        if (mapX < 0 || mapX >= MAP_WIDTH || mapY < 0 || mapY >= MAP_HEIGHT) {
+            hitWall = true;
+            distanceToWall = MAX_DEPTH;
+        } else if (map[mapY][mapX] > 0) {
+            hitWall = true;
+            wallType = map[mapY][mapX];
+
+            // Determine which side was hit
+            const blockMidX = mapX * TILE_SIZE + TILE_SIZE / 2;
+            const blockMidY = mapY * TILE_SIZE + TILE_SIZE / 2;
+
+            const dx = testX - blockMidX;
+            const dy = testY - blockMidY;
+
+            side = Math.abs(dx) > Math.abs(dy) ? 0 : 1;
+        }
+    }
+
+    return { distance: distanceToWall, wallType, side };
+}
+
+function hasLineOfSight(originX, originY, targetX, targetY) {
+    const angle = Math.atan2(targetY - originY, targetX - originX);
+    const ray = castRay(angle, originX, originY);
+    const distanceToTarget = Math.hypot(targetX - originX, targetY - originY) / TILE_SIZE;
+    return ray.distance >= distanceToTarget - 0.1;
+}
+
+function drawWalls() {
+    // Sky
+    ctx.fillStyle = '#2a2a3e';
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT / 2);
+
+    // Floor
+    ctx.fillStyle = '#3d3d3d';
+    ctx.fillRect(0, SCREEN_HEIGHT / 2, SCREEN_WIDTH, SCREEN_HEIGHT / 2);
+
+    // Cast rays
+    for (let x = 0; x < NUM_RAYS; x++) {
+        const rayAngle = (player.angle - currentFov / 2) + (x / NUM_RAYS) * currentFov;
+        const ray = castRay(rayAngle);
+
+        const distance = ray.distance * Math.cos(rayAngle - player.angle); // Fix fisheye
+        const wallHeight = (TILE_SIZE / distance) * 277;
+
+        // Wall color based on type and side
+        let color;
+        if (ray.wallType === 1) {
+            color = ray.side === 0 ? '#8B4513' : '#654321';
+        } else if (ray.wallType === 2) {
+            color = ray.side === 0 ? '#4a4a4a' : '#333333'; // Door
+        } else if (ray.wallType === 3) {
+            color = ray.side === 0 ? '#00ff00' : '#00cc00'; // Exit
+        }
+
+        // Draw wall slice
+        const drawX = x * (SCREEN_WIDTH / NUM_RAYS);
+        const drawY = (SCREEN_HEIGHT - wallHeight) / 2;
+
+        ctx.fillStyle = color;
+        ctx.fillRect(drawX, drawY, SCREEN_WIDTH / NUM_RAYS + 1, wallHeight);
+
+        // Add darkness based on distance
+        const darkness = Math.min(distance / MAX_DEPTH, 0.7);
+        ctx.fillStyle = `rgba(0, 0, 0, ${darkness})`;
+        ctx.fillRect(drawX, drawY, SCREEN_WIDTH / NUM_RAYS + 1, wallHeight);
+    }
+}
+
+function drawEnemySprite(spriteX, spriteY, spriteSize, enemy) {
+    const type = enemyTypes[enemy.type];
+    const bodyWidth = spriteSize * 0.6;
+    const bodyHeight = spriteSize;
+    const headSize = spriteSize * 0.4;
+    const centerX = spriteX + spriteSize / 2;
+    const bodyX = centerX - bodyWidth / 2;
+    const bodyY = spriteY + spriteSize * 0.05;
+
+    // Legs with speed-synced stride
+    const legStride = Math.sin(enemy.legPhase) * spriteSize * 0.08;
+    const legWidth = spriteSize * 0.18;
+    const legHeight = spriteSize * 0.45;
+    const legY = bodyY + bodyHeight * 0.55;
+
+    ctx.fillStyle = '#2a2a2a';
+    ctx.fillRect(centerX - bodyWidth * 0.45 + legStride, legY, legWidth, legHeight);
+    ctx.fillRect(centerX + bodyWidth * 0.25 - legStride, legY, legWidth, legHeight);
+
+    ctx.fillStyle = type.color;
+    ctx.fillRect(bodyX, bodyY + headSize * 0.8, bodyWidth, bodyHeight * 0.6);
+
+    ctx.fillStyle = '#2a1c1c';
+    ctx.fillRect(bodyX, bodyY + bodyHeight * 0.65, bodyWidth, bodyHeight * 0.1);
+
+    ctx.fillStyle = '#d9d9d9';
+    ctx.fillRect(centerX - headSize / 2, bodyY, headSize, headSize);
+
+    // Eyes with spinning pupils
+    const eyeRadius = headSize * 0.12;
+    const pupilRadius = eyeRadius * 0.6;
+    const eyeYOffset = headSize * 0.25;
+    const eyeSpacing = headSize * 0.18;
+
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.arc(centerX - eyeSpacing, bodyY + eyeYOffset, eyeRadius, 0, Math.PI * 2);
+    ctx.arc(centerX + eyeSpacing, bodyY + eyeYOffset, eyeRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    const pupilAngle = enemy.eyeRotation;
+    const pupilOffset = eyeRadius * 0.4;
+    const pupilXOffset = Math.cos(pupilAngle) * pupilOffset;
+    const pupilYOffset = Math.sin(pupilAngle) * pupilOffset;
+
+    ctx.fillStyle = '#222222';
+    ctx.beginPath();
+    ctx.arc(centerX - eyeSpacing + pupilXOffset, bodyY + eyeYOffset + pupilYOffset, pupilRadius, 0, Math.PI * 2);
+    ctx.arc(centerX + eyeSpacing + pupilXOffset, bodyY + eyeYOffset + pupilYOffset, pupilRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Mouth animation
+    const mouthWidth = headSize * 0.7;
+    const mouthHeight = enemy.mouthOpen ? headSize * 0.3 : headSize * 0.12;
+    const mouthX = centerX - mouthWidth / 2;
+    const mouthY = bodyY + headSize * 0.65;
+
+    ctx.fillStyle = '#b42a2a';
+    ctx.fillRect(mouthX, mouthY, mouthWidth, mouthHeight);
+
+    ctx.fillStyle = '#eeeeee';
+    const toothWidth = mouthWidth / 6;
+    const toothHeight = mouthHeight * 0.6;
+    for (let i = 0; i < 6; i++) {
+        ctx.fillRect(mouthX + i * toothWidth, mouthY, toothWidth * 0.6, toothHeight);
+    }
+
+    // Drool
+    ctx.strokeStyle = '#7ed6ff';
+    ctx.lineWidth = Math.max(2, spriteSize * 0.01);
+    const droolLength = mouthHeight * 1.2 + (enemy.droolOffset % 10);
+    ctx.beginPath();
+    ctx.moveTo(mouthX + mouthWidth * 0.1, mouthY + mouthHeight);
+    ctx.lineTo(mouthX + mouthWidth * 0.1, mouthY + mouthHeight + droolLength);
+    ctx.moveTo(mouthX + mouthWidth * 0.9, mouthY + mouthHeight);
+    ctx.lineTo(mouthX + mouthWidth * 0.9, mouthY + mouthHeight + droolLength * 0.8);
+    ctx.stroke();
+
+    // Claws or weapons indicator
+    ctx.fillStyle = '#f4f4f4';
+    ctx.fillRect(centerX - bodyWidth * 0.45, bodyY + bodyHeight * 0.6, bodyWidth * 0.15, bodyHeight * 0.2);
+    ctx.fillRect(centerX + bodyWidth * 0.3, bodyY + bodyHeight * 0.6, bodyWidth * 0.15, bodyHeight * 0.2);
+}
+
+function drawEnemies() {
+    // Sort enemies by distance (far to near)
+    const sortedEnemies = enemies
+        .filter(enemy => enemy.health > 0)
+        .map(enemy => {
+            const dx = enemy.x - player.x;
+            const dy = enemy.y - player.y;
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            const angle = Math.atan2(dy, dx) - player.angle;
+            return { enemy, distance, angle };
+        })
+        .sort((a, b) => b.distance - a.distance);
+
+    sortedEnemies.forEach(({ enemy, distance, angle }) => {
+        // Normalize angle to -PI to PI
+        let normalizedAngle = angle;
+        while (normalizedAngle > Math.PI) normalizedAngle -= 2 * Math.PI;
+        while (normalizedAngle < -Math.PI) normalizedAngle += 2 * Math.PI;
+
+        // Check if enemy is in FOV
+        if (Math.abs(normalizedAngle) < currentFov / 2 + 0.5) {
+            if (!hasLineOfSight(player.x, player.y, enemy.x, enemy.y)) {
+                return;
+            }
+
+            const type = enemyTypes[enemy.type];
+            const spriteSize = (TILE_SIZE / distance) * 277 * type.scale;
+            const spriteX = SCREEN_WIDTH / 2 + (normalizedAngle / currentFov) * SCREEN_WIDTH - spriteSize / 2;
+            const spriteY = SCREEN_HEIGHT / 2 - spriteSize / 2;
+
+            drawEnemySprite(spriteX, spriteY, spriteSize, enemy);
+
+            // Draw health bar
+            const healthBarWidth = spriteSize;
+            const healthBarHeight = 5;
+            const healthPercent = enemy.health / enemy.maxHealth;
+
+            ctx.fillStyle = '#ff0000';
+            ctx.fillRect(spriteX, spriteY - 10, healthBarWidth, healthBarHeight);
+            ctx.fillStyle = '#00ff00';
+            ctx.fillRect(spriteX, spriteY - 10, healthBarWidth * healthPercent, healthBarHeight);
+        }
+    });
+}
+
+function drawProjectiles() {
+    const sortedProjectiles = projectiles
+        .map(projectile => {
+            const dx = projectile.x - player.x;
+            const dy = projectile.y - player.y;
+            const distance = Math.max(0.1, Math.sqrt(dx * dx + dy * dy));
+            const angle = Math.atan2(dy, dx) - player.angle;
+            return { projectile, distance, angle };
+        })
+        .sort((a, b) => b.distance - a.distance);
+
+    sortedProjectiles.forEach(({ projectile, distance, angle }) => {
+        let normalizedAngle = angle;
+        while (normalizedAngle > Math.PI) normalizedAngle -= 2 * Math.PI;
+        while (normalizedAngle < -Math.PI) normalizedAngle += 2 * Math.PI;
+
+        if (
+            Math.abs(normalizedAngle) < currentFov / 2 + 0.5 &&
+            hasLineOfSight(player.x, player.y, projectile.x, projectile.y)
+        ) {
+            const spriteSize = (TILE_SIZE / distance) * 90;
+            const spriteX =
+                SCREEN_WIDTH / 2 + (normalizedAngle / currentFov) * SCREEN_WIDTH - spriteSize / 2;
+            const spriteY = SCREEN_HEIGHT / 2 - spriteSize / 2;
+
+            const gradient = ctx.createRadialGradient(
+                spriteX + spriteSize / 2,
+                spriteY + spriteSize / 2,
+                spriteSize * 0.1,
+                spriteX + spriteSize / 2,
+                spriteY + spriteSize / 2,
+                spriteSize * 0.6
+            );
+
+            gradient.addColorStop(0, '#ffcc66');
+            gradient.addColorStop(0.5, '#ff6600');
+            gradient.addColorStop(1, 'rgba(0,0,0,0)');
+
+            ctx.fillStyle = gradient;
+            ctx.beginPath();
+            ctx.arc(spriteX + spriteSize / 2, spriteY + spriteSize / 2, spriteSize / 2, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    });
+}
+
+function drawWeapon() {
+    if (weapon.isHolstered) {
+        return;
+    }
+
+    const aimLift = weapon.aiming ? 25 : 0;
+    const weaponY =
+        SCREEN_HEIGHT - 200 + Math.sin(weapon.bobOffset) * 10 + weapon.shootAnimOffset - aimLift;
+    const weaponX = SCREEN_WIDTH / 2 - 50 + (weapon.aiming ? 8 : 0);
+
+    // Draw simple gun
+    ctx.fillStyle = '#444';
+    ctx.fillRect(weaponX, weaponY, 100, 200);
+
+    ctx.fillStyle = '#666';
+    ctx.fillRect(weaponX + 20, weaponY, 60, 150);
+
+    ctx.fillStyle = '#222';
+    ctx.fillRect(weaponX + 35, weaponY, 30, 80);
+
+    // Muzzle flash
+    if (weapon.shootAnimOffset < 0) {
+        ctx.fillStyle = '#ffff00';
+        ctx.fillRect(weaponX + 25, weaponY - 20, 50, 20);
+    }
+}
+
+function drawHUD() {
+    // Health
+    ctx.fillStyle = '#ff0000';
+    ctx.font = '24px Courier New';
+    ctx.fillText(`HEALTH: ${Math.max(0, player.health)}`, 20, 30);
+
+    // Ammo
+    ctx.fillStyle = '#ffff00';
+    ctx.fillText(`Pistol: ${player.pistolAmmo} | Rifle: ${player.rifleAmmo}`, 20, 60);
+
+    // Kills
+    ctx.fillStyle = '#00ff00';
+    ctx.fillText(`KILLS: ${player.kills}/${enemies.length}`, 20, 90);
+
+    // Weapon state
+    ctx.fillStyle = weapon.isHolstered ? '#ffaa00' : '#00ff00';
+    const holsterText = weapon.isHolstered ? 'HOLSTERED' : 'READY';
+    ctx.fillText(`GUN: ${holsterText} | ${weapon.current.toUpperCase()}`, 20, 120);
+
+    // Crosshair
+    ctx.strokeStyle = '#00ff00';
+    ctx.lineWidth = 2;
+    const crosshairSize = weapon.aiming ? 6 : 10;
+    ctx.beginPath();
+    ctx.moveTo(SCREEN_WIDTH / 2 - crosshairSize, SCREEN_HEIGHT / 2);
+    ctx.lineTo(SCREEN_WIDTH / 2 + crosshairSize, SCREEN_HEIGHT / 2);
+    ctx.moveTo(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 - crosshairSize);
+    ctx.lineTo(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + crosshairSize);
+    ctx.stroke();
+}
+
+function updatePlayer(deltaTime) {
+    // Movement
+    player.speed = 0;
+    player.strafeSpeed = 0;
+
+    const sprinting = keys['shift'];
+    const moveAmount = sprinting ? 4.5 : 3;
+    if (keys['w']) player.speed = moveAmount;
+    if (keys['s']) player.speed = -moveAmount;
+    if (keys['a']) player.strafeSpeed = -moveAmount;
+    if (keys['d']) player.strafeSpeed = moveAmount;
+
+    // Calculate new position
+    const newX = player.x + Math.cos(player.angle) * player.speed + Math.cos(player.angle + Math.PI / 2) * player.strafeSpeed;
+    const newY = player.y + Math.sin(player.angle) * player.speed + Math.sin(player.angle + Math.PI / 2) * player.strafeSpeed;
+
+    // Collision detection
+    const mapX = Math.floor(newX / TILE_SIZE);
+    const mapY = Math.floor(newY / TILE_SIZE);
+
+    if (map[mapY] && map[mapY][mapX] === 0) {
+        player.x = newX;
+        player.y = newY;
+    }
+
+    // Check for exit
+    if (map[mapY] && map[mapY][mapX] === 3 && player.kills === enemies.length) {
+        gameState.won = true;
+    }
+
+    // Weapon bobbing
+    if (player.speed !== 0 || player.strafeSpeed !== 0) {
+        weapon.bobOffset += weapon.aiming ? 0.08 : 0.15;
+    }
+
+    // Weapon shoot animation
+    if (weapon.shootAnimOffset < 0) {
+        weapon.shootAnimOffset += 5;
+    }
+}
+
+function updateEnemies(deltaTime) {
+    const currentTime = Date.now();
+
+    enemies.forEach(enemy => {
+        if (enemy.health <= 0) return;
+
+        const type = enemyTypes[enemy.type];
+        const dx = player.x - enemy.x;
+        const dy = player.y - enemy.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        const angleToPlayer = Math.atan2(dy, dx);
+
+        enemy.eyeRotation += deltaTime * 10;
+        enemy.droolOffset = (enemy.droolOffset + deltaTime * 40) % 20;
+
+        const seesPlayer =
+            distance < 900 && hasLineOfSight(enemy.x, enemy.y, player.x, player.y);
+        let movement = 0;
+
+        if (seesPlayer) {
+            enemy.mouthTimer += deltaTime;
+            if (enemy.mouthTimer > 0.25) {
+                enemy.mouthOpen = !enemy.mouthOpen;
+                enemy.mouthTimer = 0;
+            }
+
+            const newX = enemy.x + Math.cos(angleToPlayer) * type.speed;
+            const newY = enemy.y + Math.sin(angleToPlayer) * type.speed;
+
+            const mapX = Math.floor(newX / TILE_SIZE);
+            const mapY = Math.floor(newY / TILE_SIZE);
+
+            if (map[mapY] && map[mapY][mapX] === 0) {
+                movement = Math.sqrt((newX - enemy.x) ** 2 + (newY - enemy.y) ** 2);
+                enemy.x = newX;
+                enemy.y = newY;
+            }
+
+            const attackReach = ATTACK_RANGE + (enemy.type === 'boss' ? 10 : 0);
+            if (distance < attackReach && currentTime - enemy.lastAttack > type.attackCooldown) {
+                player.health -= type.damage;
+                enemy.lastAttack = currentTime;
+
+                if (player.health <= 0) {
+                    handlePlayerDeath();
+                }
+            }
+
+            if (type.fireball && currentTime - enemy.lastFireball > type.fireball.cooldown) {
+                projectiles.push({
+                    x: enemy.x,
+                    y: enemy.y,
+                    angle: angleToPlayer,
+                    speed: type.fireball.speed,
+                    damage: type.fireball.damage
+                });
+                enemy.lastFireball = currentTime;
+            }
+        } else if (currentTime % 1500 < 40) {
+            const wanderAngle = (enemy.x + enemy.y + currentTime * 0.0005) % (Math.PI * 2);
+            const newX = enemy.x + Math.cos(wanderAngle) * type.speed * 0.4;
+            const newY = enemy.y + Math.sin(wanderAngle) * type.speed * 0.4;
+
+            const mapX = Math.floor(newX / TILE_SIZE);
+            const mapY = Math.floor(newY / TILE_SIZE);
+
+            if (map[mapY] && map[mapY][mapX] === 0) {
+                movement = Math.sqrt((newX - enemy.x) ** 2 + (newY - enemy.y) ** 2);
+                enemy.x = newX;
+                enemy.y = newY;
+            }
+        }
+
+        enemy.legPhase += movement * 0.2;
+    });
+}
+
+function updateProjectiles(deltaTime) {
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+        const projectile = projectiles[i];
+        projectile.x += Math.cos(projectile.angle) * projectile.speed * TILE_SIZE * deltaTime;
+        projectile.y += Math.sin(projectile.angle) * projectile.speed * TILE_SIZE * deltaTime;
+
+        const mapX = Math.floor(projectile.x / TILE_SIZE);
+        const mapY = Math.floor(projectile.y / TILE_SIZE);
+
+        if (
+            mapX < 0 ||
+            mapX >= MAP_WIDTH ||
+            mapY < 0 ||
+            mapY >= MAP_HEIGHT ||
+            (map[mapY] && map[mapY][mapX] > 0)
+        ) {
+            projectiles.splice(i, 1);
+            continue;
+        }
+
+        const distanceToPlayer = Math.hypot(projectile.x - player.x, projectile.y - player.y);
+        if (distanceToPlayer < 24) {
+            player.health -= projectile.damage;
+            projectiles.splice(i, 1);
+
+            if (player.health <= 0) {
+                handlePlayerDeath();
+            }
+        }
+    }
+}
+
+function shoot() {
+    const currentTime = Date.now();
+
+    if (weapon.isHolstered) return;
+    const weaponId = weapon.current;
+    const ammoKey = weaponId === 'rifle' ? 'rifleAmmo' : 'pistolAmmo';
+    const cooldown = weapon.cooldown[weaponId];
+
+    if (currentTime - weapon.lastShot[weaponId] < cooldown) return;
+    if (player[ammoKey] <= 0) return;
+
+    player[ammoKey]--;
+    weapon.lastShot[weaponId] = currentTime;
+    weapon.shootAnimOffset = -30;
+
+    // Check if we hit an enemy
+    const centerRay = castRay(player.angle);
+
+    enemies.forEach(enemy => {
+        if (enemy.health <= 0) return;
+
+        const dx = enemy.x - player.x;
+        const dy = enemy.y - player.y;
+        const distance = Math.sqrt(dx * dx + dy * dy) / TILE_SIZE;
+        const angle = Math.atan2(dy, dx);
+
+        let angleDiff = angle - player.angle;
+        while (angleDiff > Math.PI) angleDiff -= 2 * Math.PI;
+        while (angleDiff < -Math.PI) angleDiff += 2 * Math.PI;
+
+        const baseAim = weaponId === 'rifle' ? 0.08 : 0.1;
+        const aimAllowance =
+            (weapon.aiming ? baseAim : baseAim + 0.1) + Math.max(0, 0.05 - distance * 0.002);
+
+        // Check if enemy is in crosshair and visible
+        if (
+            Math.abs(angleDiff) < aimAllowance &&
+            distance < centerRay.distance &&
+            hasLineOfSight(player.x, player.y, enemy.x, enemy.y)
+        ) {
+            enemy.health -= weapon.damage[weaponId];
+
+            if (enemy.health <= 0) {
+                player.kills++;
+            }
+        }
+    });
+}
+
+function openDoor() {
+    const doorCheckDist = 1.5;
+    const checkX = player.x + Math.cos(player.angle) * TILE_SIZE * doorCheckDist;
+    const checkY = player.y + Math.sin(player.angle) * TILE_SIZE * doorCheckDist;
+
+    const mapX = Math.floor(checkX / TILE_SIZE);
+    const mapY = Math.floor(checkY / TILE_SIZE);
+
+    if (map[mapY] && map[mapY][mapX] === 2) {
+        map[mapY][mapX] = 0; // Open door
+    }
+}
+
+function drawGameOver() {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    ctx.fillStyle = '#ff0000';
+    ctx.font = '64px Courier New';
+    ctx.textAlign = 'center';
+    ctx.fillText('GAME OVER', SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2);
+
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '24px Courier New';
+    ctx.fillText('Refresh to try again', SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + 50);
+    ctx.textAlign = 'left';
+}
+
+function drawMinimap() {
+    if (!minimapVisible) return;
+
+    const mapScale = 4;
+    const minimapWidth = MAP_WIDTH * mapScale;
+    const minimapHeight = MAP_HEIGHT * mapScale;
+    const offset = 20;
+
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+    ctx.fillRect(
+        SCREEN_WIDTH - minimapWidth - offset - 10,
+        offset - 10,
+        minimapWidth + 20,
+        minimapHeight + 20
+    );
+
+    for (let y = 0; y < MAP_HEIGHT; y++) {
+        for (let x = 0; x < MAP_WIDTH; x++) {
+            const tile = map[y][x];
+            if (tile === 1) {
+                ctx.fillStyle = '#6b4b3e';
+            } else if (tile === 2) {
+                ctx.fillStyle = '#9d9d9d';
+            } else if (tile === 3) {
+                ctx.fillStyle = '#00cc44';
+            } else {
+                ctx.fillStyle = '#1b1b1b';
+            }
+
+            ctx.fillRect(
+                SCREEN_WIDTH - minimapWidth - offset + x * mapScale,
+                offset + y * mapScale,
+                mapScale,
+                mapScale
+            );
+        }
+    }
+
+    // Player
+    ctx.fillStyle = '#ffff00';
+    ctx.fillRect(
+        SCREEN_WIDTH - minimapWidth - offset + (player.x / TILE_SIZE) * mapScale - 2,
+        offset + (player.y / TILE_SIZE) * mapScale - 2,
+        4,
+        4
+    );
+
+    // Player direction
+    ctx.strokeStyle = '#ffff00';
+    ctx.beginPath();
+    ctx.moveTo(
+        SCREEN_WIDTH - minimapWidth - offset + (player.x / TILE_SIZE) * mapScale,
+        offset + (player.y / TILE_SIZE) * mapScale
+    );
+    ctx.lineTo(
+        SCREEN_WIDTH - minimapWidth - offset + ((player.x / TILE_SIZE) + Math.cos(player.angle)) * mapScale,
+        offset + ((player.y / TILE_SIZE) + Math.sin(player.angle)) * mapScale
+    );
+    ctx.stroke();
+
+    // Enemies
+    enemies.forEach(enemy => {
+        if (enemy.health <= 0) return;
+        ctx.fillStyle = enemyTypes[enemy.type].color;
+        ctx.fillRect(
+            SCREEN_WIDTH - minimapWidth - offset + (enemy.x / TILE_SIZE) * mapScale - 2,
+            offset + (enemy.y / TILE_SIZE) * mapScale - 2,
+            4,
+            4
+        );
+    });
+}
+
+function drawWin() {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    ctx.fillStyle = '#00ff00';
+    ctx.font = '64px Courier New';
+    ctx.textAlign = 'center';
+    ctx.fillText('YOU WIN!', SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2);
+
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '24px Courier New';
+    ctx.fillText('All enemies eliminated!', SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2 + 50);
+    ctx.textAlign = 'left';
+}
+
+// Main game loop
+let lastTime = Date.now();
+
+function gameLoop() {
+    if (!gameState.running) return;
+
+    const currentTime = Date.now();
+    const deltaTime = (currentTime - lastTime) / 1000;
+    lastTime = currentTime;
+
+    // Clear canvas
+    ctx.clearRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    if (!gameState.gameOver && !gameState.won) {
+        // Update
+        updatePlayer(deltaTime);
+        updateEnemies(deltaTime);
+        updateProjectiles(deltaTime);
+
+        // Draw
+        drawWalls();
+        drawEnemies();
+        drawProjectiles();
+        drawWeapon();
+        drawHUD();
+        drawMinimap();
+    } else if (gameState.gameOver) {
+        drawGameOver();
+    } else if (gameState.won) {
+        drawWin();
+    }
+
+    requestAnimationFrame(gameLoop);
+}

--- a/Doom/zombie-doom-game/index.html
+++ b/Doom/zombie-doom-game/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Doom-like FPS Game</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            background: #000;
+            overflow: hidden;
+            font-family: 'Courier New', monospace;
+        }
+
+        #gameCanvas {
+            display: block;
+            margin: 0 auto;
+            background: #000;
+            image-rendering: pixelated;
+            image-rendering: crisp-edges;
+        }
+
+        #startScreen {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.9);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            color: #ff0000;
+            z-index: 1000;
+        }
+
+        #startScreen h1 {
+            font-size: 64px;
+            margin-bottom: 20px;
+            text-shadow: 0 0 10px #ff0000;
+        }
+
+        #startScreen p {
+            font-size: 18px;
+            margin: 10px;
+            color: #fff;
+        }
+
+        #startScreen button {
+            margin-top: 30px;
+            padding: 15px 40px;
+            font-size: 24px;
+            background: #ff0000;
+            color: #fff;
+            border: none;
+            cursor: pointer;
+            font-family: 'Courier New', monospace;
+            text-transform: uppercase;
+        }
+
+        #startScreen button:hover {
+            background: #cc0000;
+        }
+
+        .controls {
+            color: #888;
+            font-size: 14px;
+        }
+
+        #jumpscare {
+            position: fixed;
+            inset: 0;
+            background: radial-gradient(circle at center, rgba(255, 0, 0, 0.4), rgba(0, 0, 0, 0.95)), url('https://i.imgur.com/7N4k1U4.png') center/cover no-repeat;
+            display: none;
+            justify-content: center;
+            align-items: center;
+            color: #fff;
+            font-size: 64px;
+            text-shadow: 0 0 20px #ff0000;
+            animation: shake 0.5s linear infinite;
+            z-index: 1200;
+        }
+
+        @keyframes shake {
+            0% { transform: translate(3px, 0); }
+            25% { transform: translate(-3px, 2px); }
+            50% { transform: translate(2px, -2px); }
+            75% { transform: translate(-2px, 3px); }
+            100% { transform: translate(0, 0); }
+        }
+    </style>
+</head>
+<body>
+    <div id="startScreen">
+        <h1>DOOM-LIKE</h1>
+        <p class="controls">WASD - Move (Hold Shift to Sprint)</p>
+        <p class="controls">Mouse - Look Around</p>
+        <p class="controls">Left Click - Aim</p>
+        <p class="controls">Right Click - Fire</p>
+        <p class="controls">1/2 - Switch Pistol / Rifle</p>
+        <p class="controls">E - Open Doors</p>
+        <p class="controls">H - Holster/Draw Weapon</p>
+        <p class="controls">M - Toggle Minimap</p>
+        <p style="margin-top: 20px; color: #ff0000;">Kill all enemies to win!</p>
+        <button id="startButton">START GAME</button>
+    </div>
+    <canvas id="gameCanvas"></canvas>
+
+    <div id="jumpscare">BRAINS!</div>
+
+    <script src="game.js"></script>
+</body>
+</html>

--- a/Zombie_Game/Zombie_Game_v1/README.md
+++ b/Zombie_Game/Zombie_Game_v1/README.md
@@ -1,0 +1,17 @@
+# Zombie Hallway FPS (v1)
+
+A lightweight Three.js demo of a long hallway survival run. Survive zombies and a boss while staying mobile.
+
+## Controls
+- Click canvas to lock pointer
+- WASD to move, Space to jump, Shift to sprint
+- Left click to shoot, Right click to aim (tighter FOV)
+- Press **1** for pistol or **2** for rifle (harder hits, shorter cooldown)
+
+## Gameplay
+- Zombies deal 10 damage in melee and have 80 HP
+- Boss is larger, fires slow fireballs, and has 160 HP
+- Pistol deals 10 damage per shot; rifle deals 18. Ammo starts at 60 pistol / 90 rifle.
+- Zombie jump scare appears when the player dies
+
+Open `index.html` in a browser to play.

--- a/Zombie_Game/Zombie_Game_v1/index.html
+++ b/Zombie_Game/Zombie_Game_v1/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zombie Hallway FPS (v1)</title>
+  <link rel="stylesheet" href="style.css" />
+  <script type="module" src="main.js"></script>
+</head>
+<body>
+  <div id="overlay" class="overlay">
+    <div class="overlay-content">
+      <h1>Zombie Hallway (v1)</h1>
+      <p>WASD to move, hold Shift to sprint, Space to jump. Left click: shoot. Right click: aim (tight FOV). 1 = Pistol, 2 = Rifle. Avoid zombies and the boss.</p>
+      <button id="startButton">Enter Hallway</button>
+    </div>
+  </div>
+  <div id="hud" class="hud">
+    <div id="health" class="bar">Health: 100</div>
+    <div id="bossHealth" class="bar">Boss: 180</div>
+    <div id="ammo" class="bar">Weapon: Pistol | Pistol: 60 | Rifle: 90</div>
+  </div>
+  <div id="crosshair">+</div>
+  <div id="damageFlash" class="damage"></div>
+  <div id="jumpscare" class="jumpscare">BRAAAINS!</div>
+</body>
+</html>

--- a/Zombie_Game/Zombie_Game_v1/main.js
+++ b/Zombie_Game/Zombie_Game_v1/main.js
@@ -1,0 +1,383 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+import { PointerLockControls } from 'https://unpkg.com/three@0.158.0/examples/jsm/controls/PointerLockControls.js';
+
+const PLAYER_SPEED = 12;
+const PLAYER_SPRINT = 18;
+const PLAYER_HEIGHT = 1.8;
+const GRAVITY = 30;
+const JUMP_VELOCITY = 10;
+const PISTOL_DAMAGE = 10;
+const RIFLE_DAMAGE = 18;
+const RIFLE_COOLDOWN = 0.22;
+const ZOMBIE_HEALTH = 80;
+const BOSS_HEALTH = 160;
+const ZOMBIE_DAMAGE = 10;
+const BOSS_DAMAGE = 15;
+const FIREBALL_DAMAGE = 15;
+const FIREBALL_SPEED = 14;
+const FIREBALL_COOLDOWN = 2.5;
+const SHOOT_COOLDOWN = 0.35;
+const weaponStats = {
+  pistol: { damage: PISTOL_DAMAGE, cooldown: SHOOT_COOLDOWN },
+  rifle: { damage: RIFLE_DAMAGE, cooldown: RIFLE_COOLDOWN },
+};
+const AIM_FOV = 45;
+const BASE_FOV = 70;
+
+let scene, camera, renderer, controls;
+let worldBoxes = [];
+let playerVelocityY = 0;
+let lastShot = { pistol: 0, rifle: 0 };
+let ammo = { pistol: 60, rifle: 90 };
+let currentWeapon = 'pistol';
+let playerHealth = 100;
+let gameEnded = false;
+let clock = new THREE.Clock();
+let enemies = [];
+let projectiles = [];
+let bossEnemy = null;
+
+const overlay = document.getElementById('overlay');
+const startButton = document.getElementById('startButton');
+const uiHealth = document.getElementById('health');
+const uiBossHealth = document.getElementById('bossHealth');
+const uiAmmo = document.getElementById('ammo');
+const crosshair = document.getElementById('crosshair');
+const damageFlash = document.getElementById('damageFlash');
+const jumpscare = document.getElementById('jumpscare');
+let jumpScareShown = false;
+
+function updateAmmoUI() {
+  uiAmmo.textContent = `Weapon: ${currentWeapon.toUpperCase()} | Pistol: ${ammo.pistol} | Rifle: ${ammo.rifle}`;
+}
+
+startButton.addEventListener('click', () => {
+  overlay.style.display = 'none';
+  updateAmmoUI();
+  init();
+  animate();
+});
+
+document.addEventListener('contextmenu', e => e.preventDefault());
+
+document.addEventListener('mousedown', (e) => {
+  if (!controls || !controls.isLocked) return;
+  if (e.button === 0) {
+    handleShoot();
+  } else if (e.button === 2) {
+    camera.fov = THREE.MathUtils.lerp(camera.fov, AIM_FOV, 0.8);
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(0.7)';
+  }
+});
+
+document.addEventListener('mouseup', (e) => {
+  if (e.button === 2) {
+    camera.fov = BASE_FOV;
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(1)';
+  }
+});
+
+function init() {
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x111111);
+
+  camera = new THREE.PerspectiveCamera(BASE_FOV, window.innerWidth / window.innerHeight, 0.1, 1000);
+  camera.position.set(0, PLAYER_HEIGHT, 0);
+
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  controls = new PointerLockControls(camera, renderer.domElement);
+  renderer.domElement.addEventListener('click', () => controls.lock());
+
+  const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1.1);
+  scene.add(light);
+
+  buildCorridor();
+  spawnEnemies();
+
+  window.addEventListener('resize', onWindowResize);
+}
+
+function buildCorridor() {
+  const floorGeom = new THREE.BoxGeometry(6, 0.5, 200);
+  const floor = new THREE.Mesh(floorGeom, new THREE.MeshStandardMaterial({ color: 0x202020 }));
+  floor.position.set(0, -0.25, 0);
+  floor.receiveShadow = true;
+  scene.add(floor);
+  worldBoxes.push(floorGeom.boundingBox || new THREE.Box3().setFromObject(floor));
+
+  const wallMat = new THREE.MeshStandardMaterial({ color: 0x303030 });
+  const leftWall = new THREE.Mesh(new THREE.BoxGeometry(0.5, 6, 200), wallMat);
+  leftWall.position.set(-3.25, 2.5, 0);
+  const rightWall = leftWall.clone();
+  rightWall.position.x = 3.25;
+  const ceiling = new THREE.Mesh(new THREE.BoxGeometry(6, 0.5, 200), new THREE.MeshStandardMaterial({ color: 0x222222 }));
+  ceiling.position.set(0, 5.75, 0);
+  scene.add(leftWall, rightWall, ceiling);
+  [leftWall, rightWall, ceiling].forEach(mesh => worldBoxes.push(new THREE.Box3().setFromObject(mesh)));
+
+  // Add cover buildings along the corridor
+  const coverMat = new THREE.MeshStandardMaterial({ color: 0x555555 });
+  for (let i = 0; i < 6; i++) {
+    const cover = new THREE.Mesh(new THREE.BoxGeometry(2, 3, 4), coverMat);
+    cover.position.set((i % 2 === 0 ? -1.5 : 1.5), 1.5, 25 + i * 25);
+    scene.add(cover);
+    worldBoxes.push(new THREE.Box3().setFromObject(cover));
+  }
+}
+
+function spawnEnemies() {
+  const zombiePositions = [10, 30, 60, 90, 120, 150];
+  zombiePositions.forEach((zPos, idx) => {
+    const isBoss = idx === zombiePositions.length - 1;
+    const enemy = createEnemy(isBoss);
+    enemy.group.position.set(isBoss ? 0 : (idx % 2 === 0 ? -1 : 1), 0, zPos);
+    enemies.push(enemy);
+    scene.add(enemy.group);
+    if (isBoss) bossEnemy = enemy;
+  });
+}
+
+function createEnemy(isBoss) {
+  const bodyGeom = new THREE.CapsuleGeometry(isBoss ? 0.6 : 0.45, isBoss ? 1.6 : 1.2, 6, 12);
+  const body = new THREE.Mesh(bodyGeom, new THREE.MeshStandardMaterial({ color: isBoss ? 0x8c3f3f : 0x6b8a6f }));
+  const health = isBoss ? BOSS_HEALTH : ZOMBIE_HEALTH;
+  const group = new THREE.Group();
+  group.add(body);
+
+  const healthBarBg = new THREE.Mesh(new THREE.PlaneGeometry(1.2, 0.08), new THREE.MeshBasicMaterial({ color: 0x111111 }));
+  const healthBar = new THREE.Mesh(new THREE.PlaneGeometry(1.2, 0.08), new THREE.MeshBasicMaterial({ color: 0x4caf50 }));
+  healthBar.position.z = 0.02;
+  const barGroup = new THREE.Group();
+  barGroup.add(healthBarBg, healthBar);
+  barGroup.position.set(0, isBoss ? 1.8 : 1.4, 0);
+  group.add(barGroup);
+
+  return {
+    isBoss,
+    group,
+    health,
+    maxHealth: health,
+    lastAttack: 0,
+    lastFire: 0,
+    alive: true,
+    bar: healthBar
+  };
+}
+
+function updateHealthBars() {
+  enemies.forEach(enemy => {
+    const ratio = Math.max(enemy.health, 0) / enemy.maxHealth;
+    enemy.bar.scale.x = ratio;
+    enemy.bar.position.x = (ratio - 1) * 0.6;
+  });
+}
+
+function handleShoot() {
+  const now = clock.getElapsedTime();
+  const stats = weaponStats[currentWeapon];
+  if (!stats || now - lastShot[currentWeapon] < stats.cooldown || ammo[currentWeapon] <= 0 || gameEnded) return;
+  lastShot[currentWeapon] = now;
+  ammo[currentWeapon] -= 1;
+  updateAmmoUI();
+
+  const raycaster = new THREE.Raycaster();
+  raycaster.setFromCamera(new THREE.Vector2(), camera);
+  const intersects = raycaster.intersectObjects(enemies.filter(e => e.alive).map(e => e.group), true);
+  if (intersects.length > 0) {
+    const target = enemies.find(e => e.group === intersects[0].object.parent || e.group.children.includes(intersects[0].object));
+    if (target && target.alive) {
+      target.health -= stats.damage;
+      if (target.health <= 0) {
+        target.alive = false;
+        target.group.visible = false;
+      }
+      uiBossHealth.textContent = bossEnemy ? `Boss: ${Math.max(bossEnemy.health, 0)}` : 'Boss: -';
+    }
+  }
+}
+
+function updateEnemies(delta) {
+  const playerPos = controls.getObject().position;
+  enemies.forEach(enemy => {
+    if (!enemy.alive) return;
+    const direction = new THREE.Vector3().subVectors(playerPos, enemy.group.position);
+    direction.y = 0; // prevent upward drift
+    if (direction.lengthSq() < 0.0001) return;
+    const distance = direction.length();
+    direction.normalize();
+    const moveSpeed = enemy.isBoss ? 4 : 5;
+    enemy.group.position.addScaledVector(direction, moveSpeed * delta);
+
+    // Melee damage
+    if (distance < 1.5) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastAttack > 1) {
+        applyDamage(enemy.isBoss ? BOSS_DAMAGE : ZOMBIE_DAMAGE);
+        enemy.lastAttack = now;
+      }
+    }
+
+    // Boss fireballs
+    if (enemy.isBoss) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastFire > FIREBALL_COOLDOWN) {
+        spawnFireball(enemy);
+        enemy.lastFire = now;
+      }
+    }
+  });
+}
+
+function spawnFireball(enemy) {
+  const geometry = new THREE.SphereGeometry(0.15, 8, 8);
+  const material = new THREE.MeshBasicMaterial({ color: 0xff5522 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.copy(enemy.group.position).add(new THREE.Vector3(0, 1, 0));
+  const dir = new THREE.Vector3().subVectors(controls.getObject().position, mesh.position).normalize();
+  projectiles.push({ mesh, dir, alive: true });
+  scene.add(mesh);
+}
+
+function updateProjectiles(delta) {
+  projectiles = projectiles.filter(p => p.alive);
+  projectiles.forEach(p => {
+    p.mesh.position.addScaledVector(p.dir, FIREBALL_SPEED * delta);
+    if (p.mesh.position.distanceTo(controls.getObject().position) < 1) {
+      applyDamage(FIREBALL_DAMAGE);
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+    if (Math.abs(p.mesh.position.z) > 220) {
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+  });
+}
+
+function applyDamage(amount) {
+  if (gameEnded) return;
+  playerHealth = Math.max(0, playerHealth - amount);
+  uiHealth.textContent = `Health: ${playerHealth}`;
+  damageFlash.classList.add('active');
+  setTimeout(() => damageFlash.classList.remove('active'), 180);
+  if (playerHealth <= 0) {
+    endGame('You were overrun!');
+  }
+}
+
+function endGame(message) {
+  if (gameEnded) return;
+  gameEnded = true;
+  showJumpScare(message);
+}
+
+function showJumpScare(message = 'BRAAAINS!') {
+  if (jumpScareShown) return;
+  jumpScareShown = true;
+  jumpscare.textContent = message;
+  jumpscare.classList.add('active');
+  try {
+    const audio = new (window.AudioContext || window.webkitAudioContext)();
+    const osc = audio.createOscillator();
+    const gain = audio.createGain();
+    osc.frequency.value = 170;
+    gain.gain.value = 0.22;
+    osc.connect(gain).connect(audio.destination);
+    osc.start();
+    gain.gain.exponentialRampToValueAtTime(0.0001, audio.currentTime + 0.5);
+    osc.stop(audio.currentTime + 0.55);
+  } catch (e) {
+    console.warn('Unable to play jumpscare audio', e);
+  }
+}
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function willCollide(pos) {
+  const box = new THREE.Box3().setFromCenterAndSize(pos.clone().setY(1), new THREE.Vector3(0.6, 2, 0.6));
+  return worldBoxes.some(collider => collider.intersectsBox(box));
+}
+
+function movePlayer(delta) {
+  const direction = new THREE.Vector3();
+  const forward = new THREE.Vector3();
+  const right = new THREE.Vector3();
+  controls.getDirection(forward);
+  forward.y = 0; forward.normalize();
+  right.crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize();
+
+  const speed = isSprinting ? PLAYER_SPRINT : PLAYER_SPEED;
+  if (moveForward) direction.add(forward);
+  if (moveBackward) direction.sub(forward);
+  if (moveLeft) direction.sub(right);
+  if (moveRight) direction.add(right);
+  if (direction.lengthSq() > 0) direction.normalize();
+
+  const displacement = direction.multiplyScalar(speed * delta);
+  const nextPos = controls.getObject().position.clone().add(displacement);
+  if (!willCollide(nextPos)) controls.getObject().position.copy(nextPos);
+
+  // gravity
+  playerVelocityY -= GRAVITY * delta;
+  controls.getObject().position.y += playerVelocityY * delta;
+  if (controls.getObject().position.y < PLAYER_HEIGHT) {
+    playerVelocityY = 0;
+    controls.getObject().position.y = PLAYER_HEIGHT;
+    canJump = true;
+  }
+}
+
+let moveForward = false, moveBackward = false, moveLeft = false, moveRight = false;
+let canJump = false;
+let isSprinting = false;
+
+document.addEventListener('keydown', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = true; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = true; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = true; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = true; break;
+    case 'Space': if (canJump) { playerVelocityY = JUMP_VELOCITY; canJump = false; } break;
+    case 'ShiftLeft': isSprinting = true; break;
+    case 'Digit1': currentWeapon = 'pistol'; updateAmmoUI(); break;
+    case 'Digit2': currentWeapon = 'rifle'; updateAmmoUI(); break;
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = false; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = false; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = false; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = false; break;
+    case 'ShiftLeft': isSprinting = false; break;
+  }
+});
+
+function animate() {
+  if (gameEnded) return;
+  requestAnimationFrame(animate);
+  const delta = clock.getDelta();
+  movePlayer(delta);
+  updateEnemies(delta);
+  updateProjectiles(delta);
+  updateHealthBars();
+  renderer.render(scene, camera);
+}

--- a/Zombie_Game/Zombie_Game_v1/style.css
+++ b/Zombie_Game/Zombie_Game_v1/style.css
@@ -1,0 +1,14 @@
+* { box-sizing: border-box; }
+body, html { margin: 0; padding: 0; overflow: hidden; background: #000; color: #fff; font-family: Arial, sans-serif; }
+.overlay { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.85); z-index: 5; }
+.overlay-content { text-align: center; max-width: 540px; }
+.overlay button { padding: 12px 24px; font-size: 18px; cursor: pointer; }
+.hud { position: absolute; top: 10px; left: 10px; z-index: 4; display: flex; gap: 12px; font-size: 16px; text-shadow: 0 0 4px #000; }
+.bar { padding: 6px 10px; background: rgba(0,0,0,0.5); border: 1px solid #4caf50; border-radius: 6px; }
+#crosshair { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 22px; z-index: 3; color: #fff; text-shadow: 0 0 5px #000; }
+canvas { display: block; }
+.damage { position: absolute; inset: 0; background: radial-gradient(circle, rgba(255,0,0,0.35) 0%, rgba(255,0,0,0) 60%); opacity: 0; transition: opacity 0.3s ease; pointer-events: none; z-index: 2; }
+.damage.active { opacity: 0.7; }
+.jumpscare { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; background: radial-gradient(circle at center, rgba(255,0,0,0.45), rgba(0,0,0,0.95)), url('https://i.imgur.com/7N4k1U4.png') center/cover no-repeat; color: #fff; font-size: 64px; z-index: 20; text-shadow: 0 0 24px #ff0000; animation: shake 0.5s linear infinite; }
+.jumpscare.active { display: flex; }
+@keyframes shake { 0% { transform: translate(3px, 0); } 25% { transform: translate(-3px, 2px); } 50% { transform: translate(2px, -2px); } 75% { transform: translate(-2px, 3px); } 100% { transform: translate(0,0); } }

--- a/Zombie_Game/Zombie_Game_v2/README.md
+++ b/Zombie_Game/Zombie_Game_v2/README.md
@@ -1,0 +1,18 @@
+# Zombie Hallway FPS (v2)
+
+An updated corridor shooter demo with clearer HUD feedback, boss health tracking, and improved combat pacing.
+
+## Controls
+- Click to lock pointer
+- Left click: aim (narrow FOV), Right click: fire
+- Press **1** for pistol or **2** for rifle (higher damage, faster cadence)
+- WASD to move, Space to jump, Shift to sprint
+
+## Gameplay
+- Zombies (80 HP) pursue and swipe for 10 damage
+- Boss (200 HP) is larger, swings for 15 damage, and lobs slow fireballs
+- Pistol deals 10 damage per shot, rifle deals 18; ammo starts at 120 pistol / 90 rifle
+- Zombie-themed jump scare appears when you die
+- Kills counter tracks progress
+
+Open `index.html` in a browser to play.

--- a/Zombie_Game/Zombie_Game_v2/index.html
+++ b/Zombie_Game/Zombie_Game_v2/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zombie Hallway FPS (v2)</title>
+  <link rel="stylesheet" href="style.css" />
+
+  <script type="module" src="main.js"></script>
+</head>
+<body>
+  <div id="start" class="overlay">
+    <div class="overlay-content">
+      <h1>Zombie Hallway v2</h1>
+      <p>Left click: aim, Right click: fire. 1 = Pistol, 2 = Rifle. WASD to move, Shift to sprint, Space to jump. Avoid melee and fireballs.</p>
+      <button id="play">Start</button>
+    </div>
+  </div>
+  <div id="hud" class="hud">
+    <div id="hp" class="bar">HP: 100</div>
+    <div id="boss" class="bar">Boss: 200</div>
+    <div id="ammo" class="bar">Weapon: Pistol | Pistol: 120 | Rifle: 90</div>
+    <div id="kills" class="bar">Kills: 0</div>
+  </div>
+  <div id="crosshair">+</div>
+  <div id="damageFlash" class="damage"></div>
+  <div id="jumpscare" class="jumpscare">BRAAAINS!</div>
+</body>
+</html>

--- a/Zombie_Game/Zombie_Game_v2/main.js
+++ b/Zombie_Game/Zombie_Game_v2/main.js
@@ -1,0 +1,378 @@
+
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+import { PointerLockControls } from 'https://unpkg.com/three@0.158.0/examples/jsm/controls/PointerLockControls.js';
+
+const PLAYER_SPEED = 12;
+const PLAYER_SPRINT = 18;
+const PLAYER_HEIGHT = 1.8;
+const JUMP_VELOCITY = 10;
+const GRAVITY = 30;
+const PISTOL_DAMAGE = 10;
+const RIFLE_DAMAGE = 18;
+const RIFLE_COOLDOWN = 0.22;
+const ZOMBIE_HEALTH = 80;
+const BOSS_HEALTH = 200;
+const ZOMBIE_DAMAGE = 10;
+const BOSS_DAMAGE = 15;
+const ATTACK_RANGE = 1.6;
+const FIREBALL_DAMAGE = 15;
+const FIREBALL_SPEED = 12;
+const FIREBALL_COOLDOWN = 2.3;
+const SHOOT_COOLDOWN = 0.35;
+const BASE_FOV = 65;
+const AIM_FOV = 45;
+const weaponStats = {
+  pistol: { damage: PISTOL_DAMAGE, cooldown: SHOOT_COOLDOWN },
+  rifle: { damage: RIFLE_DAMAGE, cooldown: RIFLE_COOLDOWN },
+};
+
+let scene, camera, renderer, controls;
+let moveForward = false, moveBackward = false, moveLeft = false, moveRight = false, canJump = false, isSprinting = false;
+let velocityY = 0;
+let clock = new THREE.Clock();
+let enemies = [];
+let projectiles = [];
+let ammo = { pistol: 120, rifle: 90 };
+let lastShot = { pistol: 0, rifle: 0 };
+let currentWeapon = 'pistol';
+let playerHealth = 100;
+let kills = 0;
+let bossRef = null;
+let gameOver = false;
+const colliders = [];
+
+const startOverlay = document.getElementById('start');
+const startButton = document.getElementById('play');
+const uiHp = document.getElementById('hp');
+const uiBoss = document.getElementById('boss');
+const uiAmmo = document.getElementById('ammo');
+const uiKills = document.getElementById('kills');
+const crosshair = document.getElementById('crosshair');
+const damageFlash = document.getElementById('damageFlash');
+const jumpScare = document.getElementById('jumpscare');
+let jumpScareShown = false;
+
+function updateAmmoUI() {
+  uiAmmo.textContent = `Weapon: ${currentWeapon.toUpperCase()} | Pistol: ${ammo.pistol} | Rifle: ${ammo.rifle}`;
+}
+
+startButton.addEventListener('click', () => {
+  startOverlay.style.display = 'none';
+  updateAmmoUI();
+  init();
+  animate();
+});
+
+document.addEventListener('contextmenu', (e) => e.preventDefault());
+
+document.addEventListener('mousedown', (e) => {
+  if (!controls || !controls.isLocked) return;
+  if (e.button === 0) {
+    // aim
+    camera.fov = AIM_FOV;
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(0.75)';
+  } else if (e.button === 2) {
+    shoot();
+  }
+});
+
+document.addEventListener('mouseup', (e) => {
+  if (e.button === 0) {
+    camera.fov = BASE_FOV;
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(1)';
+  }
+});
+
+function init() {
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0c0c0c);
+
+  camera = new THREE.PerspectiveCamera(BASE_FOV, window.innerWidth / window.innerHeight, 0.1, 500);
+  camera.position.set(0, PLAYER_HEIGHT, 0);
+
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  controls = new PointerLockControls(camera, renderer.domElement);
+  renderer.domElement.addEventListener('click', () => controls.lock());
+
+  scene.add(new THREE.HemisphereLight(0xffffff, 0x555555, 1.1));
+  const dirLight = new THREE.DirectionalLight(0xffffff, 0.6);
+  dirLight.position.set(5, 10, 2);
+  scene.add(dirLight);
+
+  buildLevel();
+  spawnEnemyWave();
+
+  window.addEventListener('resize', onResize);
+}
+
+// ...existing code...
+  const floorGeom = new THREE.BoxGeometry(8, 0.5, 240);
+  const floor = new THREE.Mesh(floorGeom, new THREE.MeshStandardMaterial({ color: 0x202020 }));
+  floor.position.set(0, -0.25, 0);
+  scene.add(floor);
+  colliders.push(new THREE.Box3().setFromObject(floor));
+
+  const wallMat = new THREE.MeshStandardMaterial({ color: 0x2f2f2f });
+  const wallGeom = new THREE.BoxGeometry(0.5, 6, 240);
+  const leftWall = new THREE.Mesh(wallGeom, wallMat);
+  leftWall.position.set(-4.25, 2.5, 0);
+  const rightWall = leftWall.clone();
+  rightWall.position.x = 4.25;
+  scene.add(leftWall, rightWall);
+  [leftWall, rightWall].forEach(w => colliders.push(new THREE.Box3().setFromObject(w)));
+
+  const ceiling = new THREE.Mesh(new THREE.BoxGeometry(8, 0.5, 240), new THREE.MeshStandardMaterial({ color: 0x151515 }));
+  ceiling.position.set(0, 5.75, 0);
+  scene.add(ceiling);
+  colliders.push(new THREE.Box3().setFromObject(ceiling));
+
+  const coverMat = new THREE.MeshStandardMaterial({ color: 0x505050 });
+  for (let i = 0; i < 7; i++) {
+    const cover = new THREE.Mesh(new THREE.BoxGeometry(2, 3.2, 4), coverMat);
+    cover.position.set(i % 2 === 0 ? -1.5 : 1.5, 1.6, 20 + i * 30);
+    scene.add(cover);
+    colliders.push(new THREE.Box3().setFromObject(cover));
+  }
+}
+
+function spawnEnemyWave() {
+  const positions = [15, 40, 70, 110, 140, 180, 215];
+  positions.forEach((z, idx) => {
+    const isBoss = idx === positions.length - 1;
+    const enemy = buildEnemy(isBoss);
+    enemy.group.position.set(isBoss ? 0 : (idx % 2 === 0 ? -2 : 2), 0, z);
+    enemies.push(enemy);
+    scene.add(enemy.group);
+    if (isBoss) bossRef = enemy;
+  });
+  uiBoss.textContent = bossRef ? `Boss: ${bossRef.health}` : 'Boss: --';
+}
+
+function buildEnemy(isBoss) {
+  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(isBoss ? 0.7 : 0.5, isBoss ? 1.8 : 1.2, 6, 12), new THREE.MeshStandardMaterial({ color: isBoss ? 0x8c3f3f : 0x6b8a6f }));
+  const group = new THREE.Group();
+  group.add(torso);
+
+  const barBg = new THREE.Mesh(new THREE.PlaneGeometry(1.4, 0.1), new THREE.MeshBasicMaterial({ color: 0x111111 }));
+  const bar = new THREE.Mesh(new THREE.PlaneGeometry(1.4, 0.1), new THREE.MeshBasicMaterial({ color: 0x4caf50 }));
+  bar.position.z = 0.01;
+  const barWrap = new THREE.Group();
+  barWrap.add(barBg, bar);
+  barWrap.position.set(0, isBoss ? 2.1 : 1.6, 0);
+  group.add(barWrap);
+
+  return {
+    isBoss,
+    group,
+    bar,
+    health: isBoss ? BOSS_HEALTH : ZOMBIE_HEALTH,
+    maxHealth: isBoss ? BOSS_HEALTH : ZOMBIE_HEALTH,
+    lastAttack: 0,
+    lastFire: 0,
+    alive: true
+  };
+}
+
+function shoot() {
+  const now = clock.getElapsedTime();
+  const stats = weaponStats[currentWeapon];
+  if (!stats || now - lastShot[currentWeapon] < stats.cooldown || ammo[currentWeapon] <= 0 || gameOver) return;
+  lastShot[currentWeapon] = now;
+  ammo[currentWeapon] -= 1;
+  updateAmmoUI();
+
+  const ray = new THREE.Raycaster();
+  ray.setFromCamera(new THREE.Vector2(), camera);
+  const hits = ray.intersectObjects(enemies.filter(e => e.alive).map(e => e.group), true);
+  if (hits.length === 0) return;
+  const enemy = enemies.find(e => e.group === hits[0].object.parent || e.group.children.includes(hits[0].object));
+  if (!enemy || !enemy.alive) return;
+  enemy.health -= stats.damage;
+  enemy.bar.scale.x = Math.max(enemy.health, 0) / enemy.maxHealth;
+  enemy.bar.position.x = (Math.max(enemy.health, 0) / enemy.maxHealth - 1) * 0.7;
+  if (enemy.health <= 0) {
+    enemy.alive = false;
+    enemy.group.visible = false;
+    kills += 1;
+    uiKills.textContent = `Kills: ${kills}`;
+  }
+  if (enemy.isBoss) {
+    uiBoss.textContent = `Boss: ${Math.max(enemy.health, 0)}`;
+  }
+}
+
+function updateEnemies(delta) {
+  const playerPos = controls.getObject().position.clone();
+  enemies.forEach(enemy => {
+    if (!enemy.alive) return;
+    const dir = new THREE.Vector3().subVectors(playerPos, enemy.group.position);
+    dir.y = 0;
+    const distance = dir.length();
+    if (distance > 0) dir.normalize();
+    const moveSpeed = enemy.isBoss ? 4 : 5.2;
+    enemy.group.position.addScaledVector(dir, moveSpeed * delta);
+
+    if (distance < ATTACK_RANGE) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastAttack > 1) {
+        applyDamage(enemy.isBoss ? BOSS_DAMAGE : ZOMBIE_DAMAGE);
+        enemy.lastAttack = now;
+      }
+    }
+
+    if (enemy.isBoss) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastFire > FIREBALL_COOLDOWN) {
+        launchFireball(enemy, playerPos);
+        enemy.lastFire = now;
+      }
+    }
+  });
+}
+
+function launchFireball(enemy, targetPos) {
+  const geometry = new THREE.SphereGeometry(0.16, 10, 10);
+  const material = new THREE.MeshBasicMaterial({ color: 0xff6633 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.copy(enemy.group.position).add(new THREE.Vector3(0, 1.4, 0));
+  const dir = new THREE.Vector3().subVectors(targetPos, mesh.position).setY(0).normalize();
+  projectiles.push({ mesh, dir, alive: true });
+  scene.add(mesh);
+}
+
+function updateProjectiles(delta) {
+  projectiles = projectiles.filter(p => p.alive);
+  projectiles.forEach(p => {
+    p.mesh.position.addScaledVector(p.dir, FIREBALL_SPEED * delta);
+    if (p.mesh.position.distanceTo(controls.getObject().position) < 1) {
+      applyDamage(FIREBALL_DAMAGE);
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+    if (Math.abs(p.mesh.position.z) > 260) {
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+  });
+}
+
+function applyDamage(amount) {
+  if (gameOver) return;
+  playerHealth = Math.max(0, playerHealth - amount);
+  uiHp.textContent = `HP: ${playerHealth}`;
+  damageFlash.classList.add('active');
+  setTimeout(() => damageFlash.classList.remove('active'), 150);
+  if (playerHealth <= 0) {
+    endGame('You were overrun. Refresh to retry.');
+  }
+}
+
+function endGame(message) {
+  if (gameOver) return;
+  gameOver = true;
+  showJumpScare(message);
+}
+
+function showJumpScare(message = 'BRAAAINS!') {
+  if (jumpScareShown) return;
+  jumpScareShown = true;
+  jumpScare.textContent = message;
+  jumpScare.classList.add('active');
+  try {
+    const audio = new (window.AudioContext || window.webkitAudioContext)();
+    const osc = audio.createOscillator();
+    const gain = audio.createGain();
+    osc.frequency.value = 170;
+    gain.gain.value = 0.22;
+    osc.connect(gain).connect(audio.destination);
+    osc.start();
+    gain.gain.exponentialRampToValueAtTime(0.0001, audio.currentTime + 0.5);
+    osc.stop(audio.currentTime + 0.55);
+  } catch (e) {
+    console.warn('Unable to play jumpscare audio', e);
+  }
+}
+
+function willCollide(nextPos) {
+  const box = new THREE.Box3().setFromCenterAndSize(nextPos.clone().setY(1), new THREE.Vector3(0.6, 2, 0.6));
+  return colliders.some(c => c.intersectsBox(box));
+}
+
+function movePlayer(delta) {
+  const forward = new THREE.Vector3();
+  controls.getDirection(forward);
+  forward.y = 0; forward.normalize();
+  const right = new THREE.Vector3().crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize();
+
+  const moveDir = new THREE.Vector3();
+  if (moveForward) moveDir.add(forward);
+  if (moveBackward) moveDir.sub(forward);
+  if (moveLeft) moveDir.sub(right);
+  if (moveRight) moveDir.add(right);
+  if (moveDir.lengthSq() > 0) moveDir.normalize();
+
+  const speed = isSprinting ? PLAYER_SPRINT : PLAYER_SPEED;
+  const displacement = moveDir.clone().multiplyScalar(speed * delta);
+  const nextPos = controls.getObject().position.clone().add(displacement);
+  if (!willCollide(nextPos)) controls.getObject().position.copy(nextPos);
+
+  velocityY -= GRAVITY * delta;
+  controls.getObject().position.y += velocityY * delta;
+  if (controls.getObject().position.y < PLAYER_HEIGHT) {
+    velocityY = 0;
+    controls.getObject().position.y = PLAYER_HEIGHT;
+    canJump = true;
+  }
+}
+
+document.addEventListener('keydown', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = true; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = true; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = true; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = true; break;
+    case 'Space': if (canJump) { velocityY = JUMP_VELOCITY; canJump = false; } break;
+    case 'ShiftLeft': isSprinting = true; break;
+    case 'Digit1': currentWeapon = 'pistol'; updateAmmoUI(); break;
+    case 'Digit2': currentWeapon = 'rifle'; updateAmmoUI(); break;
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = false; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = false; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = false; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = false; break;
+    case 'ShiftLeft': isSprinting = false; break;
+  }
+});
+
+function onResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+  if (gameOver) return;
+  requestAnimationFrame(animate);
+  const delta = clock.getDelta();
+  movePlayer(delta);
+  updateEnemies(delta);
+  updateProjectiles(delta);
+  renderer.render(scene, camera);
+}

--- a/Zombie_Game/Zombie_Game_v2/style.css
+++ b/Zombie_Game/Zombie_Game_v2/style.css
@@ -1,0 +1,14 @@
+* { box-sizing: border-box; }
+body, html { margin: 0; padding: 0; overflow: hidden; background: #000; color: #fff; font-family: 'Segoe UI', Arial, sans-serif; }
+canvas { display: block; }
+.overlay { position: absolute; inset: 0; background: rgba(0,0,0,0.85); display: flex; align-items: center; justify-content: center; z-index: 10; }
+.overlay-content { text-align: center; max-width: 560px; }
+.overlay button { padding: 12px 22px; font-size: 18px; cursor: pointer; }
+.hud { position: absolute; top: 12px; left: 12px; display: flex; gap: 10px; z-index: 6; font-size: 15px; text-shadow: 0 0 4px #000; }
+.bar { padding: 6px 10px; background: rgba(0,0,0,0.55); border: 1px solid #4caf50; border-radius: 6px; }
+#crosshair { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 22px; z-index: 5; text-shadow: 0 0 5px #000; }
+.damage { position: absolute; inset: 0; background: radial-gradient(circle, rgba(255,0,0,0.35) 0%, rgba(255,0,0,0) 60%); opacity: 0; transition: opacity 0.3s ease; pointer-events: none; z-index: 4; }
+.damage.active { opacity: 0.7; }
+.jumpscare { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; background: radial-gradient(circle at center, rgba(255,0,0,0.45), rgba(0,0,0,0.95)), url('https://i.imgur.com/7N4k1U4.png') center/cover no-repeat; color: #fff; font-size: 64px; z-index: 20; text-shadow: 0 0 24px #ff0000; animation: shake 0.5s linear infinite; }
+.jumpscare.active { display: flex; }
+@keyframes shake { 0% { transform: translate(3px, 0); } 25% { transform: translate(-3px, 2px); } 50% { transform: translate(2px, -2px); } 75% { transform: translate(-2px, 3px); } 100% { transform: translate(0,0); } }

--- a/Zombie_Game/Zombie_Game_v3/README.md
+++ b/Zombie_Game/Zombie_Game_v3/README.md
@@ -1,0 +1,17 @@
+# Zombie Hallway FPS (v1)
+
+A lightweight Three.js demo of a long hallway survival run. Survive zombies and a boss while staying mobile.
+
+Three.js and PointerLockControls are bundled locally under `../../vendor/three` so the game runs without CDN access.
+
+## Controls
+- Click canvas to lock pointer
+- WASD to move, Space to jump, Shift to sprint
+- Left click to shoot, Right click to aim (tighter FOV)
+
+## Gameplay
+- Zombies deal 10 damage in melee and have 80 HP
+- Boss is larger, fires slow fireballs, and has 160 HP
+- Pistol deals 10 damage per shot; ammo is limited
+
+Open `index.html` in a browser to play.

--- a/Zombie_Game/Zombie_Game_v3/index.html
+++ b/Zombie_Game/Zombie_Game_v3/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zombie Hallway FPS (v1)</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="overlay" class="overlay">
+    <div class="overlay-content">
+      <h1>Zombie Hallway (v1)</h1>
+      <p>WASD to move, Space to jump. Left click: shoot. Right click: aim (tight FOV). Avoid zombies and the boss.</p>
+      <button id="startButton">Enter Hallway</button>
+    </div>
+  </div>
+  <div id="hud" class="hud">
+    <div id="health" class="bar">Health: 100</div>
+    <div id="bossHealth" class="bar">Boss: 180</div>
+    <div id="ammo" class="bar">Ammo: 60</div>
+  </div>
+  <div id="crosshair">+</div>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/Zombie_Game/Zombie_Game_v3/main.js
+++ b/Zombie_Game/Zombie_Game_v3/main.js
@@ -1,0 +1,343 @@
+import * as THREE from '../../vendor/three/three.module.js';
+import { PointerLockControls } from '../../vendor/three/PointerLockControls.js';
+
+const PLAYER_SPEED = 12;
+const PLAYER_SPRINT = 18;
+const PLAYER_HEIGHT = 1.8;
+const GRAVITY = 30;
+const JUMP_VELOCITY = 10;
+const ZOMBIE_HEALTH = 80;
+const BOSS_HEALTH = 160;
+const ZOMBIE_DAMAGE = 10;
+const BOSS_DAMAGE = 15;
+const FIREBALL_DAMAGE = 15;
+const FIREBALL_SPEED = 14;
+const FIREBALL_COOLDOWN = 2.5;
+const SHOOT_COOLDOWN = 0.35;
+const AMMO_MAX = 60;
+const AIM_FOV = 45;
+const BASE_FOV = 70;
+
+let scene, camera, renderer, controls;
+let worldBoxes = [];
+let playerVelocityY = 0;
+let lastShot = 0;
+let ammo = AMMO_MAX;
+let playerHealth = 100;
+let gameEnded = false;
+let clock = new THREE.Clock();
+let enemies = [];
+let projectiles = [];
+let bossEnemy = null;
+
+const overlay = document.getElementById('overlay');
+const startButton = document.getElementById('startButton');
+const uiHealth = document.getElementById('health');
+const uiBossHealth = document.getElementById('bossHealth');
+const uiAmmo = document.getElementById('ammo');
+const crosshair = document.getElementById('crosshair');
+
+startButton.addEventListener('click', () => {
+  overlay.style.display = 'none';
+  init();
+  animate();
+});
+
+document.addEventListener('contextmenu', e => e.preventDefault());
+
+document.addEventListener('mousedown', (e) => {
+  if (!controls || !controls.isLocked) return;
+  if (e.button === 0) {
+    handleShoot();
+  } else if (e.button === 2) {
+    camera.fov = THREE.MathUtils.lerp(camera.fov, AIM_FOV, 0.8);
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(0.7)';
+  }
+});
+
+document.addEventListener('mouseup', (e) => {
+  if (e.button === 2) {
+    camera.fov = BASE_FOV;
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(1)';
+  }
+});
+
+function init() {
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x111111);
+
+  camera = new THREE.PerspectiveCamera(BASE_FOV, window.innerWidth / window.innerHeight, 0.1, 1000);
+  camera.position.set(0, PLAYER_HEIGHT, 0);
+
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  controls = new PointerLockControls(camera, renderer.domElement);
+  renderer.domElement.addEventListener('click', () => controls.lock());
+
+  const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1.1);
+  scene.add(light);
+
+  buildCorridor();
+  spawnEnemies();
+
+  window.addEventListener('resize', onWindowResize);
+}
+
+function buildCorridor() {
+  const floorGeom = new THREE.BoxGeometry(6, 0.5, 200);
+  const floor = new THREE.Mesh(floorGeom, new THREE.MeshStandardMaterial({ color: 0x202020 }));
+  floor.position.set(0, -0.25, 0);
+  floor.receiveShadow = true;
+  scene.add(floor);
+  worldBoxes.push(floorGeom.boundingBox || new THREE.Box3().setFromObject(floor));
+
+  const wallMat = new THREE.MeshStandardMaterial({ color: 0x303030 });
+  const leftWall = new THREE.Mesh(new THREE.BoxGeometry(0.5, 6, 200), wallMat);
+  leftWall.position.set(-3.25, 2.5, 0);
+  const rightWall = leftWall.clone();
+  rightWall.position.x = 3.25;
+  const ceiling = new THREE.Mesh(new THREE.BoxGeometry(6, 0.5, 200), new THREE.MeshStandardMaterial({ color: 0x222222 }));
+  ceiling.position.set(0, 5.75, 0);
+  scene.add(leftWall, rightWall, ceiling);
+  [leftWall, rightWall, ceiling].forEach(mesh => worldBoxes.push(new THREE.Box3().setFromObject(mesh)));
+
+  // Add cover buildings along the corridor
+  const coverMat = new THREE.MeshStandardMaterial({ color: 0x555555 });
+  for (let i = 0; i < 6; i++) {
+    const cover = new THREE.Mesh(new THREE.BoxGeometry(2, 3, 4), coverMat);
+    cover.position.set((i % 2 === 0 ? -1.5 : 1.5), 1.5, 25 + i * 25);
+    scene.add(cover);
+    worldBoxes.push(new THREE.Box3().setFromObject(cover));
+  }
+}
+
+function spawnEnemies() {
+  const zombiePositions = [10, 30, 60, 90, 120, 150];
+  zombiePositions.forEach((zPos, idx) => {
+    const isBoss = idx === zombiePositions.length - 1;
+    const enemy = createEnemy(isBoss);
+    enemy.group.position.set(isBoss ? 0 : (idx % 2 === 0 ? -1 : 1), 0, zPos);
+    enemies.push(enemy);
+    scene.add(enemy.group);
+    if (isBoss) bossEnemy = enemy;
+  });
+}
+
+function createEnemy(isBoss) {
+  const bodyGeom = new THREE.CapsuleGeometry(isBoss ? 0.6 : 0.45, isBoss ? 1.6 : 1.2, 6, 12);
+  const body = new THREE.Mesh(bodyGeom, new THREE.MeshStandardMaterial({ color: isBoss ? 0x8c3f3f : 0x6b8a6f }));
+  const health = isBoss ? BOSS_HEALTH : ZOMBIE_HEALTH;
+  const group = new THREE.Group();
+  group.add(body);
+
+  const healthBarBg = new THREE.Mesh(new THREE.PlaneGeometry(1.2, 0.08), new THREE.MeshBasicMaterial({ color: 0x111111 }));
+  const healthBar = new THREE.Mesh(new THREE.PlaneGeometry(1.2, 0.08), new THREE.MeshBasicMaterial({ color: 0x4caf50 }));
+  healthBar.position.z = 0.02;
+  const barGroup = new THREE.Group();
+  barGroup.add(healthBarBg, healthBar);
+  barGroup.position.set(0, isBoss ? 1.8 : 1.4, 0);
+  group.add(barGroup);
+
+  return {
+    isBoss,
+    group,
+    health,
+    maxHealth: health,
+    lastAttack: 0,
+    lastFire: 0,
+    alive: true,
+    bar: healthBar
+  };
+}
+
+function updateHealthBars() {
+  enemies.forEach(enemy => {
+    const ratio = Math.max(enemy.health, 0) / enemy.maxHealth;
+    enemy.bar.scale.x = ratio;
+    enemy.bar.position.x = (ratio - 1) * 0.6;
+  });
+}
+
+function handleShoot() {
+  const now = clock.getElapsedTime();
+  if (now - lastShot < SHOOT_COOLDOWN || ammo <= 0 || gameEnded) return;
+  lastShot = now;
+  ammo -= 1;
+  uiAmmo.textContent = `Ammo: ${ammo}`;
+
+  const raycaster = new THREE.Raycaster();
+  raycaster.setFromCamera(new THREE.Vector2(), camera);
+  const intersects = raycaster.intersectObjects(enemies.filter(e => e.alive).map(e => e.group), true);
+  if (intersects.length > 0) {
+    const target = enemies.find(e => e.group === intersects[0].object.parent || e.group.children.includes(intersects[0].object));
+    if (target && target.alive) {
+      target.health -= target.isBoss ? 10 : 10;
+      if (target.health <= 0) {
+        target.alive = false;
+        target.group.visible = false;
+      }
+      uiBossHealth.textContent = bossEnemy ? `Boss: ${Math.max(bossEnemy.health, 0)}` : 'Boss: -';
+    }
+  }
+}
+
+function updateEnemies(delta) {
+  const playerPos = controls.getObject().position;
+  enemies.forEach(enemy => {
+    if (!enemy.alive) return;
+    const direction = new THREE.Vector3().subVectors(playerPos, enemy.group.position);
+    direction.y = 0; // prevent upward drift
+    if (direction.lengthSq() < 0.0001) return;
+    const distance = direction.length();
+    direction.normalize();
+    const moveSpeed = enemy.isBoss ? 4 : 5;
+    enemy.group.position.addScaledVector(direction, moveSpeed * delta);
+
+    // Melee damage
+    if (distance < 1.5) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastAttack > 1) {
+        applyDamage(enemy.isBoss ? BOSS_DAMAGE : ZOMBIE_DAMAGE);
+        enemy.lastAttack = now;
+      }
+    }
+
+    // Boss fireballs
+    if (enemy.isBoss) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastFire > FIREBALL_COOLDOWN) {
+        spawnFireball(enemy);
+        enemy.lastFire = now;
+      }
+    }
+  });
+}
+
+function spawnFireball(enemy) {
+  const geometry = new THREE.SphereGeometry(0.15, 8, 8);
+  const material = new THREE.MeshBasicMaterial({ color: 0xff5522 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.copy(enemy.group.position).add(new THREE.Vector3(0, 1, 0));
+  const dir = new THREE.Vector3().subVectors(controls.getObject().position, mesh.position).normalize();
+  projectiles.push({ mesh, dir, alive: true });
+  scene.add(mesh);
+}
+
+function updateProjectiles(delta) {
+  projectiles = projectiles.filter(p => p.alive);
+  projectiles.forEach(p => {
+    p.mesh.position.addScaledVector(p.dir, FIREBALL_SPEED * delta);
+    if (p.mesh.position.distanceTo(controls.getObject().position) < 1) {
+      applyDamage(FIREBALL_DAMAGE);
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+    if (Math.abs(p.mesh.position.z) > 220) {
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+  });
+}
+
+function applyDamage(amount) {
+  if (gameEnded) return;
+  playerHealth = Math.max(0, playerHealth - amount);
+  uiHealth.textContent = `Health: ${playerHealth}`;
+  if (playerHealth <= 0) {
+    endGame('You were overrun!');
+  }
+}
+
+function endGame(message) {
+  if (gameEnded) return;
+  gameEnded = true;
+  alert(message);
+}
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function willCollide(pos) {
+  const box = new THREE.Box3().setFromCenterAndSize(pos.clone().setY(1), new THREE.Vector3(0.6, 2, 0.6));
+  return worldBoxes.some(collider => collider.intersectsBox(box));
+}
+
+function movePlayer(delta) {
+  const direction = new THREE.Vector3();
+  const forward = new THREE.Vector3();
+  const right = new THREE.Vector3();
+  controls.getDirection(forward);
+  forward.y = 0; forward.normalize();
+  right.crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize();
+
+  const speed = isSprinting ? PLAYER_SPRINT : PLAYER_SPEED;
+  if (moveForward) direction.add(forward);
+  if (moveBackward) direction.sub(forward);
+  if (moveLeft) direction.sub(right);
+  if (moveRight) direction.add(right);
+  if (direction.lengthSq() > 0) direction.normalize();
+
+  const displacement = direction.multiplyScalar(speed * delta);
+  const nextPos = controls.getObject().position.clone().add(displacement);
+  if (!willCollide(nextPos)) controls.getObject().position.copy(nextPos);
+
+  // gravity
+  playerVelocityY -= GRAVITY * delta;
+  controls.getObject().position.y += playerVelocityY * delta;
+  if (controls.getObject().position.y < PLAYER_HEIGHT) {
+    playerVelocityY = 0;
+    controls.getObject().position.y = PLAYER_HEIGHT;
+    canJump = true;
+  }
+}
+
+let moveForward = false, moveBackward = false, moveLeft = false, moveRight = false;
+let canJump = false;
+let isSprinting = false;
+
+document.addEventListener('keydown', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = true; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = true; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = true; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = true; break;
+    case 'Space': if (canJump) { playerVelocityY = JUMP_VELOCITY; canJump = false; } break;
+    case 'ShiftLeft': isSprinting = true; break;
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = false; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = false; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = false; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = false; break;
+    case 'ShiftLeft': isSprinting = false; break;
+  }
+});
+
+function animate() {
+  if (gameEnded) return;
+  requestAnimationFrame(animate);
+  const delta = clock.getDelta();
+  movePlayer(delta);
+  updateEnemies(delta);
+  updateProjectiles(delta);
+  updateHealthBars();
+  renderer.render(scene, camera);
+}

--- a/Zombie_Game/Zombie_Game_v3/style.css
+++ b/Zombie_Game/Zombie_Game_v3/style.css
@@ -1,0 +1,9 @@
+* { box-sizing: border-box; }
+body, html { margin: 0; padding: 0; overflow: hidden; background: #000; color: #fff; font-family: Arial, sans-serif; }
+.overlay { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.85); z-index: 5; }
+.overlay-content { text-align: center; max-width: 540px; }
+.overlay button { padding: 12px 24px; font-size: 18px; cursor: pointer; }
+.hud { position: absolute; top: 10px; left: 10px; z-index: 4; display: flex; gap: 12px; font-size: 16px; text-shadow: 0 0 4px #000; }
+.bar { padding: 6px 10px; background: rgba(0,0,0,0.5); border: 1px solid #4caf50; border-radius: 6px; }
+#crosshair { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 22px; z-index: 3; color: #fff; text-shadow: 0 0 5px #000; }
+canvas { display: block; }

--- a/Zombie_Game/Zombie_Game_v4/README.md
+++ b/Zombie_Game/Zombie_Game_v4/README.md
@@ -1,0 +1,18 @@
+# Zombie Hallway FPS (v2)
+
+An updated corridor shooter demo with clearer HUD feedback, boss health tracking, and improved combat pacing.
+
+Three.js and PointerLockControls are bundled locally under `../../vendor/three` so the game runs without CDN access.
+
+## Controls
+- Click to lock pointer
+- Left click: aim (narrow FOV), Right click: fire pistol
+- WASD to move, Space to jump, Shift to sprint
+
+## Gameplay
+- Zombies (80 HP) pursue and swipe for 10 damage
+- Boss (200 HP) is larger, swings for 15 damage, and lobs slow fireballs
+- Pistol deals 10 damage per shot, ammo starts at 120
+- Kills counter tracks progress
+
+Open `index.html` in a browser to play.

--- a/Zombie_Game/Zombie_Game_v4/index.html
+++ b/Zombie_Game/Zombie_Game_v4/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zombie Hallway FPS (v2)</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="start" class="overlay">
+    <div class="overlay-content">
+      <h1>Zombie Hallway v2</h1>
+      <p>Left click: aim, Right click: fire pistol. WASD to move, Space to jump, Shift to sprint. Avoid melee and fireballs.</p>
+      <button id="play">Start</button>
+    </div>
+  </div>
+  <div id="hud" class="hud">
+    <div id="hp" class="bar">HP: 100</div>
+    <div id="boss" class="bar">Boss: 200</div>
+    <div id="ammo" class="bar">Ammo: 120</div>
+    <div id="kills" class="bar">Kills: 0</div>
+  </div>
+  <div id="crosshair">+</div>
+  <div id="damageFlash" class="damage"></div>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/Zombie_Game/Zombie_Game_v4/main.js
+++ b/Zombie_Game/Zombie_Game_v4/main.js
@@ -1,0 +1,341 @@
+import * as THREE from '../../vendor/three/three.module.js';
+import { PointerLockControls } from '../../vendor/three/PointerLockControls.js';
+
+const PLAYER_SPEED = 12;
+const PLAYER_SPRINT = 18;
+const PLAYER_HEIGHT = 1.8;
+const JUMP_VELOCITY = 10;
+const GRAVITY = 30;
+const PISTOL_DAMAGE = 10;
+const ZOMBIE_HEALTH = 80;
+const BOSS_HEALTH = 200;
+const ZOMBIE_DAMAGE = 10;
+const BOSS_DAMAGE = 15;
+const ATTACK_RANGE = 1.6;
+const FIREBALL_DAMAGE = 15;
+const FIREBALL_SPEED = 12;
+const FIREBALL_COOLDOWN = 2.3;
+const SHOOT_COOLDOWN = 0.35;
+const BASE_FOV = 65;
+const AIM_FOV = 45;
+
+let scene, camera, renderer, controls;
+let moveForward = false, moveBackward = false, moveLeft = false, moveRight = false, canJump = false, isSprinting = false;
+let velocityY = 0;
+let clock = new THREE.Clock();
+let enemies = [];
+let projectiles = [];
+let ammo = 120;
+let lastShot = 0;
+let playerHealth = 100;
+let kills = 0;
+let bossRef = null;
+let gameOver = false;
+const colliders = [];
+
+const startOverlay = document.getElementById('start');
+const startButton = document.getElementById('play');
+const uiHp = document.getElementById('hp');
+const uiBoss = document.getElementById('boss');
+const uiAmmo = document.getElementById('ammo');
+const uiKills = document.getElementById('kills');
+const crosshair = document.getElementById('crosshair');
+const damageFlash = document.getElementById('damageFlash');
+
+startButton.addEventListener('click', () => {
+  startOverlay.style.display = 'none';
+  init();
+  animate();
+});
+
+document.addEventListener('contextmenu', (e) => e.preventDefault());
+
+document.addEventListener('mousedown', (e) => {
+  if (!camera || !controls || !controls.isLocked) return;
+  if (e.button === 0) {
+    // aim
+    camera.fov = AIM_FOV;
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(0.75)';
+  } else if (e.button === 2) {
+    shoot();
+  }
+});
+
+document.addEventListener('mouseup', (e) => {
+  if (!camera || !controls || !controls.isLocked) return;
+  if (e.button === 0) {
+    camera.fov = BASE_FOV;
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(1)';
+  }
+});
+
+function init() {
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0c0c0c);
+
+  camera = new THREE.PerspectiveCamera(BASE_FOV, window.innerWidth / window.innerHeight, 0.1, 500);
+  camera.position.set(0, PLAYER_HEIGHT, 0);
+
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  controls = new PointerLockControls(camera, renderer.domElement);
+  renderer.domElement.addEventListener('click', () => controls.lock());
+
+  scene.add(new THREE.HemisphereLight(0xffffff, 0x555555, 1.1));
+  const dirLight = new THREE.DirectionalLight(0xffffff, 0.6);
+  dirLight.position.set(5, 10, 2);
+  scene.add(dirLight);
+
+  buildLevel();
+  spawnEnemyWave();
+
+  window.addEventListener('resize', onResize);
+}
+
+function buildLevel() {
+  const floorGeom = new THREE.BoxGeometry(8, 0.5, 240);
+  const floor = new THREE.Mesh(floorGeom, new THREE.MeshStandardMaterial({ color: 0x202020 }));
+  floor.position.set(0, -0.25, 0);
+  scene.add(floor);
+  colliders.push(new THREE.Box3().setFromObject(floor));
+
+  const wallMat = new THREE.MeshStandardMaterial({ color: 0x2f2f2f });
+  const wallGeom = new THREE.BoxGeometry(0.5, 6, 240);
+  const leftWall = new THREE.Mesh(wallGeom, wallMat);
+  leftWall.position.set(-4.25, 2.5, 0);
+  const rightWall = leftWall.clone();
+  rightWall.position.x = 4.25;
+  scene.add(leftWall, rightWall);
+  [leftWall, rightWall].forEach(w => colliders.push(new THREE.Box3().setFromObject(w)));
+
+  const ceiling = new THREE.Mesh(new THREE.BoxGeometry(8, 0.5, 240), new THREE.MeshStandardMaterial({ color: 0x151515 }));
+  ceiling.position.set(0, 5.75, 0);
+  scene.add(ceiling);
+  colliders.push(new THREE.Box3().setFromObject(ceiling));
+
+  const coverMat = new THREE.MeshStandardMaterial({ color: 0x505050 });
+  for (let i = 0; i < 7; i++) {
+    const cover = new THREE.Mesh(new THREE.BoxGeometry(2, 3.2, 4), coverMat);
+    cover.position.set(i % 2 === 0 ? -1.5 : 1.5, 1.6, 20 + i * 30);
+    scene.add(cover);
+    colliders.push(new THREE.Box3().setFromObject(cover));
+  }
+}
+
+function spawnEnemyWave() {
+  const positions = [15, 40, 70, 110, 140, 180, 215];
+  positions.forEach((z, idx) => {
+    const isBoss = idx === positions.length - 1;
+    const enemy = buildEnemy(isBoss);
+    enemy.group.position.set(isBoss ? 0 : (idx % 2 === 0 ? -2 : 2), 0, z);
+    enemies.push(enemy);
+    scene.add(enemy.group);
+    if (isBoss) bossRef = enemy;
+  });
+  uiBoss.textContent = bossRef ? `Boss: ${bossRef.health}` : 'Boss: --';
+}
+
+function buildEnemy(isBoss) {
+  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(isBoss ? 0.7 : 0.5, isBoss ? 1.8 : 1.2, 6, 12), new THREE.MeshStandardMaterial({ color: isBoss ? 0x8c3f3f : 0x6b8a6f }));
+  const group = new THREE.Group();
+  group.add(torso);
+
+  const barBg = new THREE.Mesh(new THREE.PlaneGeometry(1.4, 0.1), new THREE.MeshBasicMaterial({ color: 0x111111 }));
+  const bar = new THREE.Mesh(new THREE.PlaneGeometry(1.4, 0.1), new THREE.MeshBasicMaterial({ color: 0x4caf50 }));
+  bar.position.z = 0.01;
+  const barWrap = new THREE.Group();
+  barWrap.add(barBg, bar);
+  barWrap.position.set(0, isBoss ? 2.1 : 1.6, 0);
+  group.add(barWrap);
+
+  return {
+    isBoss,
+    group,
+    bar,
+    health: isBoss ? BOSS_HEALTH : ZOMBIE_HEALTH,
+    maxHealth: isBoss ? BOSS_HEALTH : ZOMBIE_HEALTH,
+    lastAttack: 0,
+    lastFire: 0,
+    alive: true
+  };
+}
+
+function shoot() {
+  const now = clock.getElapsedTime();
+  if (now - lastShot < SHOOT_COOLDOWN || ammo <= 0 || gameOver) return;
+  lastShot = now;
+  ammo -= 1;
+  uiAmmo.textContent = `Ammo: ${ammo}`;
+
+  const ray = new THREE.Raycaster();
+  ray.setFromCamera(new THREE.Vector2(), camera);
+  const hits = ray.intersectObjects(enemies.filter(e => e.alive).map(e => e.group), true);
+  if (hits.length === 0) return;
+  const enemy = enemies.find(e => e.group === hits[0].object.parent || e.group.children.includes(hits[0].object));
+  if (!enemy || !enemy.alive) return;
+  enemy.health -= PISTOL_DAMAGE;
+  enemy.bar.scale.x = Math.max(enemy.health, 0) / enemy.maxHealth;
+  enemy.bar.position.x = (Math.max(enemy.health, 0) / enemy.maxHealth - 1) * 0.7;
+  if (enemy.health <= 0) {
+    enemy.alive = false;
+    enemy.group.visible = false;
+    kills += 1;
+    uiKills.textContent = `Kills: ${kills}`;
+  }
+  if (enemy.isBoss) {
+    uiBoss.textContent = `Boss: ${Math.max(enemy.health, 0)}`;
+  }
+}
+
+function updateEnemies(delta) {
+  const playerPos = controls.getObject().position.clone();
+  enemies.forEach(enemy => {
+    if (!enemy.alive) return;
+    const dir = new THREE.Vector3().subVectors(playerPos, enemy.group.position);
+    dir.y = 0;
+    const distance = dir.length();
+    if (distance > 0) dir.normalize();
+    const moveSpeed = enemy.isBoss ? 4 : 5.2;
+    enemy.group.position.addScaledVector(dir, moveSpeed * delta);
+
+    if (distance < ATTACK_RANGE) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastAttack > 1) {
+        applyDamage(enemy.isBoss ? BOSS_DAMAGE : ZOMBIE_DAMAGE);
+        enemy.lastAttack = now;
+      }
+    }
+
+    if (enemy.isBoss) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastFire > FIREBALL_COOLDOWN) {
+        launchFireball(enemy, playerPos);
+        enemy.lastFire = now;
+      }
+    }
+  });
+}
+
+function launchFireball(enemy, targetPos) {
+  const geometry = new THREE.SphereGeometry(0.16, 10, 10);
+  const material = new THREE.MeshBasicMaterial({ color: 0xff6633 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.copy(enemy.group.position).add(new THREE.Vector3(0, 1.4, 0));
+  const dir = new THREE.Vector3().subVectors(targetPos, mesh.position).setY(0).normalize();
+  projectiles.push({ mesh, dir, alive: true });
+  scene.add(mesh);
+}
+
+function updateProjectiles(delta) {
+  projectiles = projectiles.filter(p => p.alive);
+  projectiles.forEach(p => {
+    p.mesh.position.addScaledVector(p.dir, FIREBALL_SPEED * delta);
+    if (p.mesh.position.distanceTo(controls.getObject().position) < 1) {
+      applyDamage(FIREBALL_DAMAGE);
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+    if (Math.abs(p.mesh.position.z) > 260) {
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+  });
+}
+
+function applyDamage(amount) {
+  if (gameOver) return;
+  playerHealth = Math.max(0, playerHealth - amount);
+  uiHp.textContent = `HP: ${playerHealth}`;
+  damageFlash.classList.add('active');
+  setTimeout(() => damageFlash.classList.remove('active'), 150);
+  if (playerHealth <= 0) {
+    endGame('You were overrun. Refresh to retry.');
+  }
+}
+
+function endGame(message) {
+  if (gameOver) return;
+  gameOver = true;
+  alert(message);
+}
+
+function willCollide(nextPos) {
+  const box = new THREE.Box3().setFromCenterAndSize(nextPos.clone().setY(1), new THREE.Vector3(0.6, 2, 0.6));
+  return colliders.some(c => c.intersectsBox(box));
+}
+
+function movePlayer(delta) {
+  const forward = new THREE.Vector3();
+  controls.getDirection(forward);
+  forward.y = 0; forward.normalize();
+  const right = new THREE.Vector3().crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize();
+
+  const moveDir = new THREE.Vector3();
+  if (moveForward) moveDir.add(forward);
+  if (moveBackward) moveDir.sub(forward);
+  if (moveLeft) moveDir.sub(right);
+  if (moveRight) moveDir.add(right);
+  if (moveDir.lengthSq() > 0) moveDir.normalize();
+
+  const speed = isSprinting ? PLAYER_SPRINT : PLAYER_SPEED;
+  const displacement = moveDir.clone().multiplyScalar(speed * delta);
+  const nextPos = controls.getObject().position.clone().add(displacement);
+  if (!willCollide(nextPos)) controls.getObject().position.copy(nextPos);
+
+  velocityY -= GRAVITY * delta;
+  controls.getObject().position.y += velocityY * delta;
+  if (controls.getObject().position.y < PLAYER_HEIGHT) {
+    velocityY = 0;
+    controls.getObject().position.y = PLAYER_HEIGHT;
+    canJump = true;
+  }
+}
+
+document.addEventListener('keydown', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = true; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = true; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = true; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = true; break;
+    case 'Space': if (canJump) { velocityY = JUMP_VELOCITY; canJump = false; } break;
+    case 'ShiftLeft': isSprinting = true; break;
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = false; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = false; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = false; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = false; break;
+    case 'ShiftLeft': isSprinting = false; break;
+  }
+});
+
+function onResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+  if (gameOver) return;
+  requestAnimationFrame(animate);
+  const delta = clock.getDelta();
+  movePlayer(delta);
+  updateEnemies(delta);
+  updateProjectiles(delta);
+  renderer.render(scene, camera);
+}

--- a/Zombie_Game/Zombie_Game_v4/style.css
+++ b/Zombie_Game/Zombie_Game_v4/style.css
@@ -1,0 +1,11 @@
+* { box-sizing: border-box; }
+body, html { margin: 0; padding: 0; overflow: hidden; background: #000; color: #fff; font-family: 'Segoe UI', Arial, sans-serif; }
+canvas { display: block; }
+.overlay { position: absolute; inset: 0; background: rgba(0,0,0,0.85); display: flex; align-items: center; justify-content: center; z-index: 10; }
+.overlay-content { text-align: center; max-width: 560px; }
+.overlay button { padding: 12px 22px; font-size: 18px; cursor: pointer; }
+.hud { position: absolute; top: 12px; left: 12px; display: flex; gap: 10px; z-index: 6; font-size: 15px; text-shadow: 0 0 4px #000; }
+.bar { padding: 6px 10px; background: rgba(0,0,0,0.55); border: 1px solid #4caf50; border-radius: 6px; }
+#crosshair { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 22px; z-index: 5; text-shadow: 0 0 5px #000; }
+.damage { position: absolute; inset: 0; background: radial-gradient(circle, rgba(255,0,0,0.35) 0%, rgba(255,0,0,0) 60%); opacity: 0; transition: opacity 0.3s ease; pointer-events: none; z-index: 4; }
+.damage.active { opacity: 0.7; }

--- a/Zombie_Game/Zombie_Game_v5/README.md
+++ b/Zombie_Game/Zombie_Game_v5/README.md
@@ -1,0 +1,19 @@
+# Zombie Hallway FPS (v1)
+
+A lightweight Three.js demo of a long hallway survival run. Survive zombies and a boss while staying mobile.
+
+Three.js and PointerLockControls are bundled locally under `../../vendor/three` so the game runs without CDN access.
+
+## Controls
+- Click canvas to lock pointer
+- WASD to move, Space to jump, Shift to sprint
+- Left click to shoot, Right click to aim (tighter FOV)
+- Press **1** for pistol or **2** for rifle (harder hits, shorter cooldown)
+
+## Gameplay
+- Zombies deal 10 damage in melee and have 80 HP
+- Boss is larger, fires slow fireballs, and has 160 HP
+- Pistol deals 10 damage per shot; rifle deals 18. Ammo starts at 60 pistol / 90 rifle.
+- Zombie jump scare appears when the player dies
+
+Open `index.html` in a browser to play.

--- a/Zombie_Game/Zombie_Game_v5/index.html
+++ b/Zombie_Game/Zombie_Game_v5/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zombie Hallway FPS (v1)</title>
+  <link rel="stylesheet" href="style.css" />
+  <script type="module" src="main.js"></script>
+</head>
+<body>
+  <div id="overlay" class="overlay">
+    <div class="overlay-content">
+      <h1>Zombie Hallway (v1)</h1>
+      <p>WASD to move, hold Shift to sprint, Space to jump. Left click: shoot. Right click: aim (tight FOV). 1 = Pistol, 2 = Rifle. Avoid zombies and the boss.</p>
+      <button id="startButton">Enter Hallway</button>
+    </div>
+  </div>
+  <div id="hud" class="hud">
+    <div id="health" class="bar">Health: 100</div>
+    <div id="bossHealth" class="bar">Boss: 180</div>
+    <div id="ammo" class="bar">Weapon: Pistol | Pistol: 60 | Rifle: 90</div>
+  </div>
+  <div id="crosshair">+</div>
+  <div id="damageFlash" class="damage"></div>
+  <div id="jumpscare" class="jumpscare">BRAAAINS!</div>
+</body>
+</html>

--- a/Zombie_Game/Zombie_Game_v5/main.js
+++ b/Zombie_Game/Zombie_Game_v5/main.js
@@ -1,0 +1,383 @@
+import * as THREE from '../../vendor/three/three.module.js';
+import { PointerLockControls } from '../../vendor/three/PointerLockControls.js';
+
+const PLAYER_SPEED = 12;
+const PLAYER_SPRINT = 18;
+const PLAYER_HEIGHT = 1.8;
+const GRAVITY = 30;
+const JUMP_VELOCITY = 10;
+const PISTOL_DAMAGE = 10;
+const RIFLE_DAMAGE = 18;
+const RIFLE_COOLDOWN = 0.22;
+const ZOMBIE_HEALTH = 80;
+const BOSS_HEALTH = 160;
+const ZOMBIE_DAMAGE = 10;
+const BOSS_DAMAGE = 15;
+const FIREBALL_DAMAGE = 15;
+const FIREBALL_SPEED = 14;
+const FIREBALL_COOLDOWN = 2.5;
+const SHOOT_COOLDOWN = 0.35;
+const weaponStats = {
+  pistol: { damage: PISTOL_DAMAGE, cooldown: SHOOT_COOLDOWN },
+  rifle: { damage: RIFLE_DAMAGE, cooldown: RIFLE_COOLDOWN },
+};
+const AIM_FOV = 45;
+const BASE_FOV = 70;
+
+let scene, camera, renderer, controls;
+let worldBoxes = [];
+let playerVelocityY = 0;
+let lastShot = { pistol: 0, rifle: 0 };
+let ammo = { pistol: 60, rifle: 90 };
+let currentWeapon = 'pistol';
+let playerHealth = 100;
+let gameEnded = false;
+let clock = new THREE.Clock();
+let enemies = [];
+let projectiles = [];
+let bossEnemy = null;
+
+const overlay = document.getElementById('overlay');
+const startButton = document.getElementById('startButton');
+const uiHealth = document.getElementById('health');
+const uiBossHealth = document.getElementById('bossHealth');
+const uiAmmo = document.getElementById('ammo');
+const crosshair = document.getElementById('crosshair');
+const damageFlash = document.getElementById('damageFlash');
+const jumpscare = document.getElementById('jumpscare');
+let jumpScareShown = false;
+
+function updateAmmoUI() {
+  uiAmmo.textContent = `Weapon: ${currentWeapon.toUpperCase()} | Pistol: ${ammo.pistol} | Rifle: ${ammo.rifle}`;
+}
+
+startButton.addEventListener('click', () => {
+  overlay.style.display = 'none';
+  updateAmmoUI();
+  init();
+  animate();
+});
+
+document.addEventListener('contextmenu', e => e.preventDefault());
+
+document.addEventListener('mousedown', (e) => {
+  if (!controls || !controls.isLocked) return;
+  if (e.button === 0) {
+    handleShoot();
+  } else if (e.button === 2) {
+    camera.fov = THREE.MathUtils.lerp(camera.fov, AIM_FOV, 0.8);
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(0.7)';
+  }
+});
+
+document.addEventListener('mouseup', (e) => {
+  if (e.button === 2) {
+    camera.fov = BASE_FOV;
+    camera.updateProjectionMatrix();
+    crosshair.style.transform = 'translate(-50%, -50%) scale(1)';
+  }
+});
+
+function init() {
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x111111);
+
+  camera = new THREE.PerspectiveCamera(BASE_FOV, window.innerWidth / window.innerHeight, 0.1, 1000);
+  camera.position.set(0, PLAYER_HEIGHT, 0);
+
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  controls = new PointerLockControls(camera, renderer.domElement);
+  renderer.domElement.addEventListener('click', () => controls.lock());
+
+  const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1.1);
+  scene.add(light);
+
+  buildCorridor();
+  spawnEnemies();
+
+  window.addEventListener('resize', onWindowResize);
+}
+
+function buildCorridor() {
+  const floorGeom = new THREE.BoxGeometry(6, 0.5, 200);
+  const floor = new THREE.Mesh(floorGeom, new THREE.MeshStandardMaterial({ color: 0x202020 }));
+  floor.position.set(0, -0.25, 0);
+  floor.receiveShadow = true;
+  scene.add(floor);
+  worldBoxes.push(floorGeom.boundingBox || new THREE.Box3().setFromObject(floor));
+
+  const wallMat = new THREE.MeshStandardMaterial({ color: 0x303030 });
+  const leftWall = new THREE.Mesh(new THREE.BoxGeometry(0.5, 6, 200), wallMat);
+  leftWall.position.set(-3.25, 2.5, 0);
+  const rightWall = leftWall.clone();
+  rightWall.position.x = 3.25;
+  const ceiling = new THREE.Mesh(new THREE.BoxGeometry(6, 0.5, 200), new THREE.MeshStandardMaterial({ color: 0x222222 }));
+  ceiling.position.set(0, 5.75, 0);
+  scene.add(leftWall, rightWall, ceiling);
+  [leftWall, rightWall, ceiling].forEach(mesh => worldBoxes.push(new THREE.Box3().setFromObject(mesh)));
+
+  // Add cover buildings along the corridor
+  const coverMat = new THREE.MeshStandardMaterial({ color: 0x555555 });
+  for (let i = 0; i < 6; i++) {
+    const cover = new THREE.Mesh(new THREE.BoxGeometry(2, 3, 4), coverMat);
+    cover.position.set((i % 2 === 0 ? -1.5 : 1.5), 1.5, 25 + i * 25);
+    scene.add(cover);
+    worldBoxes.push(new THREE.Box3().setFromObject(cover));
+  }
+}
+
+function spawnEnemies() {
+  const zombiePositions = [10, 30, 60, 90, 120, 150];
+  zombiePositions.forEach((zPos, idx) => {
+    const isBoss = idx === zombiePositions.length - 1;
+    const enemy = createEnemy(isBoss);
+    enemy.group.position.set(isBoss ? 0 : (idx % 2 === 0 ? -1 : 1), 0, zPos);
+    enemies.push(enemy);
+    scene.add(enemy.group);
+    if (isBoss) bossEnemy = enemy;
+  });
+}
+
+function createEnemy(isBoss) {
+  const bodyGeom = new THREE.CapsuleGeometry(isBoss ? 0.6 : 0.45, isBoss ? 1.6 : 1.2, 6, 12);
+  const body = new THREE.Mesh(bodyGeom, new THREE.MeshStandardMaterial({ color: isBoss ? 0x8c3f3f : 0x6b8a6f }));
+  const health = isBoss ? BOSS_HEALTH : ZOMBIE_HEALTH;
+  const group = new THREE.Group();
+  group.add(body);
+
+  const healthBarBg = new THREE.Mesh(new THREE.PlaneGeometry(1.2, 0.08), new THREE.MeshBasicMaterial({ color: 0x111111 }));
+  const healthBar = new THREE.Mesh(new THREE.PlaneGeometry(1.2, 0.08), new THREE.MeshBasicMaterial({ color: 0x4caf50 }));
+  healthBar.position.z = 0.02;
+  const barGroup = new THREE.Group();
+  barGroup.add(healthBarBg, healthBar);
+  barGroup.position.set(0, isBoss ? 1.8 : 1.4, 0);
+  group.add(barGroup);
+
+  return {
+    isBoss,
+    group,
+    health,
+    maxHealth: health,
+    lastAttack: 0,
+    lastFire: 0,
+    alive: true,
+    bar: healthBar
+  };
+}
+
+function updateHealthBars() {
+  enemies.forEach(enemy => {
+    const ratio = Math.max(enemy.health, 0) / enemy.maxHealth;
+    enemy.bar.scale.x = ratio;
+    enemy.bar.position.x = (ratio - 1) * 0.6;
+  });
+}
+
+function handleShoot() {
+  const now = clock.getElapsedTime();
+  const stats = weaponStats[currentWeapon];
+  if (!stats || now - lastShot[currentWeapon] < stats.cooldown || ammo[currentWeapon] <= 0 || gameEnded) return;
+  lastShot[currentWeapon] = now;
+  ammo[currentWeapon] -= 1;
+  updateAmmoUI();
+
+  const raycaster = new THREE.Raycaster();
+  raycaster.setFromCamera(new THREE.Vector2(), camera);
+  const intersects = raycaster.intersectObjects(enemies.filter(e => e.alive).map(e => e.group), true);
+  if (intersects.length > 0) {
+    const target = enemies.find(e => e.group === intersects[0].object.parent || e.group.children.includes(intersects[0].object));
+    if (target && target.alive) {
+      target.health -= stats.damage;
+      if (target.health <= 0) {
+        target.alive = false;
+        target.group.visible = false;
+      }
+      uiBossHealth.textContent = bossEnemy ? `Boss: ${Math.max(bossEnemy.health, 0)}` : 'Boss: -';
+    }
+  }
+}
+
+function updateEnemies(delta) {
+  const playerPos = controls.getObject().position;
+  enemies.forEach(enemy => {
+    if (!enemy.alive) return;
+    const direction = new THREE.Vector3().subVectors(playerPos, enemy.group.position);
+    direction.y = 0; // prevent upward drift
+    if (direction.lengthSq() < 0.0001) return;
+    const distance = direction.length();
+    direction.normalize();
+    const moveSpeed = enemy.isBoss ? 4 : 5;
+    enemy.group.position.addScaledVector(direction, moveSpeed * delta);
+
+    // Melee damage
+    if (distance < 1.5) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastAttack > 1) {
+        applyDamage(enemy.isBoss ? BOSS_DAMAGE : ZOMBIE_DAMAGE);
+        enemy.lastAttack = now;
+      }
+    }
+
+    // Boss fireballs
+    if (enemy.isBoss) {
+      const now = clock.getElapsedTime();
+      if (now - enemy.lastFire > FIREBALL_COOLDOWN) {
+        spawnFireball(enemy);
+        enemy.lastFire = now;
+      }
+    }
+  });
+}
+
+function spawnFireball(enemy) {
+  const geometry = new THREE.SphereGeometry(0.15, 8, 8);
+  const material = new THREE.MeshBasicMaterial({ color: 0xff5522 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.copy(enemy.group.position).add(new THREE.Vector3(0, 1, 0));
+  const dir = new THREE.Vector3().subVectors(controls.getObject().position, mesh.position).normalize();
+  projectiles.push({ mesh, dir, alive: true });
+  scene.add(mesh);
+}
+
+function updateProjectiles(delta) {
+  projectiles = projectiles.filter(p => p.alive);
+  projectiles.forEach(p => {
+    p.mesh.position.addScaledVector(p.dir, FIREBALL_SPEED * delta);
+    if (p.mesh.position.distanceTo(controls.getObject().position) < 1) {
+      applyDamage(FIREBALL_DAMAGE);
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+    if (Math.abs(p.mesh.position.z) > 220) {
+      p.alive = false;
+      scene.remove(p.mesh);
+    }
+  });
+}
+
+function applyDamage(amount) {
+  if (gameEnded) return;
+  playerHealth = Math.max(0, playerHealth - amount);
+  uiHealth.textContent = `Health: ${playerHealth}`;
+  damageFlash.classList.add('active');
+  setTimeout(() => damageFlash.classList.remove('active'), 180);
+  if (playerHealth <= 0) {
+    endGame('You were overrun!');
+  }
+}
+
+function endGame(message) {
+  if (gameEnded) return;
+  gameEnded = true;
+  showJumpScare(message);
+}
+
+function showJumpScare(message = 'BRAAAINS!') {
+  if (jumpScareShown) return;
+  jumpScareShown = true;
+  jumpscare.textContent = message;
+  jumpscare.classList.add('active');
+  try {
+    const audio = new (window.AudioContext || window.webkitAudioContext)();
+    const osc = audio.createOscillator();
+    const gain = audio.createGain();
+    osc.frequency.value = 170;
+    gain.gain.value = 0.22;
+    osc.connect(gain).connect(audio.destination);
+    osc.start();
+    gain.gain.exponentialRampToValueAtTime(0.0001, audio.currentTime + 0.5);
+    osc.stop(audio.currentTime + 0.55);
+  } catch (e) {
+    console.warn('Unable to play jumpscare audio', e);
+  }
+}
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function willCollide(pos) {
+  const box = new THREE.Box3().setFromCenterAndSize(pos.clone().setY(1), new THREE.Vector3(0.6, 2, 0.6));
+  return worldBoxes.some(collider => collider.intersectsBox(box));
+}
+
+function movePlayer(delta) {
+  const direction = new THREE.Vector3();
+  const forward = new THREE.Vector3();
+  const right = new THREE.Vector3();
+  controls.getDirection(forward);
+  forward.y = 0; forward.normalize();
+  right.crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize();
+
+  const speed = isSprinting ? PLAYER_SPRINT : PLAYER_SPEED;
+  if (moveForward) direction.add(forward);
+  if (moveBackward) direction.sub(forward);
+  if (moveLeft) direction.sub(right);
+  if (moveRight) direction.add(right);
+  if (direction.lengthSq() > 0) direction.normalize();
+
+  const displacement = direction.multiplyScalar(speed * delta);
+  const nextPos = controls.getObject().position.clone().add(displacement);
+  if (!willCollide(nextPos)) controls.getObject().position.copy(nextPos);
+
+  // gravity
+  playerVelocityY -= GRAVITY * delta;
+  controls.getObject().position.y += playerVelocityY * delta;
+  if (controls.getObject().position.y < PLAYER_HEIGHT) {
+    playerVelocityY = 0;
+    controls.getObject().position.y = PLAYER_HEIGHT;
+    canJump = true;
+  }
+}
+
+let moveForward = false, moveBackward = false, moveLeft = false, moveRight = false;
+let canJump = false;
+let isSprinting = false;
+
+document.addEventListener('keydown', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = true; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = true; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = true; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = true; break;
+    case 'Space': if (canJump) { playerVelocityY = JUMP_VELOCITY; canJump = false; } break;
+    case 'ShiftLeft': isSprinting = true; break;
+    case 'Digit1': currentWeapon = 'pistol'; updateAmmoUI(); break;
+    case 'Digit2': currentWeapon = 'rifle'; updateAmmoUI(); break;
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW': moveForward = false; break;
+    case 'ArrowLeft':
+    case 'KeyA': moveLeft = false; break;
+    case 'ArrowDown':
+    case 'KeyS': moveBackward = false; break;
+    case 'ArrowRight':
+    case 'KeyD': moveRight = false; break;
+    case 'ShiftLeft': isSprinting = false; break;
+  }
+});
+
+function animate() {
+  if (gameEnded) return;
+  requestAnimationFrame(animate);
+  const delta = clock.getDelta();
+  movePlayer(delta);
+  updateEnemies(delta);
+  updateProjectiles(delta);
+  updateHealthBars();
+  renderer.render(scene, camera);
+}

--- a/Zombie_Game/Zombie_Game_v5/style.css
+++ b/Zombie_Game/Zombie_Game_v5/style.css
@@ -1,0 +1,14 @@
+* { box-sizing: border-box; }
+body, html { margin: 0; padding: 0; overflow: hidden; background: #000; color: #fff; font-family: Arial, sans-serif; }
+.overlay { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.85); z-index: 5; }
+.overlay-content { text-align: center; max-width: 540px; }
+.overlay button { padding: 12px 24px; font-size: 18px; cursor: pointer; }
+.hud { position: absolute; top: 10px; left: 10px; z-index: 4; display: flex; gap: 12px; font-size: 16px; text-shadow: 0 0 4px #000; }
+.bar { padding: 6px 10px; background: rgba(0,0,0,0.5); border: 1px solid #4caf50; border-radius: 6px; }
+#crosshair { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 22px; z-index: 3; color: #fff; text-shadow: 0 0 5px #000; }
+canvas { display: block; }
+.damage { position: absolute; inset: 0; background: radial-gradient(circle, rgba(255,0,0,0.35) 0%, rgba(255,0,0,0) 60%); opacity: 0; transition: opacity 0.3s ease; pointer-events: none; z-index: 2; }
+.damage.active { opacity: 0.7; }
+.jumpscare { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; background: radial-gradient(circle at center, rgba(255,0,0,0.45), rgba(0,0,0,0.95)), url('https://i.imgur.com/7N4k1U4.png') center/cover no-repeat; color: #fff; font-size: 64px; z-index: 20; text-shadow: 0 0 24px #ff0000; animation: shake 0.5s linear infinite; }
+.jumpscare.active { display: flex; }
+@keyframes shake { 0% { transform: translate(3px, 0); } 25% { transform: translate(-3px, 2px); } 50% { transform: translate(2px, -2px); } 75% { transform: translate(-2px, 3px); } 100% { transform: translate(0,0); } }

--- a/games/peanut_butter_panic/README.md
+++ b/games/peanut_butter_panic/README.md
@@ -1,0 +1,42 @@
+# Peanut Butter Panic - Remixed
+
+A modern remix of Atari's *Peanut Butter Panic* built with Python and Pygame. Guide a
+heroic jar of peanut butter as it protects sandwiches from waves of hungry critters.
+The remake layers in progression, defensive tools, combo-driven scoring, and quick-hit
+power-ups to keep every run fresh.
+
+## Feature highlights
+
+- **Wave-based pressure** with accelerating spawn rates and tougher enemy bites.
+- **Retro brawler enemies** occasionally spawn, recalling the chunky doom-like
+  monsters from the earliest prototype while offering bigger rewards.
+- **Combo-driven scoring** that rewards streaks and speedy clears.
+- **Defense toolkit**: wide spatula swipes, sticky traps, dashes, and screen-clearing
+  shockwaves.
+- **Power-ups** including sugar rush speed boosts, sticky gloves for wider swings, and
+  instant shockwave charges.
+- **Sandwich integrity tracking** to keep your objectives top-of-mind.
+
+## Controls
+
+- **WASD / Arrow keys**: Move
+- **Space**: Spatula swipe (short cooldown)
+- **Ctrl**: Drop a sticky trap that slows enemies
+- **Shift**: Dash
+- **Q**: Shockwave (clears nearby enemies)
+- **Close the window** to end the run
+
+## Running the game
+
+```bash
+python -m peanut_butter_panic.game
+```
+
+For deterministic behavior in tests or practice runs, you can seed the simulation by
+passing a `seed` to `GameWorld` in code:
+
+```python
+from peanut_butter_panic import GameWorld
+
+world = GameWorld(seed=42)
+```

--- a/games/peanut_butter_panic/__init__.py
+++ b/games/peanut_butter_panic/__init__.py
@@ -1,0 +1,9 @@
+"""Peanut Butter Panic - modernized arcade remake."""
+
+from .core import GameConfig, GameWorld, InputState
+
+__all__ = [
+    "GameConfig",
+    "GameWorld",
+    "InputState",
+]

--- a/games/peanut_butter_panic/core.py
+++ b/games/peanut_butter_panic/core.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+Vec2 = tuple[float, float]
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def _length(vec: Vec2) -> float:
+    return math.sqrt(vec[0] ** 2 + vec[1] ** 2)
+
+
+def _normalize(vec: Vec2) -> Vec2:
+    magnitude = _length(vec)
+    if magnitude == 0:
+        return (0.0, 0.0)
+    return (vec[0] / magnitude, vec[1] / magnitude)
+
+
+def _add(a: Vec2, b: Vec2) -> Vec2:
+    return (a[0] + b[0], a[1] + b[1])
+
+
+def _scale(vec: Vec2, scalar: float) -> Vec2:
+    return (vec[0] * scalar, vec[1] * scalar)
+
+
+def _distance(a: Vec2, b: Vec2) -> float:
+    return _length((a[0] - b[0], a[1] - b[1]))
+
+
+@dataclass
+class InputState:
+    move: Vec2 = (0.0, 0.0)
+    swing: bool = False
+    deploy_trap: bool = False
+    shockwave: bool = False
+    dash: bool = False
+
+
+@dataclass
+class GameConfig:
+    width: int = 960
+    height: int = 640
+    player_speed: float = 220.0
+    dash_speed: float = 360.0
+    dash_time: float = 0.3
+    dash_cooldown: float = 3.5
+    swing_radius: float = 60.0
+    swing_cooldown: float = 0.45
+    trap_radius: float = 72.0
+    trap_slow_factor: float = 0.45
+    trap_lifetime: float = 8.0
+    trap_cooldown: float = 4.0
+    shockwave_radius: float = 140.0
+    shockwave_cooldown: float = 12.0
+    combo_window: float = 2.8
+    combo_bonus: float = 0.35
+    max_combo: int = 5
+    base_spawn_interval: float = 2.4
+    wave_duration: float = 36.0
+    spawn_acceleration: float = 0.12
+    max_wave: int = 12
+    powerup_chance: float = 0.18
+    sandwich_health: int = 5
+    player_health: int = 3
+    retro_spawn_chance: float = 0.22
+    retro_speed_scale: float = 0.82
+    retro_radius: float = 18.0
+    retro_damage_bonus: int = 1
+    retro_reward_bonus: int = 15
+
+
+@dataclass
+class Player:
+    position: Vec2
+    speed: float
+    radius: float = 16.0
+    dash_cooldown: float = 0.0
+    dash_time: float = 0.0
+    swing_cooldown: float = 0.0
+    trap_cooldown: float = 0.0
+    shockwave_cooldown: float = 0.0
+    health: int = 3
+
+
+@dataclass
+class Sandwich:
+    position: Vec2
+    health: int
+    radius: float = 20.0
+
+    @property
+    def alive(self) -> bool:
+        return self.health > 0
+
+
+@dataclass(frozen=True)
+class EnemyArchetype:
+    name: str
+    speed_scale: float
+    damage_bonus: int
+    reward_bonus: int
+    radius: float
+
+
+@dataclass
+class Enemy:
+    position: Vec2
+    speed: float
+    damage: int
+    reward: int
+    radius: float = 14.0
+    kind: str = "modern_swarm"
+
+
+@dataclass
+class Trap:
+    position: Vec2
+    radius: float
+    slow_factor: float
+    lifetime: float
+
+    def tick(self, dt: float) -> None:
+        self.lifetime = max(0.0, self.lifetime - dt)
+
+    @property
+    def expired(self) -> bool:
+        return self.lifetime <= 0.0
+
+
+@dataclass
+class PowerUp:
+    position: Vec2
+    kind: str
+    duration: float
+    radius: float = 16.0
+
+
+@dataclass
+class WorldStats:
+    score: int = 0
+    combo: int = 0
+    combo_timer: float = 0.0
+    wave: int = 1
+    elapsed: float = 0.0
+    sandwiches_saved: int = 0
+
+
+class GameWorld:
+    def __init__(self, config: GameConfig | None = None, seed: int | None = 1337):
+        self.config = config or GameConfig()
+        self.rng = random.Random(seed)
+        self.base_player_speed = self.config.player_speed
+        self.base_swing_radius = self.config.swing_radius
+        self.player = Player(
+            position=(self.config.width / 2, self.config.height / 2),
+            speed=self.config.player_speed,
+            health=self.config.player_health,
+        )
+        self.sandwiches: list[Sandwich] = [
+            Sandwich(
+                position=(self.config.width * 0.3, self.config.height / 2),
+                health=self.config.sandwich_health,
+            ),
+            Sandwich(
+                position=(self.config.width * 0.7, self.config.height / 2),
+                health=self.config.sandwich_health,
+            ),
+        ]
+        self.enemies: list[Enemy] = []
+        self.traps: list[Trap] = []
+        self.powerups: list[PowerUp] = []
+        self.active_effects: dict[str, float] = {}
+        self.stats = WorldStats()
+        self.stats.sandwiches_saved = len(self.sandwiches)
+        self.spawn_timer = self.config.base_spawn_interval
+        self.wave_timer = self.config.wave_duration
+
+    def update(self, dt: float, input_state: InputState) -> None:
+        self.stats.elapsed += dt
+        self._handle_wave_progression(dt)
+        self._tick_cooldowns(dt)
+        self._update_player(dt, input_state)
+        self._move_enemies(dt)
+        self._resolve_enemy_collisions()
+        self._collect_powerups()
+        self._age_traps(dt)
+        self._tick_effects(dt)
+        self._decay_combo(dt)
+        self._maybe_spawn_enemy(dt)
+
+    def _handle_wave_progression(self, dt: float) -> None:
+        self.wave_timer -= dt
+        if self.wave_timer <= 0 and self.stats.wave < self.config.max_wave:
+            self.stats.wave += 1
+            self.wave_timer = self.config.wave_duration
+            self.spawn_timer = max(
+                0.6, self.spawn_timer * (1 - self.config.spawn_acceleration)
+            )
+
+    def _tick_cooldowns(self, dt: float) -> None:
+        self.player.dash_cooldown = max(0.0, self.player.dash_cooldown - dt)
+        self.player.dash_time = max(0.0, self.player.dash_time - dt)
+        self.player.swing_cooldown = max(0.0, self.player.swing_cooldown - dt)
+        self.player.trap_cooldown = max(0.0, self.player.trap_cooldown - dt)
+        self.player.shockwave_cooldown = max(0.0, self.player.shockwave_cooldown - dt)
+
+    def _update_player(self, dt: float, input_state: InputState) -> None:
+        direction = _normalize(input_state.move)
+        speed = (
+            self.config.dash_speed if self.player.dash_time > 0 else self.player.speed
+        )
+        self.player.position = self._clamped_position(
+            _add(self.player.position, _scale(direction, speed * dt))
+        )
+
+        if input_state.dash and self.player.dash_cooldown == 0.0:
+            self.player.dash_time = self.config.dash_time
+            self.player.dash_cooldown = self.config.dash_cooldown
+
+        if input_state.swing and self.player.swing_cooldown == 0.0:
+            self._perform_swing()
+            self.player.swing_cooldown = self.config.swing_cooldown
+
+        if input_state.deploy_trap and self.player.trap_cooldown == 0.0:
+            self._deploy_trap()
+            self.player.trap_cooldown = self.config.trap_cooldown
+
+        if input_state.shockwave and self.player.shockwave_cooldown == 0.0:
+            self._detonate_shockwave()
+            self.player.shockwave_cooldown = self.config.shockwave_cooldown
+
+    def _perform_swing(self) -> None:
+        radius = self.config.swing_radius
+        defeated: list[Enemy] = []
+        for enemy in list(self.enemies):
+            if _distance(self.player.position, enemy.position) <= radius + enemy.radius:
+                defeated.append(enemy)
+                self._register_kill(enemy)
+        self._remove_enemies(defeated)
+
+    def _deploy_trap(self) -> None:
+        self.traps.append(
+            Trap(
+                position=self.player.position,
+                radius=self.config.trap_radius,
+                slow_factor=self.config.trap_slow_factor,
+                lifetime=self.config.trap_lifetime,
+            )
+        )
+
+    def _detonate_shockwave(self) -> None:
+        defeated: list[Enemy] = []
+        for enemy in list(self.enemies):
+            if (
+                _distance(self.player.position, enemy.position)
+                <= self.config.shockwave_radius
+            ):
+                defeated.append(enemy)
+                self._register_kill(enemy)
+        self._remove_enemies(defeated)
+
+    def _move_enemies(self, dt: float) -> None:
+        for enemy in self.enemies:
+            target = self._primary_target(enemy)
+            direction = _normalize(
+                (target[0] - enemy.position[0], target[1] - enemy.position[1])
+            )
+            speed = enemy.speed * self._trap_slowdown(enemy)
+            enemy.position = self._clamped_position(
+                _add(enemy.position, _scale(direction, speed * dt))
+            )
+
+    def _primary_target(self, enemy: Enemy) -> Vec2:
+        living = [s for s in self.sandwiches if s.alive]
+        if living:
+            return min(
+                living, key=lambda s: _distance(s.position, enemy.position)
+            ).position
+        return self.player.position
+
+    def _trap_slowdown(self, enemy: Enemy) -> float:
+        slowdown = 1.0
+        for trap in self.traps:
+            if _distance(trap.position, enemy.position) <= trap.radius:
+                slowdown *= trap.slow_factor
+        return slowdown
+
+    def _resolve_enemy_collisions(self) -> None:
+        surviving_enemies: list[Enemy] = []
+        for enemy in self.enemies:
+            target = self._find_hit_target(enemy)
+            if target is None:
+                surviving_enemies.append(enemy)
+            elif isinstance(target, Sandwich):
+                target.health = max(0, target.health - enemy.damage)
+            else:
+                self.player.health = max(0, self.player.health - enemy.damage)
+        self.enemies = surviving_enemies
+        self.stats.sandwiches_saved = sum(
+            1 for sandwich in self.sandwiches if sandwich.alive
+        )
+
+    def _find_hit_target(self, enemy: Enemy) -> Sandwich | Player | None:
+        for sandwich in self.sandwiches:
+            if (
+                sandwich.alive
+                and _distance(sandwich.position, enemy.position)
+                <= sandwich.radius + enemy.radius
+            ):
+                return sandwich
+        if (
+            _distance(self.player.position, enemy.position)
+            <= self.player.radius + enemy.radius
+        ):
+            return self.player
+        return None
+
+    def _collect_powerups(self) -> None:
+        remaining: list[PowerUp] = []
+        for powerup in self.powerups:
+            if (
+                _distance(powerup.position, self.player.position)
+                <= powerup.radius + self.player.radius
+            ):
+                self._apply_powerup(powerup)
+            else:
+                remaining.append(powerup)
+        self.powerups = remaining
+
+    def _age_traps(self, dt: float) -> None:
+        for trap in self.traps:
+            trap.tick(dt)
+        self.traps = [trap for trap in self.traps if not trap.expired]
+
+    def _tick_effects(self, dt: float) -> None:
+        expired: list[str] = []
+        for name, remaining in list(self.active_effects.items()):
+            remaining -= dt
+            if remaining <= 0:
+                expired.append(name)
+            else:
+                self.active_effects[name] = remaining
+
+        for name in expired:
+            del self.active_effects[name]
+            if name == "sugar_rush":
+                self.player.speed = self.base_player_speed
+            elif name == "sticky_gloves":
+                self.config.swing_radius = self.base_swing_radius
+
+    def _decay_combo(self, dt: float) -> None:
+        if self.stats.combo_timer > 0:
+            self.stats.combo_timer = max(0.0, self.stats.combo_timer - dt)
+            if self.stats.combo_timer == 0:
+                self.stats.combo = 0
+
+    def _maybe_spawn_enemy(self, dt: float) -> None:
+        self.spawn_timer -= dt
+        if self.spawn_timer <= 0:
+            self.spawn_timer = max(
+                0.6,
+                self.config.base_spawn_interval * (1 - 0.04 * (self.stats.wave - 1)),
+            )
+            self.enemies.append(self._make_enemy())
+
+    def _make_enemy(self) -> Enemy:
+        side = self.rng.choice(["top", "bottom", "left", "right"])
+        if side == "top":
+            position = (self.rng.uniform(0, self.config.width), -10)
+        elif side == "bottom":
+            position = (self.rng.uniform(0, self.config.width), self.config.height + 10)
+        elif side == "left":
+            position = (-10, self.rng.uniform(0, self.config.height))
+        else:
+            position = (self.config.width + 10, self.rng.uniform(0, self.config.height))
+
+        archetype = self._choose_archetype()
+        speed = (90 + 14 * (self.stats.wave - 1)) * archetype.speed_scale
+        damage = 1 + (self.stats.wave // 4) + archetype.damage_bonus
+        reward = 30 + 5 * self.stats.wave + archetype.reward_bonus
+        return Enemy(
+            position=position,
+            speed=float(speed),
+            damage=damage,
+            reward=reward,
+            radius=archetype.radius,
+            kind=archetype.name,
+        )
+
+    def _choose_archetype(self) -> EnemyArchetype:
+        retro_roll = self.rng.random()
+        if retro_roll <= self.config.retro_spawn_chance:
+            return EnemyArchetype(
+                name="retro_brawler",
+                speed_scale=self.config.retro_speed_scale,
+                damage_bonus=self.config.retro_damage_bonus,
+                reward_bonus=self.config.retro_reward_bonus,
+                radius=self.config.retro_radius,
+            )
+
+        return EnemyArchetype(
+            name="modern_swarm",
+            speed_scale=1.0,
+            damage_bonus=0,
+            reward_bonus=0,
+            radius=14.0,
+        )
+
+    def _register_kill(self, enemy: Enemy) -> None:
+        self.stats.combo = min(self.config.max_combo, self.stats.combo + 1)
+        self.stats.combo_timer = self.config.combo_window
+        multiplier = 1 + (self.stats.combo - 1) * self.config.combo_bonus
+        self.stats.score += int(enemy.reward * multiplier)
+        self.stats.sandwiches_saved = sum(
+            1 for sandwich in self.sandwiches if sandwich.alive
+        )
+        if self.rng.random() <= self.config.powerup_chance:
+            self._drop_powerup(enemy.position)
+
+    def _drop_powerup(self, position: Vec2) -> None:
+        kind = self.rng.choice(["sugar_rush", "sticky_gloves", "free_shockwave"])
+        duration = 7.0 if kind != "free_shockwave" else 0.0
+        self.powerups.append(PowerUp(position=position, kind=kind, duration=duration))
+
+    def _apply_powerup(self, powerup: PowerUp) -> None:
+        if powerup.kind == "sugar_rush":
+            self.active_effects["sugar_rush"] = max(
+                powerup.duration, self.active_effects.get("sugar_rush", 0.0)
+            )
+            self.player.speed = self.base_player_speed * 1.25
+        elif powerup.kind == "sticky_gloves":
+            self.active_effects["sticky_gloves"] = max(
+                powerup.duration, self.active_effects.get("sticky_gloves", 0.0)
+            )
+            self.config.swing_radius = self.base_swing_radius + 12
+        elif powerup.kind == "free_shockwave":
+            self.player.shockwave_cooldown = 0.0
+
+    def _remove_enemies(self, defeated: Iterable[Enemy]) -> None:
+        defeated_ids = {id(enemy) for enemy in defeated}
+        self.enemies = [
+            enemy for enemy in self.enemies if id(enemy) not in defeated_ids
+        ]
+
+    def _clamped_position(self, position: Vec2) -> Vec2:
+        return (
+            _clamp(position[0], 0, self.config.width),
+            _clamp(position[1], 0, self.config.height),
+        )
+
+    def reset(self) -> None:
+        self.player = Player(
+            position=(self.config.width / 2, self.config.height / 2),
+            speed=self.config.player_speed,
+            health=self.config.player_health,
+        )
+        self.sandwiches = [
+            Sandwich(
+                position=(self.config.width * 0.3, self.config.height / 2),
+                health=self.config.sandwich_health,
+            ),
+            Sandwich(
+                position=(self.config.width * 0.7, self.config.height / 2),
+                health=self.config.sandwich_health,
+            ),
+        ]
+        self.enemies.clear()
+        self.traps.clear()
+        self.powerups.clear()
+        self.active_effects.clear()
+        self.player.speed = self.base_player_speed
+        self.config.swing_radius = self.base_swing_radius
+        self.stats = WorldStats()
+        self.stats.sandwiches_saved = len(self.sandwiches)
+        self.spawn_timer = self.config.base_spawn_interval
+        self.wave_timer = self.config.wave_duration
+
+    def add_enemy(
+        self,
+        position: Vec2,
+        speed: float = 120.0,
+        damage: int = 1,
+        reward: int = 25,
+        radius: float = 14.0,
+        kind: str = "modern_swarm",
+    ) -> None:
+        self.enemies.append(
+            Enemy(
+                position=position,
+                speed=speed,
+                damage=damage,
+                reward=reward,
+                radius=radius,
+                kind=kind,
+            )
+        )
+
+    @property
+    def defeated(self) -> bool:
+        sandwiches_lost = all(not sandwich.alive for sandwich in self.sandwiches)
+        return sandwiches_lost or self.player.health <= 0

--- a/games/peanut_butter_panic/game.py
+++ b/games/peanut_butter_panic/game.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import os
+
+import pygame
+
+from .core import GameConfig, GameWorld, InputState
+
+Color = tuple[int, int, int]
+
+
+def _draw_circle(
+    surface: pygame.Surface, color: Color, position: tuple[float, float], radius: float
+) -> None:
+    pygame.draw.circle(
+        surface, color, (int(position[0]), int(position[1])), int(radius)
+    )
+
+
+def _draw_text(
+    surface: pygame.Surface,
+    text: str,
+    position: tuple[int, int],
+    font: pygame.font.Font,
+    color: Color,
+) -> None:
+    surface.blit(font.render(text, True, color), position)
+
+
+def _build_input_state() -> InputState:
+    keys = pygame.key.get_pressed()
+    move_x = float(keys[pygame.K_d] or keys[pygame.K_RIGHT]) - float(
+        keys[pygame.K_a] or keys[pygame.K_LEFT]
+    )
+    move_y = float(keys[pygame.K_s] or keys[pygame.K_DOWN]) - float(
+        keys[pygame.K_w] or keys[pygame.K_UP]
+    )
+    return InputState(
+        move=(move_x, move_y),
+        swing=keys[pygame.K_SPACE],
+        deploy_trap=keys[pygame.K_LCTRL] or keys[pygame.K_RCTRL],
+        shockwave=keys[pygame.K_q],
+        dash=keys[pygame.K_LSHIFT] or keys[pygame.K_RSHIFT],
+    )
+
+
+def _render_world(
+    surface: pygame.Surface, world: GameWorld, hud_font: pygame.font.Font
+) -> None:
+    surface.fill((20, 16, 28))
+
+    for trap in world.traps:
+        _draw_circle(surface, (100, 160, 255), trap.position, trap.radius)
+
+    for sandwich in world.sandwiches:
+        color = (0, 180, 120) if sandwich.alive else (120, 80, 80)
+        _draw_circle(surface, color, sandwich.position, sandwich.radius)
+        health_ratio = sandwich.health / world.config.sandwich_health
+        pygame.draw.rect(
+            surface,
+            (180, 255, 230),
+            pygame.Rect(
+                sandwich.position[0] - sandwich.radius,
+                sandwich.position[1] - sandwich.radius - 10,
+                sandwich.radius * 2 * health_ratio,
+                6,
+            ),
+        )
+
+    _draw_circle(surface, (255, 230, 150), world.player.position, world.player.radius)
+
+    for enemy in world.enemies:
+        color = (200, 70, 90) if enemy.kind == "modern_swarm" else (120, 180, 210)
+        _draw_circle(surface, color, enemy.position, enemy.radius)
+
+    for powerup in world.powerups:
+        _draw_circle(surface, (255, 180, 60), powerup.position, powerup.radius)
+
+    hud_lines = [
+        f"Score: {world.stats.score}",
+        f"Wave: {world.stats.wave}  Combo: x{max(1, world.stats.combo)}",
+        f"Sandwiches: {world.stats.sandwiches_saved}/{len(world.sandwiches)}",
+        f"Health: {world.player.health}",
+        "[Space] Swipe | [Ctrl] Sticky Trap | [Q] Shockwave | [Shift] Dash",
+    ]
+
+    for idx, line in enumerate(hud_lines):
+        _draw_text(surface, line, (14, 14 + idx * 22), hud_font, (230, 230, 240))
+
+
+def run(config: GameConfig | None = None) -> None:
+    os.environ.setdefault("SDL_VIDEO_CENTERED", "1")
+    pygame.init()
+    world_config = config or GameConfig()
+    screen = pygame.display.set_mode((world_config.width, world_config.height))
+    pygame.display.set_caption("Peanut Butter Panic - Remixed")
+    clock = pygame.time.Clock()
+    hud_font = pygame.font.SysFont("ubuntu", 18)
+
+    world = GameWorld(config=world_config)
+    running = True
+
+    while running:
+        dt = clock.tick(60) / 1000.0
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+
+        world.update(dt, _build_input_state())
+        _render_world(screen, world, hud_font)
+        pygame.display.flip()
+
+        if world.defeated:
+            running = False
+
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    run()

--- a/games/zombie-hallway-fixes/README.md
+++ b/games/zombie-hallway-fixes/README.md
@@ -1,0 +1,17 @@
+# Zombie Hallway Fix Packages
+
+This directory packages three playable hallway builds side-by-side so you can pick the variant that runs best in your environment without juggling multiple pull requests.
+
+## Contents
+- **Fix 1**: Based on `zombie-hallway-v1` with local Three.js modules, simple ammo + boss HUD.
+- **Fix 2**: Based on `zombie-hallway-v2` with tighter combat pacing, kill counter, and the same local module dependencies.
+- **Fix 3**: Based on the weapon-switching variant (pistol + rifle) with a jump-scare death screen and local module dependencies.
+
+Each package is self-contained except for the shared Three.js assets under `../vendor/three`.
+
+## How to run
+1. Open the desired `Fix */index.html` file in a browser.
+2. Click **Enter Hallway** to lock the pointer and start.
+3. If the page is opened from the filesystem, allow pointer lock when prompted.
+
+All builds import Three.js and PointerLockControls from `../vendor/three` so they work offline and avoid CDN black screens.


### PR DESCRIPTION
This PR adds the Peanut Butter Panic game from the Playground repository:

- Added games/peanut_butter_panic/ with all game files
- Includes README.md, core.py, game.py, and __init__.py

**Note:** This game was moved from Playground repository as part of the reorganization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multiple playable game demos: an HTML5 Doom-like FPS, several Three.js zombie hallway variants (CDN and local-module builds), and a Pygame-based Peanut Butter Panic, with full code and docs.
> 
> - **Games Added**:
>   - **Pygame**: `games/peanut_butter_panic/` (`core.py`, `game.py`, `__init__.py`, `README.md`)
>     - Wave-based enemies, power-ups, combo scoring; runnable via `python -m peanut_butter_panic.game`.
>   - **HTML5/Canvas FPS**:
>     - `Doom/parent-doom-game/`: Raycasting Doom-like (movement/shooting, doors, minimap, win/lose).
>     - `Doom/zombie-doom-game/`: Variant with sprint, pistol/rifle switching, jumpscare on death.
>   - **Three.js Corridor Shooters**:
>     - `Zombie_Game/Zombie_Game_v1`–`v5`: Multiple hallway builds (weapon loadouts, HUD/boss tracking, jumpscare, CDN vs local `vendor/three` imports).
>     - `games/zombie-hallway-fixes/README.md`: Describes packaged fix variants and how to run.
> - **Assets/UX**:
>   - Each game includes `index.html`, JS logic (`main.js`/`game.js`), and `style.css`/HUD with controls, enemy AI/projectiles, and basic UI instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd317db157109fd2991bb761986dab3ad67b51ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->