### PR TITLE
fix: correct workflow_call syntax in Jules workflows

### DIFF
--- a/.github/workflows/Jules-Scientific-Auditor.yml
+++ b/.github/workflows/Jules-Scientific-Auditor.yml
@@ -1,5 +1,7 @@
 name: Scientific Auditor (Worker)
-on: workflow_call
+
+on:
+  workflow_call:
 
 jobs:
   audit:

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -1,5 +1,7 @@
 name: Jules Test Generator (Worker)
-on: workflow_call
+
+on:
+  workflow_call:
 
 jobs:
   generate-tests:


### PR DESCRIPTION
## Summary
Fixed inline syntax issues in 2 worker workflows that prevented proper execution when called by Jules Control Tower.

## Changes
- Jules-Test-Generator.yml
- Jules-Scientific-Auditor.yml

Changed from `on: workflow_call` (inline) to proper nested format:
```yaml
on:
  workflow_call:
```

## Reason
GitHub Actions requires nested syntax for workflow triggers. The inline syntax causes validation errors when Control Tower attempts to call these workflows, resulting in startup failures.

## Testing
- YAML syntax validated
- Matches fixes applied to Gasification_Model (PR #633), Golf_Modeling_Suite (PR #529), and AffineDrift (PRs #434-436)

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes GitHub Actions trigger syntax in two Jules worker workflows.
> 
> - Changes `on: workflow_call` to nested form under `on:` in `Jules-Scientific-Auditor.yml` and `Jules-Test-Generator.yml` to ensure workflows can be invoked by Control Tower
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b75627166dcc997f5f9150337ecc1d387ae85e65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->