### PR TITLE
fix(ci): reduce workflow costs

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -8,8 +8,15 @@ on:
       - '**.md'
       - 'LICENSE'
       - '.gitignore'
+      - '.github/**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add paths-ignore to triggers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger-only change; main risk is accidentally skipping CI for PRs that only modify `.github/**` files.
> 
> **Overview**
> Reduces unnecessary CI runs by adding `paths-ignore` filters to the `push` and `pull_request` triggers in `ci-standard.yml`.
> 
> The workflow now skips execution when changes are limited to docs/markdown, `LICENSE`, `.gitignore`, or `.github/**` (workflow/config-only updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a26d77a916f66223822d5f77b89fc22296240037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->