### PR TITLE
URGENT: Replace PR-Comment-Responder with queue-based workflow

### DIFF
--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -1,52 +1,59 @@
-name: PR Comment Responder
+name: PR Comment Collector
 
-# This workflow triggers when comments are added to PRs
-# It can be configured to use Claude API or other AI services
+# Collects PR comments into a queue for batch processing
+# Does NOT act immediately - prevents workflow cascades
+# Comments are processed by Jules-Comment-Processor on a schedule
 
 on:
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to review comments on'
-        required: true
-        type: string
 
 permissions:
   contents: write
-  pull-requests: write
+  pull-requests: read
   issues: read
 
+# Prevent concurrent runs from corrupting the queue file
+concurrency:
+  group: pr-comment-collector-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
-  respond-to-comments:
-    # Run on PR comments (from issue_comment), review comments (from pull_request_review_comment), or manual dispatch
-    # Skip if the comment author is a bot to prevent feedback loops
+  collect-comment:
+    # Only run on PR comments (not issue comments)
     if: |
-      (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request != null)
-      && !contains(github.event.comment.user.login, '[bot]')
-      && github.event.comment.user.login != 'github-actions'
-      && github.event.comment.user.login != 'jules'
+      (github.event_name == 'pull_request_review_comment') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Filter Bot Comments
+        id: filter
+        run: |
+          ACTOR="${{ github.actor }}"
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+          # List of bot actors to ignore
+          BOTS="copilot-pull-request-reviewer[bot] cursor[bot] dependabot[bot] github-actions[bot] renovate[bot] codecov[bot] sonarcloud[bot]"
 
-      - name: Get PR Details
-        id: pr
+          for bot in $BOTS; do
+            if [ "$ACTOR" = "$bot" ]; then
+              echo "::notice::Ignoring comment from bot: $ACTOR"
+              echo "is_bot=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+
+          echo "is_bot=false" >> $GITHUB_OUTPUT
+
+      - name: Get PR State
+        id: pr_state
+        if: steps.filter.outputs.is_bot != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ inputs.pr_number }}"
-          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
           else
             PR_NUMBER="${{ github.event.issue.number }}"
@@ -54,356 +61,162 @@ jobs:
 
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
-          # Get PR details
-          # Note: reviewComments field is deprecated or unavailable in some gh versions, using reviews instead
-          gh pr view $PR_NUMBER --json headRefName,headRepository,headRepositoryOwner,isCrossRepository,title,body,comments,reviews \
-            > .pr_details.json
+          # Check if PR is already merged or closed
+          PR_STATE=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json state --jq '.state')
+          echo "pr_state=$PR_STATE" >> $GITHUB_OUTPUT
 
