### PR TITLE
fix: correct workflow schedules to specific days

### DIFF
--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -20,7 +20,7 @@ on:
 
   # Also run on a schedule to catch any missed PRs
   schedule:
-    - cron: "0 8 */3 * *"  # Every 2 hours (reduced from 15 min for cost control)
+    - cron: "0 8 * * 2"  # Every 2 hours (reduced from 15 min for cost control)
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 8 */3 * *"  # Daily at midnight UTC (overnight window)
+  #   - cron: "0 8 * * 2"  # Daily at midnight UTC (overnight window)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -35,7 +35,7 @@ on:
         type: string
   schedule:
     # Weekly on Monday at 6 AM UTC - conservative to prevent PR explosion
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 2"
 
 permissions:
   contents: read

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -11,7 +11,7 @@ on:
         type: string
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 8 */3 * *"  # Weekly Sunday 3 AM UTC (Tier 3 relaxed schedule)
+  #   - cron: "0 8 * * 2"  # Weekly Sunday 3 AM UTC (Tier 3 relaxed schedule)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -2,7 +2,7 @@ name: Jules Comprehensive Assessment
 
 on:
   schedule:
-    - cron: "0 8 */3 * *"  # Every 3 days at 5 AM PST (10 UTC) - cost optimized
+    - cron: "0 8 * * 2"  # Every 3 days at 5 AM PST (10 UTC) - cost optimized
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/Jules-Consolidator.yml
+++ b/.github/workflows/Jules-Consolidator.yml
@@ -9,7 +9,7 @@ on:
         default: 'false'
         type: boolean
   schedule:
-    - cron: "0 8 */3 * *"  # Monday at 5 AM PST (13 UTC)
+    - cron: "0 8 * * 2"  # Monday at 5 AM PST (13 UTC)
 
 concurrency:
   group: jules-consolidator

--- a/.github/workflows/Jules-Curie.yml
+++ b/.github/workflows/Jules-Curie.yml
@@ -3,7 +3,7 @@ name: Jules Curie (Data Hygiene)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 8 */3 * *"  # 1st of month at 2 AM PST (10 UTC)
+    - cron: "0 8 * * 2"  # 1st of month at 2 AM PST (10 UTC)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Hypatia.yml
+++ b/.github/workflows/Jules-Hypatia.yml
@@ -2,7 +2,7 @@ name: Jules Hypatia (Librarian)
 
 on:
   schedule:
-    - cron: "0 8 */3 * *"  # 1st of month at 1 AM PST (9 UTC)
+    - cron: "0 8 * * 2"  # 1st of month at 1 AM PST (9 UTC)
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -11,7 +11,7 @@ on:
         type: string
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 8 */3 * *"  # Daily at 2:30 AM UTC (overnight window)
+  #   - cron: "0 8 * * 2"  # Daily at 2:30 AM UTC (overnight window)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -5,7 +5,7 @@ name: Jules PR Cleanup
 
 on:
   schedule:
-    - cron: "0 8 */3 * *"  # Weekly on Sundays at 5 AM PST (13 UTC)
+    - cron: "0 8 * * 2"  # Weekly on Sundays at 5 AM PST (13 UTC)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/Nightly-Doc-Organizer.yml
+++ b/.github/workflows/Nightly-Doc-Organizer.yml
@@ -2,7 +2,7 @@ name: Nightly Documentation Organizer
 
 on:
   schedule:
-    - cron: "0 8 */3 * *"  # Daily at 3 AM PST (11 UTC)
+    - cron: "0 8 * * 2"  # Daily at 3 AM PST (11 UTC)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/agent-metrics-dashboard.yml
+++ b/.github/workflows/agent-metrics-dashboard.yml
@@ -3,7 +3,7 @@ name: Agent Metrics Dashboard
 on:
   schedule:
     # Every Monday at 10am UTC (after CI failure digest)
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 2"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -3,7 +3,7 @@ name: Weekly CI Failure Digest
 on:
   schedule:
     # Every Monday at 9am UTC
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 2"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -3,7 +3,7 @@ name: Stale PR/Issue Cleanup
 on:
   schedule:
     # Run daily at 1 AM PST (9 UTC)
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 2"
   workflow_dispatch: # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
## Summary
Fixes workflow schedules to use specific days instead of `*/3` which caused back-to-back runs at month boundaries (e.g., Jan 31 → Feb 1).

## Changes
- **Priority repos**: Thursday & Sunday (`0 8 * * 0,4`)
- **Non-priority repos**: Tuesday (`0 8 * * 2`)

This ensures predictable, evenly-spaced workflow runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cron-only changes to workflow schedules; no code, permissions, or execution steps were modified, but timing of automated jobs will change.
> 
> **Overview**
> Switches a set of scheduled GitHub Actions workflows from `*/3`-based cron expressions to a fixed weekday schedule (`0 8 * * 2`), including aligning commented-out schedules in worker workflows.
> 
> This is intended to avoid irregular/back-to-back executions around month boundaries and make automation runs more predictable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db849a406919542fbd79e9508e1d54522a9ca7f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->