### PR TITLE
fix: add automationMode for auto PR creation

### DIFF
--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -140,7 +140,8 @@ jobs:
                 githubRepoContext: {
                   startingBranch: $startBranch
                 }
-              }
+              },
+              automationMode: "AUTO_CREATE_PR"
             }')
 
           HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \


### PR DESCRIPTION
Adds automationMode: AUTO_CREATE_PR so Jules automatically creates PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables automatic PR creation by Jules when an issue mention triggers the workflow.
> 
> - Updates `Jules-Issue-Mention-Handler.yml` to include `automationMode: "AUTO_CREATE_PR"` in the `sessions` API request payload
> - Fixes JSON construction by adding a missing comma after `githubRepoContext` in the request body
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7555cc9525d9b9c9a6b441dba7098b712f23765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->