-          # Get the branch
-          BRANCH=$(cat .pr_details.json | jq -r '.headRefName')
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-
-          IS_FORK=$(cat .pr_details.json | jq -r '.isCrossRepository // false')
-          HEAD_REPO=$(cat .pr_details.json | jq -r '.headRepository.nameWithOwner // ""')
-          echo "is_fork=$IS_FORK" >> $GITHUB_OUTPUT
-          echo "head_repo=$HEAD_REPO" >> $GITHUB_OUTPUT
-
-      - name: Analyze Comments
-        id: analyze
-        run: |
-          python3 << 'PYEOF'
-          import json
-          import os
-          import re
-
-          with open('.pr_details.json', 'r') as f:
-              pr = json.load(f)
-
-          # Bot usernames to ignore - these are informational, not actionable
-          BOT_USERS = [
-              'github-actions[bot]',
-              'github-actions',
-              'jules[bot]',
-              'jules',
-              'dependabot[bot]',
-              'dependabot',
-              'renovate[bot]',
-              'codecov[bot]',
-          ]
-
-          # Patterns that indicate informational/welcome messages (not actionable)
-          INFORMATIONAL_PATTERNS = [
-              r'reporting for duty',
-              r'welcome.*message',
-              r'thank you for',
-              r'thanks for (your|the|submitting)',
-              r'i\'m.*bot',
-              r'automated (message|comment|response)',
-              r'this is an automated',
-              r'label.*applied',
-              r'size.*label',
-          ]
-
-          # Stricter actionable patterns - require explicit request phrases
-          ACTIONABLE_PATTERNS = [
-              r'please\s+(fix|change|update|add|remove|rename|refactor)',
-              r'(could|can)\s+you\s+(please\s+)?(fix|change|update|add|remove)',
-              r'(should|needs? to|must)\s+(be\s+)?(fix|chang|updat|remov)',
-              r'this\s+(needs?|should|must)',
-              r'@\w+\s+please',  # Direct mention with please
-          ]
-
-          def is_from_bot(comment):
-              """Check if comment is from a bot user."""
-              author = comment.get('author', {}).get('login', '')
-              return author.lower() in [b.lower() for b in BOT_USERS]
-
-          def is_informational(body):
-              """Check if comment is just informational (not actionable)."""
-              body_lower = body.lower()
-              return any(re.search(pattern, body_lower) for pattern in INFORMATIONAL_PATTERNS)
-
-          def is_actionable(body):
-              """Check if comment contains an actionable request."""
-              body_lower = body.lower()
-              return any(re.search(pattern, body_lower) for pattern in ACTIONABLE_PATTERNS)
-
-          # Collect all comments that might need response
-          actionable_comments = []
-
-          # Check review comments (inline code comments)
-          # They are nested within reviews in the new structure
-          for review in pr.get('reviews', []):
-              if is_from_bot(review):
-                  continue
-              for comment in review.get('comments', []):
-                  if is_from_bot(comment):
-                      continue
-                  body = comment.get('body', '')
-                  if is_informational(body):
-                      print(f"Skipping informational review comment: {body[:100]}...")
-                      continue
-                  if is_actionable(body):
-                      actionable_comments.append({
-                          'type': 'review',
-                          'path': comment.get('path', ''),
-                          'line': comment.get('line', 0),
-                          'body': body
-                      })
-
-          # Check PR comments
-          for comment in pr.get('comments', []):
-              if is_from_bot(comment):
-                  print(f"Skipping bot comment from: {comment.get('author', {}).get('login', 'unknown')}")
-                  continue
-              body = comment.get('body', '')
-              if is_informational(body):
-                  print(f"Skipping informational PR comment: {body[:100]}...")
-                  continue
-              if is_actionable(body):
-                  actionable_comments.append({
-                      'type': 'pr',
-                      'body': body
-                  })
-
-          with open('.actionable_comments.json', 'w') as f:
-              json.dump(actionable_comments, f, indent=2)
-
-          count = len(actionable_comments)
-          print(f"Found {count} actionable comments (filtered out bot/informational messages)")
-
-          with open(os.environ.get('GITHUB_OUTPUT', '/dev/null'), 'a') as f:
-              f.write(f"count={count}\n")
-              f.write(f"has_comments={'true' if count > 0 else 'false'}\n")
-          PYEOF
-
-      - name: Skip if No Actionable Comments
-        if: steps.analyze.outputs.has_comments != 'true'
-        run: |
-          echo "No actionable comments found. Exiting."
-
-      - name: Skip Forked PRs
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork == 'true'
-        run: |
-          echo "PR is from a fork. Skipping branch checkout and push-based automation."
-
-      - name: Checkout PR Branch
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork != 'true'
-        run: |
-          git fetch origin ${{ steps.pr.outputs.branch }}
-          git checkout ${{ steps.pr.outputs.branch }}
-
-      # Option 1: Use Jules if available
-      - name: Address Comments with Jules
-        id: jules
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork != 'true'
-        env:
-          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
-        run: |
-          set -e
-          DATE=$(date +%Y-%m-%d)
-          REPO="${{ github.repository }}"
-          API_BASE="https://jules.googleapis.com/v1alpha"
-          
-          # Check if API key is configured
-          if [ -z "$JULES_API_KEY" ]; then
-            echo "::warning::JULES_API_KEY not configured. Skipping Jules task."
-            echo "ran=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          
-          echo "Looking up repository source..."
-          SOURCES=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/sources" || echo '{"sources":[]}')
-          
-          OWNER=$(echo "$REPO" | cut -d'/' -f1)
-          REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
-          
-          SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.githubRepo.owner == \"$OWNER\" and .githubRepo.repo == \"$REPO_NAME\") | .name" | head -1)
-          
-          if [ -z "$SOURCE_ID" ] || [ "$SOURCE_ID" = "null" ]; then
-            echo "::warning::Repository $REPO not found in Jules sources."
-            echo "ran=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          
-          echo "Found source: $SOURCE_ID"
-
-          COMMENTS_CONTENT=$(cat .actionable_comments.json)
-          
-          # Create session prompt
-          PROMPT=$(cat << PROMPT_EOF
-          Review and address the PR comments in the following JSON data:
-
-          $COMMENTS_CONTENT
-          
-          For each comment:
-          1. Understand what change is being requested
-          2. Make the appropriate code change
-          3. Keep changes minimal and focused
-          
-          Do NOT respond to comments that are just acknowledgments or thank-yous.
-          PROMPT_EOF
-          )
-          
-          # Get the PR branch name for pushing changes to the existing PR
-          PR_BRANCH="${{ steps.pr.outputs.branch }}"
-
-          echo "Creating Jules session to push changes to PR branch: $PR_BRANCH"
-          REQUEST_JSON=$(jq -n \
-            --arg prompt "$PROMPT" \
-            --arg source "$SOURCE_ID" \
-            --arg branch "$PR_BRANCH" \
-            '{
-              prompt: $prompt,
-              sourceContext: {
-                source: $source,
-                githubRepoContext: {
-                  startingBranch: $branch
-                }
-              },
-              automationMode: "PUSH_TO_BRANCH"
-            }')
-          
-          echo "Request: $REQUEST_JSON"
-          
-          HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
-            -H "X-Goog-Api-Key: $JULES_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$REQUEST_JSON" \
-            "$API_BASE/sessions")
-          
-          SESSION_RESPONSE=$(cat /tmp/session_response.json)
-          echo "HTTP Status: $HTTP_CODE"
-          
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "::error::Jules API returned HTTP $HTTP_CODE"
-            exit 1
-          fi
-          
-          SESSION_ID=$(echo "$SESSION_RESPONSE" | jq -r '.name')
-          echo "Created session: $SESSION_ID"
-          
-          # Poll for completion
-          MAX_WAIT=1800
-          POLL_INTERVAL=30
-          ELAPSED=0
-          JULES_DONE=false
-          
-          while [ $ELAPSED -lt $MAX_WAIT ]; do
-            SESSION_STATUS=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/$SESSION_ID")
-            STATE=$(echo "$SESSION_STATUS" | jq -r '.state')
-            echo "Session state: $STATE (elapsed: ${ELAPSED}s)"
-          
-            case "$STATE" in
-              "COMPLETED"|"SUBMITTED")
-                JULES_DONE=true
-                echo "Session completed successfully!"
-                break
-                ;;
-              "FAILED"|"CANCELLED")
-                echo "::error::Session $STATE"
-                exit 1
-                ;;
-            esac
-            sleep $POLL_INTERVAL
-            ELAPSED=$((ELAPSED + POLL_INTERVAL))
-          done
-          
-          if [ "$JULES_DONE" = "true" ]; then
-            echo "ran=true" >> "$GITHUB_OUTPUT"
+          if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then
+            echo "::notice::PR #$PR_NUMBER is $PR_STATE, skipping comment collection"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
           else
