### PR TITLE
fix: make pre-commit hooks cross-platform (Windows/Linux)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,9 @@
 # Fleet-Wide Pre-commit Configuration (Polyglot)
 # =============================================================================
 # Supports: Python, JavaScript/TypeScript, React, HTML, CSS, C++
+# CROSS-PLATFORM: Works on Windows, Linux, and macOS
+# - Uses `language: python` instead of `language: system` for local hooks
+# - Avoids shell-specific commands that fail on Windows
 #
 # Fast checks on every commit (<15 seconds)
 # Slower checks (mypy, tests) on pre-push only
@@ -124,6 +127,7 @@ repos:
   # QUALITY CHECKS (All Languages)
   # ===========================================================================
 
+  # NOTE: Using language: python (not system) for cross-platform compatibility (Windows/Linux)
   - repo: local
     hooks:
       # Prevent wildcard imports (Python)
@@ -211,13 +215,16 @@ repos:
         types: [python]
 
   # Pytest - Python unit tests (pre-push only)
+  # NOTE: Using language: python (not system) for cross-platform compatibility (Windows/Linux)
   - repo: local
     hooks:
       - id: pytest-unit
         name: "pytest (Python tests)"
         stages: [pre-push]
-        entry: python -m pytest tests/unit -x -q --tb=short -m "not slow and not integration"
-        language: system
+        entry: pytest
+        args: ["tests/unit", "-x", "-q", "--tb=short", "-m", "not slow and not integration"]
+        language: python
+        additional_dependencies: [pytest, pytest-cov]
         pass_filenames: false
         types: [python]
 
@@ -235,13 +242,16 @@ repos:
 
   # Radon - Cyclomatic complexity check (pre-push)
   # Note: Using local hook since rubik/radon doesn't provide pre-commit hooks
+  # NOTE: Using language: python (not system) for cross-platform compatibility (Windows/Linux)
   - repo: local
     hooks:
       - id: radon
         name: "radon (complexity check)"
         stages: [pre-push]
-        entry: python -m radon cc --min C --show-complexity --total-average
-        language: system
+        entry: radon
+        args: ["cc", "--min", "C", "--show-complexity", "--total-average"]
+        language: python
+        additional_dependencies: [radon]
         types: [python]
         files: ^src/
         exclude: ^(tests/|archive/|legacy/|experimental/)


### PR DESCRIPTION
## Summary

- Fix pre-commit hooks to work on both Windows and Linux
- Change `language: system` to `language: python` for local hooks (pytest-unit, radon)
- Use explicit args arrays instead of inline command strings
- Add additional_dependencies for proper tool installation

## Problem

On Windows (Git Bash), running pre-commit with `language: system` hooks fails with:
```
An unexpected error has occurred: ExecutableNotFoundError: Executable `/bin/bash` not found
```

## Solution

Use `language: python` which pre-commit handles cross-platform by creating isolated virtualenvs with the specified dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to developer tooling; main risk is minor behavior differences in how `pytest`/`radon` resolve versions and arguments under pre-commit-managed virtualenvs.
> 
> **Overview**
> Improves cross-platform reliability of pre-commit by switching local `pytest-unit` and `radon` hooks from `language: system` command strings to `language: python` with explicit `args`.
> 
> Adds `additional_dependencies` so pre-commit installs `pytest`/`pytest-cov` and `radon` in isolated environments, and updates comments to document the Windows/Linux compatibility rationale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9242986d58cc63b941c382ab9831edf46bb894d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->