### PR TITLE
fix: add --repo flag to Jules Auto-Assign workflow

### DIFF
--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -22,6 +22,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABELS: ${{ toJson(github.event.issue.labels) }}
         run: |
+          # LABELS is passed via env to prevent shell injection
+
           # Skip if labeled with 'no-jules', 'question', 'documentation', or 'wontfix'
           SKIP_LABELS="no-jules question documentation wontfix duplicate invalid"
 
@@ -40,8 +42,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "$(cat <<'EOF'
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$(cat <<'EOF'
           @jules Please analyze and fix this issue.
 
           ---
@@ -56,9 +59,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
           # Create label if it doesn't exist
-          gh label create "jules-assigned" --color "7057ff" --description "Issue assigned to Jules AI" 2>/dev/null || true
+          gh label create "jules-assigned" --repo "$REPO" --color "7057ff" --description "Issue assigned to Jules AI" 2>/dev/null || true
 
           # Add label to issue
-          gh issue edit "$ISSUE_NUMBER" --add-label "jules-assigned" || true
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "jules-assigned" || true


### PR DESCRIPTION
Fixes the 'fatal: not a git repository' error by adding --repo flag to gh commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `gh` commands run against the correct repository in the auto-assign workflow to avoid context errors.
> 
> - Passes `REPO` via env and adds `--repo "$REPO"` to `gh issue comment`, `gh label create`, and `gh issue edit`
> - Notes that `LABELS` is passed via env to avoid shell injection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d473287072d36c6b31045a332ce88ad187748b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->