### PR TITLE
feat: Force Field Minigun Polish & Audio Pause

### DIFF
--- a/games/Force_Field/src/game.py
+++ b/games/Force_Field/src/game.py
@@ -567,10 +567,12 @@ class Game:
                 if self.input_manager.is_action_just_pressed(event, "pause"):
                     self.paused = not self.paused
                     if self.paused:
+                        self.sound_manager.pause_all()
                         self.pause_start_time = pygame.time.get_ticks()
                         pygame.mouse.set_visible(True)
                         pygame.event.set_grab(False)
                     else:
+                        self.sound_manager.unpause_all()
                         if self.pause_start_time > 0:
                             now = pygame.time.get_ticks()
                             pause_duration = now - self.pause_start_time
@@ -634,6 +636,7 @@ class Game:
                     if 500 <= mx <= 700:
                         if 350 <= my <= 400:  # Resume
                             self.paused = False
+                            self.sound_manager.unpause_all()
                             if self.pause_start_time > 0:
                                 now = pygame.time.get_ticks()
                                 pause_duration = now - self.pause_start_time
@@ -1174,6 +1177,15 @@ class Game:
         keys = pygame.key.get_pressed()
 
         shield_active = self.input_manager.is_action_pressed("shield")
+
+        if self.joystick and not self.paused and self.player and self.player.alive:
+            pass  # Joystick handled below
+
+        # Keyboard Continuous Fire (for auto weapons like Minigun)
+        if not self.paused and self.player and self.player.alive:
+            if self.input_manager.is_action_pressed("shoot"):
+                if self.player.shoot():
+                    self.fire_weapon()
 
         if self.joystick and not self.paused and self.player and self.player.alive:
             axis_x = self.joystick.get_axis(0)

--- a/games/Force_Field/src/sound.py
+++ b/games/Force_Field/src/sound.py
@@ -58,6 +58,7 @@ class SoundManager:
             "reload_rifle": "gun-reload-2-395177.mp3",
             "shoot_shotgun": "shotgun-firing-3-14483.mp3",
             "reload_shotgun": "realistic-shotgun-cocking-sound-38640.mp3",
+            "shoot_minigun": "pistol-shot-233473.mp3",  # Fast re-use of pistol sound
             "shoot_plasma": "bfg-laser-89662.mp3",  # BFG Sound
             "shoot_stormtrooper": "sci-fi-weapon-laser-shot-04-316416.mp3",
             "shoot_laser": "sci-fi-weapon-laser-shot-04-316416.mp3",
@@ -143,3 +144,13 @@ class SoundManager:
         # Fallback
         if "ambient" in self.sounds:
             self.sounds["ambient"].stop()
+
+    def pause_all(self) -> None:
+        """Pause all sounds and music"""
+        if self.sound_enabled:
+            pygame.mixer.pause()
+
+    def unpause_all(self) -> None:
+        """Unpause all sounds and music"""
+        if self.sound_enabled:
+            pygame.mixer.unpause()


### PR DESCRIPTION
## Minigun & Audio Polish
This PR addresses user feedback regarding the Minigun mechanics and game audio behavior.

### Changes
1.  **Minigun Mechanics**:
    - Enabled **continuous fire** for keyboard/mouse (holding 'Shoot'). Previously, only semi-auto (click-per-shot) was handled for keyboard, which prevented the Minigun from ever finishing its spin-up sequence.
    - Added 'shoot_minigun' sound alias (currently reusing pistol sound for valid feedback).
2.  **Audio Polish**:
    - Implemented `pause_all()` and `unpause_all()` in `SoundManager`.
    - Game now correctly silences all SFX and music when paused.
3.  **Build**:
    - Previous stable state saved as 'Force Field r2.exe' locally before these changes.

### Verification
- Holding Left-Ctrl or Mouse1 will now continuously call `shoot()`, allowing Minigun to spin up and fire.
- Pausing the game stops the 'heartbeat', 'music_loop', etc.