-            echo "::warning::Jules session timed out after ${MAX_WAIT}s."
-            echo "ran=false" >> "$GITHUB_OUTPUT"
+            echo "should_skip=false" >> $GITHUB_OUTPUT
           fi
 
+      - uses: actions/checkout@v4
+        if: steps.filter.outputs.is_bot != 'true' && steps.pr_state.outputs.should_skip != 'true'
+        with:
+          fetch-depth: 1
 
-
-      # Option 2: Use Claude API directly (requires ANTHROPIC_API_KEY secret)
-      # Only runs if Jules was skipped (no JULES_API_KEY) and ANTHROPIC_API_KEY is set
-      - name: Address Comments with Claude API
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork != 'true' && steps.jules.outputs.ran != 'true'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+      - name: Analyze Comment
+        id: analyze
+        if: steps.filter.outputs.is_bot != 'true' && steps.pr_state.outputs.should_skip != 'true'
         run: |
-          # Skip if no Anthropic key
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "ANTHROPIC_API_KEY not configured, skipping"
-            exit 0
+          # Get comment body
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            COMMENT_BODY="${{ github.event.comment.body }}"
+            COMMENT_PATH="${{ github.event.comment.path }}"
+            COMMENT_LINE="${{ github.event.comment.line }}"
+            COMMENT_TYPE="review"
+          else
+            COMMENT_BODY="${{ github.event.comment.body }}"
+            COMMENT_PATH=""
+            COMMENT_LINE=""
+            COMMENT_TYPE="pr"
           fi
