### PR TITLE
fix: Enforce Universal Standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ ruff_output_ff_2.txt
 .jules/palette*
 .jules/pallette*
 .jules/sentinel*
+
+# Enforce NPM
+pnpm-lock.yaml


### PR DESCRIPTION
Standardizing on NPM and cleaning up CI/CD workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Standardize package manager**
> 
> - Adds `pnpm-lock.yaml` to `.gitignore` with a note to enforce using npm
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8a0d1e0977f31fa93f88c735bbd5b5fb47935bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->