### PR TITLE
chore: add CODEOWNERS protection for .github/workflows/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS - Protect critical infrastructure from automated changes
+#
+# GitHub Actions workflows require human review before merging.
+# This prevents automated agents from archiving, deleting, or
+# modifying CI/CD workflows without explicit human approval.
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Protect ALL workflow files - require owner review
+.github/workflows/ @dieterolson
+
+# Protect CODEOWNERS itself
+.github/CODEOWNERS @dieterolson


### PR DESCRIPTION
Prevents automated agents from archiving or modifying CI/CD workflows without explicit human review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds repository ownership rules only; no application/runtime code changes.
> 
> **Overview**
> Adds `.github/CODEOWNERS` to enforce required review by `@dieterolson` for any changes under `.github/workflows/`, and to protect modifications to the `CODEOWNERS` file itself.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6510fd7725ea034337e1866a3a2917aab3729c0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->