### PR TITLE
docs: Fix misleading schedule comments in workflows

### DIFF
--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -2,7 +2,7 @@ name: Jules Comprehensive Assessment
 
 on:
   schedule:
-    - cron: "0 8 * * 2"  # Every 3 days at 5 AM PST (10 UTC) - cost optimized
+    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/Jules-Consolidator.yml
+++ b/.github/workflows/Jules-Consolidator.yml
@@ -9,7 +9,7 @@ on:
         default: 'false'
         type: boolean
   schedule:
-    - cron: "0 8 * * 2"  # Monday at 5 AM PST (13 UTC)
+    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
 
 concurrency:
   group: jules-consolidator

--- a/.github/workflows/Jules-Curie.yml
+++ b/.github/workflows/Jules-Curie.yml
@@ -3,7 +3,7 @@ name: Jules Curie (Data Hygiene)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 8 * * 2"  # 1st of month at 2 AM PST (10 UTC)
+    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Hypatia.yml
+++ b/.github/workflows/Jules-Hypatia.yml
@@ -2,7 +2,7 @@ name: Jules Hypatia (Librarian)
 
 on:
   schedule:
-    - cron: "0 8 * * 2"  # 1st of month at 1 AM PST (9 UTC)
+    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -5,7 +5,7 @@ name: Jules PR Cleanup
 
 on:
   schedule:
-    - cron: "0 8 * * 2"  # Weekly on Sundays at 5 AM PST (13 UTC)
+    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/Nightly-Doc-Organizer.yml
+++ b/.github/workflows/Nightly-Doc-Organizer.yml
@@ -1,8 +1,8 @@
-name: Nightly Documentation Organizer
+name: Weekly Documentation Organizer
 
 on:
   schedule:
-    - cron: "0 8 * * 2"  # Daily at 3 AM PST (11 UTC)
+    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -2,7 +2,7 @@ name: Stale PR/Issue Cleanup
 
 on:
   schedule:
-    # Run daily at 1 AM PST (9 UTC)
+    # Weekly on Tuesday at 8 AM UTC (midnight PST)
     - cron: "0 8 * * 2"
   workflow_dispatch: # Allow manual trigger
 


### PR DESCRIPTION
## Summary
- Fixed misleading comments in 7 workflow files that incorrectly described their schedules
- All these workflows run on Tuesday at 8 AM UTC (midnight PST), not daily/monthly/different days as claimed
- Renamed "Nightly Documentation Organizer" to "Weekly Documentation Organizer"

## Workflows Updated
| File | Old Comment | New Comment |
|------|-------------|-------------|
| Jules-Comprehensive-Assessment | "Every 3 days" | "Weekly on Tuesday" |
| Jules-Consolidator | "Monday at 5 AM PST" | "Weekly on Tuesday" |
| Jules-Curie | "1st of month" | "Weekly on Tuesday" |
| Jules-Hypatia | "1st of month" | "Weekly on Tuesday" |
| Jules-PR-Cleanup | "Weekly on Sundays" | "Weekly on Tuesday" |
| Nightly-Doc-Organizer | "Daily at 3 AM PST" | "Weekly on Tuesday" |
| stale-cleanup | "Run daily at 1 AM PST" | "Weekly on Tuesday" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only updates plus a workflow name rename; execution timing/configuration is unchanged and no runtime logic is modified.
> 
> **Overview**
> Updates multiple GitHub Actions workflow `schedule` comments to consistently reflect that they run **weekly on Tuesday at 08:00 UTC (midnight PST)**, correcting previously misleading daily/monthly/other-day descriptions.
> 
> Also renames the workflow from `Nightly Documentation Organizer` to `Weekly Documentation Organizer` to match the actual cadence (cron expression unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e87832efbae9b18b2f8b742c6d4407f4965f8f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->