### PR TITLE
Standardize workflow schedules: every 3 days at midnight PST

### DIFF
--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -20,7 +20,7 @@ on:
 
   # Also run on a schedule to catch any missed PRs
   schedule:
-    - cron: '0 */2 * * *'  # Every 2 hours (reduced from 15 min for cost control)
+    - cron: "0 8 */3 * *"  # Every 2 hours (reduced from 15 min for cost control)
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 0 * * *"  # Daily at midnight UTC (overnight window)
+  #   - cron: "0 8 */3 * *"  # Daily at midnight UTC (overnight window)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -35,7 +35,7 @@ on:
         type: string
   schedule:
     # Weekly on Monday at 6 AM UTC - conservative to prevent PR explosion
-    - cron: '0 6 * * 1'
+    - cron: "0 8 */3 * *"
 
 permissions:
   contents: read

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -11,7 +11,7 @@ on:
         type: string
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 3 * * 0"  # Weekly Sunday 3 AM UTC (Tier 3 relaxed schedule)
+  #   - cron: "0 8 */3 * *"  # Weekly Sunday 3 AM UTC (Tier 3 relaxed schedule)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -2,7 +2,7 @@ name: Jules Comprehensive Assessment
 
 on:
   schedule:
-    - cron: "0 10 */3 * *"  # Every 3 days at 5 AM PST (10 UTC) - cost optimized
+    - cron: "0 8 */3 * *"  # Every 3 days at 5 AM PST (10 UTC) - cost optimized
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/Jules-Consolidator.yml
+++ b/.github/workflows/Jules-Consolidator.yml
@@ -9,7 +9,7 @@ on:
         default: 'false'
         type: boolean
   schedule:
-    - cron: "0 13 * * 1"  # Monday at 5 AM PST (13 UTC)
+    - cron: "0 8 */3 * *"  # Monday at 5 AM PST (13 UTC)
 
 concurrency:
   group: jules-consolidator

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -12,13 +12,13 @@ on:
     # OVERNIGHT SCHEDULE - All work done before morning (midnight-6 AM PST / 8 AM-2 PM UTC)
     - cron: "0 8 */3 * *"   # Midnight PST - Assessment Generator
     - cron: "30 8 */3 * *"  # 12:30 AM PST - Code Quality Reviewer
-    - cron: "0 9 */3 * *"   # 1 AM PST - Completist (incomplete impl)
+    - cron: "0 8 */3 * *"   # 1 AM PST - Completist (incomplete impl)
     - cron: "30 9 */3 * *"  # 1:30 AM PST - Documentation Auditor
     - cron: "30 10 */3 * *" # 2:30 AM PST - Sentinel (security)
-    - cron: "0 11 */3 * *"  # 3 AM PST - Auto-Refactor
+    - cron: "0 8 */3 * *"  # 3 AM PST - Auto-Refactor
     - cron: "30 11 */3 * *" # 3:30 AM PST - Issue Resolver (daily fix)
-    - cron: "0 13 */3 * *"  # 5 AM PST - Auto-Rebase
-    - cron: "0 12 */3 * *"  # 4 AM PST - PR Compiler (consolidate PRs)
+    - cron: "0 8 */3 * *"  # 5 AM PST - Auto-Rebase
+    - cron: "0 8 */3 * *"  # 4 AM PST - PR Compiler (consolidate PRs)
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/Jules-Curie.yml
+++ b/.github/workflows/Jules-Curie.yml
@@ -3,7 +3,7 @@ name: Jules Curie (Data Hygiene)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 10 1 * *"  # 1st of month at 2 AM PST (10 UTC)
+    - cron: "0 8 */3 * *"  # 1st of month at 2 AM PST (10 UTC)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Hypatia.yml
+++ b/.github/workflows/Jules-Hypatia.yml
@@ -2,7 +2,7 @@ name: Jules Hypatia (Librarian)
 
 on:
   schedule:
-    - cron: "0 9 1 * *"  # 1st of month at 1 AM PST (9 UTC)
+    - cron: "0 8 */3 * *"  # 1st of month at 1 AM PST (9 UTC)
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -11,7 +11,7 @@ on:
         type: string
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "30 2 * * *"  # Daily at 2:30 AM UTC (overnight window)
+  #   - cron: "0 8 */3 * *"  # Daily at 2:30 AM UTC (overnight window)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -5,7 +5,7 @@ name: Jules PR Cleanup
 
 on:
   schedule:
-    - cron: "0 13 * * 0"  # Weekly on Sundays at 5 AM PST (13 UTC)
+    - cron: "0 8 */3 * *"  # Weekly on Sundays at 5 AM PST (13 UTC)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/Nightly-Doc-Organizer.yml
+++ b/.github/workflows/Nightly-Doc-Organizer.yml
@@ -2,7 +2,7 @@ name: Nightly Documentation Organizer
 
 on:
   schedule:
-    - cron: "0 11 * * *"  # Daily at 3 AM PST (11 UTC)
+    - cron: "0 8 */3 * *"  # Daily at 3 AM PST (11 UTC)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/agent-metrics-dashboard.yml
+++ b/.github/workflows/agent-metrics-dashboard.yml
@@ -3,7 +3,7 @@ name: Agent Metrics Dashboard
 on:
   schedule:
     # Every Monday at 10am UTC (after CI failure digest)
-    - cron: "0 10 * * 1"
+    - cron: "0 8 */3 * *"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -3,7 +3,7 @@ name: Weekly CI Failure Digest
 on:
   schedule:
     # Every Monday at 9am UTC
-    - cron: "0 9 * * 1"
+    - cron: "0 8 */3 * *"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -3,7 +3,7 @@ name: Stale PR/Issue Cleanup
 on:
   schedule:
     # Run daily at 1 AM PST (9 UTC)
-    - cron: "0 9 * * *"
+    - cron: "0 8 */3 * *"
   workflow_dispatch: # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
All automated workflows: `0 8 */3 * *` (midnight PST, every 3 days)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many workflows’ `schedule` triggers, which can unexpectedly change automation cadence or cause missed/duplicated runs if any jobs relied on prior weekly/daily timing or unique cron routing.
> 
> **Overview**
> Standardizes GitHub Actions automation timing by updating cron schedules across bot CI triggering, Jules agent workflows, and repo maintenance workflows to `0 8 */3 * *`.
> 
> This effectively shifts/aligns previously weekly/daily/monthly schedules (and some Control Tower dispatch times) onto the same every-3-days midnight-PST window, reducing run frequency and cost but changing when/if certain scheduled automations execute.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0be410d75150224efa85eed5c4e34423ca9bb8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->