### PR TITLE
Fix CI: Remove failing placeholder 'Fast API Ping' step

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -29,13 +29,6 @@ jobs:
       # FIX: Matched output name to what downstream jobs expect ("target")
       target: ${{ steps.decide.outputs.target }}
     steps:
-      - name: Fast API Ping (Optional)
-        env:
-          API_KEY: ${{ secrets.JULES_API_KEY }}
-        run: |
-          # Example: Just checking if Jules is alive or valid before dispatching expensive workers
-          curl -fsS -H "x-goog-api-key: $API_KEY" \
-            https://jules.google/api/v1/health || exit 1
 
       - name: Analyze Event Context
         id: decide


### PR DESCRIPTION
The 'Fast API Ping' step in checking https://jules.google/api/v1/health is returning 404 and failing the build. This step was marked as optional/example but the failure was not handled. Removing the step to unblock CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the failing placeholder API ping and correctly exposes the triage job's `target` output.
> 
> - **CI Workflow (`.github/workflows/Jules-Control-Tower.yml`)**:
>   - Remove the optional/failing `Fast API Ping` step.
>   - Expose `triage` job output `target` from `steps.decide.outputs.target` to match downstream expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4929a16b9f7f53e47b4e2ee72ddf957b0fd34b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->