### PR TITLE
Fix: Launcher Double-Launch Debounce

### DIFF
--- a/game_launcher.py
+++ b/game_launcher.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import time
 import webbrowser
 from pathlib import Path
 from typing import Any
@@ -132,6 +133,7 @@ def main() -> None:
 
     running = True
     clock = pygame.time.Clock()
+    last_launch_time = 0.0
 
     while running:
         mx, my = pygame.mouse.get_pos()
@@ -153,7 +155,10 @@ def main() -> None:
 
                         rect = pygame.Rect(x, y, ITEM_WIDTH, ITEM_HEIGHT)
                         if rect.collidepoint(mx, my):
-                            launch_game(game)
+                            now = time.time()
+                            if now - last_launch_time > 1.0:
+                                last_launch_time = now
+                                launch_game(game)
 
         # Draw
         screen.fill(BG_COLOR)


### PR DESCRIPTION
Separated PR for Game Launcher debounce fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents accidental double-launch when clicking game tiles in `game_launcher.py`.
> 
> - Adds a 1s debounce: tracks `last_launch_time` and only calls `launch_game` if `time.time() - last_launch_time > 1.0`
> - Imports `time`; otherwise logic and UI remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcabbdcc822f98fb3a9957e61564564b34721521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->