### PR TITLE
fix: sync CI tool versions with pre-commit config

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
-      - run: pip install ruff==0.14.10 black==25.12.0 mypy==1.13.0 bandit==1.7.7 pydocstyle==6.3.0
+      - run: pip install ruff==0.14.10 black==26.1.0 mypy==1.13.0 bandit==1.7.7 pydocstyle==6.3.0
 
       # Validate that CI tool versions match pre-commit config
       - name: Check Tool Version Consistency
@@ -43,7 +43,7 @@ jobs:
           echo "Validating tool versions match .pre-commit-config.yaml..."
 
           # Check Black version
-          if ! grep -q "rev: 24.4.2" .pre-commit-config.yaml; then
+          if ! grep -q "rev: 26.1.0" .pre-commit-config.yaml; then
             echo "::error::Black version mismatch between CI and pre-commit config"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Update black from 25.12.0 to 26.1.0
- Fix version check assertions to match pre-commit config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that bumps a formatter version and updates a grep-based assertion; no production code or data-path impact.
> 
> **Overview**
> Updates the CI `quality-gate` workflow to install `black==26.1.0` (from `25.12.0`) to match the repo’s pre-commit configuration.
> 
> Adjusts the workflow’s tool-version consistency check to assert `rev: 26.1.0` for Black in `.pre-commit-config.yaml`, preventing false CI failures due to mismatched formatter versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b59823f801128ce370a3705aeded7121f32d9497. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->