### PR TITLE
refactor: Wave 6 — Decompose all >100-line functions in shared/

### DIFF
--- a/src/games/shared/bot_renderer.py
+++ b/src/games/shared/bot_renderer.py
@@ -29,7 +29,61 @@ class BotRenderer:
         base_color = type_data["color"]
         visual_style = type_data.get("visual_style", "monster")
 
-        # Special handling for item types
+        # Delegate item types to specialised renderer
+        if BotRenderer._render_item_sprite(
+            screen, bot, center_x, sprite_y, sprite_size, base_color, config
+        ):
+            return
+
+        render_height = sprite_size
+        render_width = (
+            sprite_size * 0.55 if visual_style == "monster" else sprite_size * 0.7
+        )
+        render_y = sprite_y
+
+        if bot.dead:
+            result = BotRenderer._render_death_animation(
+                screen,
+                bot,
+                center_x,
+                sprite_y,
+                render_width,
+                render_height,
+                base_color,
+            )
+            if result is None:
+                return  # Disintegration complete or fully dissolved
+            render_y, render_width, render_height, base_color = result
+
+        # Delegate to specialized renderer
+        renderer = BotStyleRendererFactory.get_renderer(visual_style)
+        if renderer:
+            renderer.render(
+                screen,
+                bot,
+                center_x,
+                render_y,
+                render_width,
+                render_height,
+                base_color,
+                config,
+            )
+
+    @staticmethod
+    def _render_item_sprite(
+        screen: pygame.Surface,
+        bot: Bot,
+        center_x: float,
+        sprite_y: int,
+        sprite_size: float,
+        base_color: tuple[int, int, int],
+        config: RaycasterConfig,
+    ) -> bool:
+        """Render item-type sprites (health packs, ammo, pickups).
+
+        Returns:
+            True if the bot was an item type and was rendered (or skipped).
+        """
         if bot.enemy_type in ("health_pack", "ammo_box", "bomb_item"):
             renderer = BotStyleRendererFactory.get_renderer(bot.enemy_type)
             if renderer:
@@ -43,7 +97,7 @@ class BotRenderer:
                     base_color,
                     config,
                 )
-            return
+            return True
 
         if bot.enemy_type.startswith("pickup_"):
             renderer = BotStyleRendererFactory.get_renderer("weapon_pickup")
@@ -58,62 +112,59 @@ class BotRenderer:
                     base_color,
                     config,
                 )
-            return
+            return True
 
-        render_height = sprite_size
-        render_width = (
-            sprite_size * 0.55 if visual_style == "monster" else sprite_size * 0.7
-        )
-        render_y = sprite_y
+        return False
 
-        if bot.dead:
-            # Melting animation
-            melt_pct = min(1.0, bot.death_timer / 60.0)
-            goo_color = (50, 150, 50)
-            base_color = tuple(
-                int(c * (1 - melt_pct) + g * melt_pct)
-                for c, g in zip(base_color, goo_color, strict=False)
-            )  # type: ignore
+    @staticmethod
+    def _render_death_animation(
+        screen: pygame.Surface,
+        bot: Bot,
+        center_x: float,
+        sprite_y: int,
+        render_width: float,
+        render_height: float,
+        base_color: tuple[int, int, int],
+    ) -> tuple[int, int, int, tuple[int, int, int]] | None:
+        """Calculate death animation transforms (melting + disintegration).
 
-            scale_y = 1.0 - (melt_pct * 0.85)
-            scale_x = 1.0 + (melt_pct * 0.8)
+        Returns:
+            (render_y, render_width, render_height, modified_color) or
+            None if the sprite should not be drawn.
+        """
+        melt_pct = min(1.0, bot.death_timer / 60.0)
+        goo_color = (50, 150, 50)
+        base_color = tuple(
+            int(c * (1 - melt_pct) + g * melt_pct)
+            for c, g in zip(base_color, goo_color, strict=False)
+        )  # type: ignore[assignment]
 
-            current_h = render_height * scale_y
-            current_w = render_width * scale_x
+        scale_y = 1.0 - (melt_pct * 0.85)
+        scale_x = 1.0 + (melt_pct * 0.8)
 
-            offset_y = (render_height - current_h) + (render_height * 0.05)
-            render_y = int(sprite_y + offset_y)
-            render_height = int(current_h)
-            render_width = int(current_w)
+        current_h = render_height * scale_y
+        current_w = render_width * scale_x
 
-            if bot.disintegrate_timer > 0:
-                dis_pct = bot.disintegrate_timer / 100.0
-                radius_mult = 1.0 - dis_pct
-                if radius_mult <= 0:
-                    return
-                pygame.draw.ellipse(
-                    screen,
-                    base_color,
-                    (
-                        int(center_x - render_width / 2 * radius_mult),
-                        int(render_y + render_height - 10),
-                        int(render_width * radius_mult),
-                        int(20 * radius_mult),
-                    ),
-                )
-                return
+        offset_y = (render_height - current_h) + (render_height * 0.05)
+        render_y = int(sprite_y + offset_y)
+        render_height = int(current_h)
+        render_width = int(current_w)
 
-        # Delegate to specialized renderer
-        # Delegate to specialized renderer
-        renderer = BotStyleRendererFactory.get_renderer(visual_style)
-        if renderer:
-            renderer.render(
+        if bot.disintegrate_timer > 0:
+            dis_pct = bot.disintegrate_timer / 100.0
+            radius_mult = 1.0 - dis_pct
+            if radius_mult <= 0:
+                return None
+            pygame.draw.ellipse(
                 screen,
-                bot,
-                center_x,
-                render_y,
-                render_width,
-                render_height,
                 base_color,
-                config,
+                (
+                    int(center_x - render_width / 2 * radius_mult),
+                    int(render_y + render_height - 10),
+                    int(render_width * radius_mult),
+                    int(20 * radius_mult),
+                ),
             )
+            return None
+
+        return render_y, render_width, render_height, base_color  # type: ignore[return-value]


### PR DESCRIPTION
## Wave 6: Function Decomposition (Shared Module)

### Problem
4 functions in  exceeded 100 lines, violating the orthogonality criterion:
-  — **102 lines**
-  — **188 lines**
-  — **232 lines**
-  — **128 lines**

### Solution
Decomposed into **16 focused sub-methods** (pure extract-method refactoring, zero behaviour changes):

| Original Function | Lines | New Methods | Max Method Size |
|---|---|---|---|
|  | 102 | 3 methods | 55 lines |
|  | 188 | 5 methods | 87 lines |
|  | 232 | 6 methods | 71 lines |
|  | 128 | 2 methods | 43 lines |

### Result
- **0 functions > 100 lines** in  (down from 4)
- All 226 tests pass ✅
- Ruff + Black clean ✅
- No public API changes — purely internal method extraction

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly extract-method refactoring in the core render path, but it touches wall/sprite rendering and cache keys/flow, so small logic differences could cause visual regressions or performance changes.
> 
> **Overview**
> Refactors shared rendering code by extracting large blocks into focused helpers across `BotRenderer` and `Raycaster`, keeping the main wall/sprite/projectile rendering loops shorter and easier to follow.
> 
> In `bot_renderer.py`, item rendering and death (melt/disintegrate) animation logic are moved into `_render_item_sprite` and `_render_death_animation`. In `raycaster.py`, wall rendering is split into theme resolution and per-column textured/solid render helpers, sprite drawing is decomposed into cached-surface creation, z-buffer visibility scanning, and two blit strategies, and projectile weapon-specific effects are centralized in `_draw_projectile_effect`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14ceadb396a11eced5bd3da57abc259d53d009e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->