### PR TITLE
chore: ignore jules artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ ruff_errors.txt
 ruff_output.txt
 ruff_output_ff.txt
 ruff_output_ff_2.txt
+
+# Jules generated files
+.jules/bolt*
+.jules/palette*
+.jules/pallette*
+.jules/sentinel*


### PR DESCRIPTION
Excludes bolt, palette, and sentinel files generated by .jules from version control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> .gitignore updated to exclude .jules bolt, palette/pallette, and sentinel artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae4ef03d537a5543bf9a87ccdf475e0d694358d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->