### PR TITLE
Fix pre-commit stage name for push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,7 +121,7 @@ repos:
         name: "rustfmt (Rust format)"
       - id: cargo-check
         name: "cargo check (Rust)"
-        stages: [pre-push]
+        stages: [push]
 
   # ===========================================================================
   # UNIVERSAL FORMATTING (All Languages)
@@ -196,7 +196,7 @@ repos:
     hooks:
       - id: mypy
         name: "mypy (Python type check)"
-        stages: [pre-push]
+        stages: [push]
         additional_dependencies:
           - types-requests
           - types-PyYAML
@@ -223,7 +223,7 @@ repos:
     hooks:
       - id: bandit
         name: "bandit (Python security)"
-        stages: [pre-push]
+        stages: [push]
         args: ["-r", ".", "-ll", "-ii", "-x", "tests/,archive/,legacy/,.github/,node_modules/"]
         pass_filenames: false
         types: [python]
@@ -234,7 +234,7 @@ repos:
     hooks:
       - id: pytest-unit
         name: "pytest (Python tests)"
-        stages: [pre-push]
+        stages: [push]
         entry: pytest
         args: ["tests/unit", "-x", "-q", "--tb=short", "-m", "not slow and not integration"]
         language: python
@@ -249,7 +249,7 @@ repos:
     hooks:
       - id: semgrep
         name: "semgrep (security + quality)"
-        stages: [pre-push]
+        stages: [push]
         args: ["--config", "auto", "--error", "--quiet"]
         types: [python]
         exclude: ^(tests/|archive/|legacy/|experimental/|\.github/)
@@ -261,7 +261,7 @@ repos:
     hooks:
       - id: radon
         name: "radon (complexity check)"
-        stages: [pre-push]
+        stages: [push]
         entry: radon
         args: ["cc", "--min", "C", "--show-complexity", "--total-average"]
         language: python


### PR DESCRIPTION
Replaces invalid  with valid  in  so pre-commit can parse and run hooks correctly with current stage schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that corrects hook stage naming; main impact is when these checks execute, not runtime application behavior.
> 
> **Overview**
> Updates `.pre-commit-config.yaml` to replace the invalid `stages: [pre-push]` with `stages: [push]` for the slower hooks (`cargo-check`, `mypy`, `bandit`, `pytest-unit`, `semgrep`, `radon`).
> 
> This fixes hook staging so pre-commit can parse and run these checks at push time as intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3666af4413f38ce7389424c6031b88f58dd61f58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->