### PR TITLE
fix: resolve ruff import ordering and mypy TypedDict errors

### DIFF
--- a/src/games/Duum/tests/test_utils.py
+++ b/src/games/Duum/tests/test_utils.py
@@ -3,10 +3,9 @@
 import math
 import unittest
 
+from games.shared.utils import cast_ray_dda, has_line_of_sight, try_move_entity
 from src.map import Map
 from src.projectile import Projectile
-
-from games.shared.utils import cast_ray_dda, has_line_of_sight, try_move_entity
 
 
 class MockEntity:

--- a/src/games/Tetris/tetris.py
+++ b/src/games/Tetris/tetris.py
@@ -9,6 +9,7 @@ import sys
 from typing import Any
 
 import pygame
+
 import src.constants as C  # noqa: N812
 from src.game_logic import TetrisLogic
 from src.input_handler import InputHandler


### PR DESCRIPTION
## Summary
- Fix ruff I001 import ordering errors (auto-fixed)
- Fix mypy errors in scripts/analyze_completist_data.py:
  - Replace NotRequired (Python 3.11+) with two-class TypedDict inheritance pattern for Python 3.10 compatibility
  - Use Finding() TypedDict constructor instead of bare dict literals for proper type checking

### Verification
All quality gates pass locally:
- ruff check: ✅
- black --check: ✅
- mypy --ignore-missing-imports: ✅ (0 errors in 153 files)

Closes #235, Closes #184

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily type/lint compliance changes; runtime behavior should be unchanged aside from the `Finding` dict construction style in a reporting script.
> 
> **Overview**
> Resolves mypy issues in `scripts/analyze_completist_data.py` by replacing `NotRequired` fields with a two-class `TypedDict` inheritance pattern for Python 3.10 compatibility, and by constructing `Finding` instances via `Finding(...)` instead of raw dict literals.
> 
> Cleans up `ruff` import-ordering violations in `src/games/Duum/tests/test_utils.py` and `src/games/Tetris/tetris.py` (no functional/gameplay behavior changes intended).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e4d84b96596af569023a671a5036d047a674237. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->