### PR TITLE
chore: Add auto-update-prs workflow

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,0 +1,14 @@
+name: Auto-Update PRs
+on:
+  push:
+    branches: [ "master", "main" ]
+
+jobs:
+  update-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update PRs with strictly linear history
+        uses: chinthakagodawita/autoupdate-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Action to automatically update PRs with the latest changes from the main branch, ensuring a linear history and reducing merge conflicts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add GitHub Actions workflow to auto-update open PRs on pushes to master/main using autoupdate-action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c05c3532a1bf0efec7caa546682f79ec8431dea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->