### PR TITLE
fix(jules): use BOT_PAT for auto-assign workflow

### DIFF
--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check Issue Labels
         id: check
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
           LABELS: ${{ toJson(github.event.issue.labels) }}
         run: |
           # LABELS is passed via env to prevent shell injection
@@ -40,8 +40,6 @@ jobs:
       - name: Comment @jules
         if: steps.check.outputs.should_assign == 'true'
         env:
-          # Use BOT_PAT instead of GITHUB_TOKEN so this comment triggers other workflows
-          # (GITHUB_TOKEN actions don't trigger subsequent workflows - GitHub security feature)
           GH_TOKEN: ${{ secrets.BOT_PAT }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
@@ -59,7 +57,7 @@ jobs:
       - name: Add Jules Label
         if: steps.check.outputs.should_assign == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
## Summary
- Updates Jules Auto-Assign workflow to use BOT_PAT instead of GITHUB_TOKEN
- Enables recursive workflow triggering for Jules integration
- Actions triggered by GITHUB_TOKEN don't trigger subsequent workflows (GitHub security feature)

## Test plan
- [ ] Verify workflow triggers correctly on new issue creation
- [ ] Verify @jules comment triggers the fix workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the `Jules Auto-Assign Issues` GitHub Actions workflow to ensure comments/labels trigger downstream workflows.
> 
> - Replaces `GITHUB_TOKEN` with `BOT_PAT` for `GH_TOKEN` across check, comment, and label steps
> - Retains label-skip logic and labeling behavior (`jules-assigned`) while preventing bot loops via author checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56e8d715e4b9bc2c91ef0a8b2c1376841b23f0c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->