### PR TITLE
fix: Optimize workflow schedule to 2x weekly (Mon/Thu)

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -9,16 +9,9 @@ on:
     workflows: ["CI Standard"]
     types: [completed]
   schedule:
-    # OVERNIGHT SCHEDULE - All work done before morning (midnight-6 AM PST / 8 AM-2 PM UTC)
-    - cron: "0 8 */3 * *"   # Midnight PST - Assessment Generator
-    - cron: "30 8 */3 * *"  # 12:30 AM PST - Code Quality Reviewer
-    - cron: "0 8 */3 * *"   # 1 AM PST - Completist (incomplete impl)
-    - cron: "30 9 */3 * *"  # 1:30 AM PST - Documentation Auditor
-    - cron: "30 10 */3 * *" # 2:30 AM PST - Sentinel (security)
-    - cron: "0 8 */3 * *"  # 3 AM PST - Auto-Refactor
-    - cron: "30 11 */3 * *" # 3:30 AM PST - Issue Resolver (daily fix)
-    - cron: "0 8 */3 * *"  # 5 AM PST - Auto-Rebase
-    - cron: "0 8 */3 * *"  # 4 AM PST - PR Compiler (consolidate PRs)
+    # COST OPTIMIZED: Runs Mon/Thu (2x weekly for active repos)
+    # Time-based routing in triage step handles worker selection
+    - cron: "0 8 * * 1,4"  # Monday and Thursday at midnight PST
   workflow_dispatch:
     inputs:
       target:


### PR DESCRIPTION
## Problem
- Multiple identical cron expressions caused 9x workflow runs per trigger
- The `*/3` pattern caused consecutive-day runs at month boundaries (Jan 31 + Feb 1)

## Solution
- Single optimized cron schedule (2x weekly (Mon/Thu))
- Time-based routing handles worker selection
- Reduces GitHub Actions costs significantly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only scheduling change; main risk is reduced automation frequency or missed time-based routing expectations if other logic assumed the previous cron patterns.
> 
> **Overview**
> **Optimizes the `Jules Control Tower` GitHub Actions schedule** by replacing multiple `*/3` cron entries with a single cron (`0 8 * * 1,4`) that runs twice weekly (Mon/Thu) and relies on existing time-based/triage routing for worker selection.
> 
> This reduces duplicate scheduled workflow invocations (and cost) and avoids `*/3` month-boundary quirks by removing the previously overlapping schedule definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1117bae8d5469d677526647f6590bfd2d19ede2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->