### PR TITLE
Add Claude lint and tests skills

### DIFF
--- a/.claude/skills/lint.md
+++ b/.claude/skills/lint.md
@@ -1,0 +1,51 @@
+---
+name: lint
+description: Run linting tools (ruff, black, mypy) and fix placeholder/TODO statements
+---
+
+# Lint Skill
+
+Run comprehensive linting and code quality checks on the codebase.
+
+## Instructions
+
+1. **Run ruff with auto-fix**:
+   ```bash
+   ruff check . --fix
+   ```
+
+2. **Run black formatter**:
+   ```bash
+   black .
+   ```
+
+3. **Run mypy type checking**:
+   ```bash
+   mypy . --ignore-missing-imports
+   ```
+
+4. **Find and fix placeholder statements**:
+   - Search for `pass` statements that should have implementations
+   - Search for `TODO`, `FIXME`, `XXX`, `HACK` comments
+   - Search for `NotImplementedError` that should be implemented
+   - Search for `...` (ellipsis) placeholders in function bodies
+   
+   ```bash
+   grep -rn "TODO\|FIXME\|XXX\|HACK\|NotImplementedError\|pass$" --include="*.py" .
+   ```
+
+5. **Fix any issues found**:
+   - For each linting error, apply the appropriate fix
+   - For placeholder statements, implement the functionality or remove if unnecessary
+   - Ensure all changes pass linting after fixes
+
+6. **Verify all checks pass**:
+   ```bash
+   ruff check .
+   black --check .
+   mypy . --ignore-missing-imports
+   ```
+
+## Output
+
+Report all issues found and fixes applied. If any issues cannot be automatically fixed, list them with recommendations.

--- a/.claude/skills/tests.md
+++ b/.claude/skills/tests.md
@@ -1,0 +1,62 @@
+---
+name: tests
+description: Run all tests and iterate to fix failures
+---
+
+# Tests Skill
+
+Run the complete test suite and fix any failing tests.
+
+## Instructions
+
+1. **Discover test configuration**:
+   - Check for `pytest.ini`, `pyproject.toml`, or `setup.cfg` for test configuration
+   - Check for `package.json` for JavaScript/TypeScript tests
+   - Identify test directories: `tests/`, `test/`, `*_test.py`, `test_*.py`
+
+2. **Run Python tests**:
+   ```bash
+   pytest -v --tb=short
+   ```
+   
+   If pytest is not available, try:
+   ```bash
+   python -m pytest -v --tb=short
+   ```
+
+3. **Run JavaScript/TypeScript tests** (if applicable):
+   ```bash
+   npm test
+   ```
+   or
+   ```bash
+   yarn test
+   ```
+
+4. **For each failing test**:
+   - Read the test file and understand what it's testing
+   - Read the implementation being tested
+   - Identify the root cause of the failure
+   - Fix the implementation (preferred) or update the test if the test is incorrect
+   - Re-run the specific test to verify the fix:
+     ```bash
+     pytest path/to/test_file.py::test_name -v
+     ```
+
+5. **Iterate until all tests pass**:
+   - Continue fixing failures one by one
+   - After each fix, run the full test suite to check for regressions
+   - Document any tests that cannot be fixed and why
+
+6. **Final verification**:
+   ```bash
+   pytest -v
+   ```
+
+## Output
+
+Report:
+- Total tests run
+- Tests passed/failed/skipped
+- Fixes applied
+- Any remaining issues that need manual attention


### PR DESCRIPTION
Adds two Claude skills:

- **lint**: Runs ruff, black, mypy and finds/fixes placeholder statements
- **tests**: Runs full test suite and iterates to fix failures

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions that don’t change runtime code paths; risk is limited to developer workflow guidance.
> 
> **Overview**
> Adds two new Claude skills under `.claude/skills/`:
> 
> **`lint`** documents a standard workflow to run `ruff --fix`, `black`, and `mypy`, plus a grep pass to find and address placeholder/TODO-style code.
> 
> **`tests`** documents a workflow to discover test config and run Python/JS test suites, iterating on failures and re-running targeted tests until green.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb94b933942a2cd0e3ba938506cf82c4e1f29f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->