### PR TITLE
fix: match Jules API request format

### DIFF
--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -27,8 +27,8 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          # Check if @jules is mentioned (case insensitive, word boundary)
-          if echo "$COMMENT_BODY" | grep -iqE "@jules\b"; then
+          # Check if @jules is mentioned as a standalone word (case insensitive)
+          if echo "$COMMENT_BODY" | grep -iqE "(^|[^a-zA-Z0-9_])@jules([^a-zA-Z0-9_]|$)"; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "@jules mention detected!"
           else
@@ -49,15 +49,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          COMMENT_USER: ${{ github.event.comment.user.login }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "$(cat <<EOF
+          gh issue comment "$ISSUE_NUMBER" --body "$(cat <<'EOF'
           👋 **Jules here!** I've received your request and I'm analyzing this issue now.
 
           I'll create a PR with a fix shortly. Stay tuned! 🔧
 
           ---
-          *Triggered by @${COMMENT_USER}*
+          *Triggered by @${{ github.event.comment.user.login }}*
           EOF
           )"
 
@@ -82,7 +81,7 @@ jobs:
             exit 0
           fi
 
-          # Get issue details (ISSUE_TITLE and COMMENT_BODY are from env)
+          # Get issue details (ISSUE_TITLE and COMMENT_BODY are passed via env to prevent injection)
           ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --json body -q '.body')
 
           echo "Processing issue #$ISSUE_NUMBER: $ISSUE_TITLE"
@@ -129,25 +128,19 @@ jobs:
           PROMPT_EOF
           )
 
-          # Create branch name
-          BRANCH_NAME="jules/fix-issue-$ISSUE_NUMBER"
-
           echo "Creating Jules session..."
           REQUEST_JSON=$(jq -n \
             --arg prompt "$PROMPT" \
             --arg source "$SOURCE_ID" \
-            --arg branch "$BRANCH_NAME" \
-            --arg starting_branch "$DEFAULT_BRANCH" \
+            --arg startBranch "$DEFAULT_BRANCH" \
             '{
               prompt: $prompt,
               sourceContext: {
                 source: $source,
                 githubRepoContext: {
-                  startingBranch: $starting_branch,
-                  targetBranch: $branch
+                  startingBranch: $startBranch
                 }
-              },
-              automationMode: "AUTO_CREATE_PR"
+              }
             }')
 
           HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
@@ -240,19 +233,13 @@ jobs:
 
       - name: Summary
         if: always()
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          COMMENT_USER: ${{ github.event.comment.user.login }}
-          JULES_STATUS: ${{ steps.jules.outputs.status }}
-          PR_URL: ${{ steps.jules.outputs.pr_url }}
         run: |
           echo "## Jules Issue Fixer Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Issue:** #${ISSUE_NUMBER}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Title:** ${ISSUE_TITLE}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Triggered by:** @${COMMENT_USER}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Status:** ${JULES_STATUS:-N/A}" >> $GITHUB_STEP_SUMMARY
-          if [ -n "$PR_URL" ]; then
-            echo "- **PR:** ${PR_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Issue:** #${{ github.event.issue.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Title:** ${{ github.event.issue.title }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by:** @${{ github.event.comment.user.login }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status:** ${{ steps.jules.outputs.status || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ steps.jules.outputs.pr_url }}" ]; then
+            echo "- **PR:** ${{ steps.jules.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
Matches the API request format to other working Jules workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the Jules issue-handler workflow with the current Jules API and hardens comment/trigger handling.
> 
> - Updates session payload to `sourceContext.githubRepoContext.startingBranch` and removes `targetBranch`/`automationMode` and branch creation logic
> - Tightens `@jules` mention detection to match standalone mentions case‑insensitively
> - Uses single-quoted heredoc to prevent shell expansion and injects GitHub expressions directly; removes unnecessary env vars (e.g., `COMMENT_USER`)
> - Simplifies the summary step by referencing outputs/expressions inline and handling missing PR URL/status
> - Adds notes clarifying env usage to reduce injection risk
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5147af9feebb3fd83b92c377c945a8315a7562e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->