-          pip install anthropic
 
-          python3 << 'PYEOF'
-          import anthropic
-          import json
-          import subprocess
-          import os
+          # Check if comment is actionable (contains request-like words)
+          BODY_LOWER=$(echo "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]')
 
-          client = anthropic.Anthropic()
+          IS_ACTIONABLE=false
+          for word in "please" "should" "could you" "can you" "fix" "change" "update" "add" "remove" "consider" "suggest" "recommend"; do
+            if echo "$BODY_LOWER" | grep -q "$word"; then
+              IS_ACTIONABLE=true
+              break
+            fi
+          done
 
-          with open('.actionable_comments.json', 'r') as f:
-              comments = json.load(f)
+          # Also check for question marks (requests for clarification/changes)
+          if echo "$COMMENT_BODY" | grep -q "?"; then
+            IS_ACTIONABLE=true
+          fi
 
-          # Read relevant files mentioned in comments
-          files_to_read = set()
-          for c in comments:
-              if c.get('path'):
-                  files_to_read.add(c['path'])
+          echo "is_actionable=$IS_ACTIONABLE" >> $GITHUB_OUTPUT
 
-          file_contents = {}
-          for path in files_to_read:
-              try:
-                  with open(path, 'r') as f:
-            file_contents[path] = f.read()
-              except:
-                  pass
+          if [ "$IS_ACTIONABLE" = "false" ]; then
+            echo "::notice::Comment does not appear actionable, skipping"
+          fi
 
-          prompt = f"""You are a code reviewer assistant. Address these PR comments by suggesting specific code changes.
-
-          Comments to address:
-          {json.dumps(comments, indent=2)}
-
-          Relevant file contents:
-          {json.dumps(file_contents, indent=2)}
-
-          For each comment, provide:
-          1. The file path
-          2. The exact change needed (as a diff or replacement)
-          3. Brief explanation
-
-          Format your response as JSON with structure:
-          {{"changes": [{{"file": "path", "old": "old code", "new": "new code", "explanation": "why"}}]}}
-          """
-
-          message = client.messages.create(
-              model="claude-sonnet-4-20250514",
-              max_tokens=4096,
-              messages=[{"role": "user", "content": prompt}]
-          )
-
-          print(message.content[0].text)
-          # Note: In a full implementation, you would parse the response
-          # and apply the changes automatically
-          PYEOF
-
-      - name: Commit Changes
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork != 'true'
+      - name: Queue Comment for Processing
+        if: |
+          steps.filter.outputs.is_bot != 'true' &&
+          steps.pr_state.outputs.should_skip != 'true' &&
+          steps.analyze.outputs.is_actionable == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if ! git diff --staged --quiet; then
-            git commit -m "Address PR review comments
+          mkdir -p .jules/pending
+          QUEUE_FILE=".jules/pending/pr_comments.json"
 
-          Automated response to reviewer feedback.
+          # Initialize queue file if it doesn't exist
+          if [ ! -f "$QUEUE_FILE" ]; then
+            echo '{"comments": []}' > "$QUEUE_FILE"
+          fi
 
-          Co-Authored-By: Claude <noreply@anthropic.com>"
+          # Create comment entry
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          PR_NUMBER="${{ steps.pr_state.outputs.pr_number }}"
 
-            git push origin ${{ steps.pr.outputs.branch }}
-
-            gh pr comment ${{ steps.pr.outputs.pr_number }} --body "I've addressed the review comments. Please take another look!"
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            COMMENT_ID="${{ github.event.comment.id }}"
+            COMMENT_BODY=$(echo '${{ toJson(github.event.comment.body) }}')
+            COMMENT_PATH="${{ github.event.comment.path }}"
+            COMMENT_LINE="${{ github.event.comment.line }}"
+            COMMENT_TYPE="review"
+            COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
           else
-            echo "No changes made"
+            COMMENT_ID="${{ github.event.comment.id }}"
+            COMMENT_BODY=$(echo '${{ toJson(github.event.comment.body) }}')
+            COMMENT_PATH=""
+            COMMENT_LINE=""
+            COMMENT_TYPE="pr"
+            COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
+          fi
+
+          # Use Python for safe JSON manipulation
+          python3 << PYEOF
+          import json
+          import os
+
+          queue_file = "$QUEUE_FILE"
+
+          # Load existing queue
+          try:
+              with open(queue_file, 'r') as f:
+                  queue = json.load(f)
+          except:
+              queue = {"comments": []}
+
+          # Check for duplicate (same comment ID)
+          comment_id = "$COMMENT_ID"
+          existing_ids = [c.get('comment_id') for c in queue.get('comments', [])]
+
+          if comment_id in existing_ids:
+              print(f"Comment {comment_id} already in queue, skipping")
+          else:
+              # Add new comment
+              new_comment = {
+                  "comment_id": comment_id,
+                  "pr_number": int("$PR_NUMBER"),
+                  "type": "$COMMENT_TYPE",
+                  "author": "$COMMENT_AUTHOR",
+                  "body": $COMMENT_BODY,
+                  "path": "$COMMENT_PATH" if "$COMMENT_PATH" else None,
+                  "line": int("$COMMENT_LINE") if "$COMMENT_LINE" else None,
+                  "queued_at": "$TIMESTAMP",
+                  "repository": "${{ github.repository }}"
+              }
+
+              queue["comments"].append(new_comment)
+              queue["last_updated"] = "$TIMESTAMP"
+
+              with open(queue_file, 'w') as f:
+                  json.dump(queue, f, indent=2)
+
+              print(f"Queued comment {comment_id} from PR #{new_comment['pr_number']}")
+              print(f"Queue now has {len(queue['comments'])} pending comments")
+          PYEOF
+
+      - name: Commit Queue Update
+        if: |
+          steps.filter.outputs.is_bot != 'true' &&
+          steps.pr_state.outputs.should_skip != 'true' &&
+          steps.analyze.outputs.is_actionable == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add .jules/pending/pr_comments.json
+
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: queue PR comment for batch processing
+
+          PR: #${{ steps.pr_state.outputs.pr_number }}
+          Comment ID: ${{ github.event.comment.id }}
+
+          This comment will be processed by Jules-Comment-Processor on the next scheduled run."
+
+            git push
+            echo "::notice::Comment queued for batch processing"
+          else
+            echo "No changes to commit"
           fi


### PR DESCRIPTION
Replacing broken workflow causing cascade. Auto-merge enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes from immediate automated responses to committing queued comment data on every actionable comment, which could affect workflow reliability and repo history if the heuristics or concurrency handling misbehave.
> 
> **Overview**
> Replaces the PR comment auto-responder with a **queue-based** workflow that records actionable PR and review comments into `.jules/pending/pr_comments.json` for later scheduled processing (avoiding cascade-triggered runs).
> 
> The workflow now filters bot actors, skips merged/closed PRs, uses lightweight heuristics to decide whether a single new comment is actionable, and commits/pushes the updated queue file under a repository-wide concurrency lock; permissions are reduced from `pull-requests: write` to `pull-requests: read` and `workflow_dispatch` support is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb6dd084a84cc1ecc99ecf3725e0def381b9a506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->