### PR TITLE
fix: Add permissions to auto-update-prs workflow

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [ "master", "main" ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-prs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the missing 'permissions' block (contents: write, pull-requests: write) required for the autoupdate-action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add required write permissions to the auto-update PRs GitHub Actions workflow.
> 
> - **CI**:
>   - Add `permissions` (`contents: write`, `pull-requests: write`) to `.github/workflows/auto-update-prs.yml` for `chinthakagodawita/autoupdate-action@v1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 800556e491339527ac487114be526cac8ee1bc34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->