### PR TITLE
feat: add Rust pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Fleet-Wide Pre-commit Configuration (Polyglot)
 # =============================================================================
-# Supports: Python, JavaScript/TypeScript, React, HTML, CSS, C++
+# Supports: Python, JavaScript/TypeScript, React, HTML, CSS, C++, Rust
 # CROSS-PLATFORM: Works on Windows, Linux, and macOS
 # - Uses `language: python` instead of `language: system` for local hooks
 # - Avoids shell-specific commands that fail on Windows
@@ -108,6 +108,20 @@ repos:
         types_or: [c, c++]
         args: ["-i", "--style=file"]
         exclude: ^(\.github/|docs/|third_party/)
+
+  # ===========================================================================
+  # RUST CHECKS (Tauri desktop apps)
+  # ===========================================================================
+
+  # Rustfmt - Rust code formatter (skips if no .rs files)
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+        name: "rustfmt (Rust format)"
+      - id: cargo-check
+        name: "cargo check (Rust)"
+        stages: [pre-push]
 
   # ===========================================================================
   # UNIVERSAL FORMATTING (All Languages)
@@ -281,6 +295,7 @@ exclude: |
     venv/|
     build/|
     dist/|
+    target/|
     .*\.egg-info/|
     \.next/|
     coverage/|
@@ -296,4 +311,4 @@ ci:
   autofix_prs: true
   autoupdate_branch: "main"
   autoupdate_commit_msg: "chore: update pre-commit hooks"
-  skip: [pytest-unit, bandit, mypy, semgrep, radon]  # Skip slow hooks in CI
+  skip: [pytest-unit, bandit, mypy, semgrep, radon, fmt, cargo-check]  # Skip slow hooks in CI


### PR DESCRIPTION
## Summary
- Add Rust checks (rustfmt, cargo-check) to pre-commit hooks
- Add target/ to global exclude patterns  
- Update CI skip list to include Rust hooks

## Test plan
- [ ] Pre-commit hooks run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates developer tooling via pre-commit configuration; main risk is added local/pre-push friction or CI skip misconfiguration, with no runtime impact.
> 
> **Overview**
> Adds **Rust support** to `.pre-commit-config.yaml` by introducing `pre-commit-rust` hooks: `fmt` (`rustfmt`) on commit and `cargo-check` on *pre-push*.
> 
> Updates global exclusions to ignore Rust `target/` artifacts and extends the pre-commit `ci.skip` list to skip the new Rust hooks in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 599ac486edc09efd7f9a1fede1d960321401635d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->