### PR TITLE
Fix Wizard of Wor Black Screen Maze

### DIFF
--- a/games/Wizard_of_Wor/wizard_of_wor/effects.py
+++ b/games/Wizard_of_Wor/wizard_of_wor/effects.py
@@ -203,4 +203,4 @@ class Vignette:
 
     def draw(self, screen: pygame.Surface) -> None:
         """Draw the vignette effect on the screen."""
-        screen.blit(self.surface, self.top_left, special_flags=pygame.BLEND_RGBA_MULT)
+        screen.blit(self.surface, self.top_left)


### PR DESCRIPTION
The Vignette effect was using 'pygame.BLEND_RGBA_MULT' with a transparent black surface, which resulted in the entire screen being multiplied by 0 (black), rendering the game invisible. This PR removes the multiplication flag to use standard alpha blending.