### PR TITLE
Fix FPS-Shooter crashing on launch

### DIFF
--- a/games/FPS Shooter/fps_shooter.py
+++ b/games/FPS Shooter/fps_shooter.py
@@ -2023,9 +2023,6 @@ class Game:
 
         pygame.display.flip()
 
-        pygame.quit()
-        sys.exit()
-
 
 def main() -> None:
     """Entry point of the FPS Shooter application.
@@ -2034,6 +2031,8 @@ def main() -> None:
     """
     game = Game()
     game.run()
+    pygame.quit()
+    sys.exit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The FPS Shooter game was crashing immediately on launch because pygame.quit() and sys.exit() were being called inside the render_intro() method, which is invoked every frame during the intro sequence.

This caused the game to terminate on the first frame of the intro screen before the player could see or interact with anything.

Fixed by moving the cleanup calls to the main() function, where they execute only after the game loop properly exits.

Resolves the crash issue where the game window would not stay open.

## Summary
Explain what changed and why.

## AI Changes
- [ ] If AI-assisted: explain changes line-by-line or attach diff with comments.

## Checklist
- [ ] Reproducible: `matlab/run_all.m` (or Python pipeline) completes
- [ ] Tests pass (MATLAB + Python)
- [ ] Large binaries tracked via LFS
- [ ] Env files updated
- [ ] No secrets added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relocates `pygame.quit()` and `sys.exit()` from `Game.render_intro()` to `main()` after `game.run()` to ensure clean exit and prevent immediate shutdown on launch.
> 
> - **Game lifecycle**:
>   - Removed `pygame.quit()` and `sys.exit()` from `Game.render_intro()`.
>   - Added cleanup calls in `main()` after `game.run()` to exit only after the loop finishes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 390fa858216dcbf6eee039bd0a5d39c34ae52793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->