### PR TITLE
fix(pre-commit): use local hook for radon complexity check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -234,16 +234,18 @@ repos:
         exclude: ^(tests/|archive/|legacy/|experimental/|\.github/)
 
   # Radon - Cyclomatic complexity check (pre-push)
-  - repo: https://github.com/rubik/radon
-    rev: v6.0.1
+  # Note: Using local hook since rubik/radon doesn't provide pre-commit hooks
+  - repo: local
     hooks:
       - id: radon
         name: "radon (complexity check)"
         stages: [pre-push]
-        args: ["cc", "--min", "C", "--show-complexity", "--total-average"]
+        entry: python -m radon cc --min C --show-complexity --total-average
+        language: system
         types: [python]
         files: ^src/
         exclude: ^(tests/|archive/|legacy/|experimental/)
+        pass_filenames: true
 
 # =============================================================================
 # Global Settings


### PR DESCRIPTION
## Summary
- Replace rubik/radon repo hook with local system hook
- The rubik/radon repository doesn't provide pre-commit hooks natively
- Local hook uses `python -m radon` which works correctly

## Test plan
- [x] Verify pre-commit config is valid YAML
- [ ] Run `pre-commit run radon --all-files` to verify hook works

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pre-commit configuration-only change; main risk is developers without `radon` installed locally will see the hook fail.
> 
> **Overview**
> Fixes the pre-push `radon` cyclomatic complexity check by replacing the `rubik/radon` pre-commit repo reference with a **local** hook that runs `python -m radon cc ...` via `language: system`.
> 
> The hook is configured to run on Python files under `src/` and to pass filenames through to Radon (`pass_filenames: true`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20026964f9c77b3c98c6c492d592afac03b189a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->