### PR TITLE
feat(gameplay): Enemy Scoring

### DIFF
--- a/src/games/QuatGolf/src/main.cpp
+++ b/src/games/QuatGolf/src/main.cpp
@@ -77,6 +77,7 @@ struct App {
     bool  charging = false;
     bool  ball_in_play = false;
     int   stroke_count = 0;
+    int   total_score = 0; // Game score (points)
     std::vector<int> scores;  // Per-hole stroke count
 
     // Visual
@@ -505,7 +506,8 @@ void update(App& app, float dt) {
     // Enemy collision
     if (app.ball.in_flight || app.ball.rolling) {
         qe::math::Vec3 normal;
-        if (app.enemy_manager.check_collision(app.ball.position, app.physics.constants.radius, normal)) {
+        int points = app.enemy_manager.check_collision(app.ball.position, app.physics.constants.radius, normal);
+        if (points > 0) {
             // Reflect velocity
             float v_dot_n = app.ball.velocity.dot(normal);
             // Only reflect if moving towards enemy
@@ -513,7 +515,8 @@ void update(App& app, float dt) {
                  app.ball.velocity = app.ball.velocity - normal * (2.0f * v_dot_n);
                  // Add some energy loss and maybe randomness
                  app.ball.velocity = app.ball.velocity * 0.7f;
-                 std::cout << "Bonk! Enemy hit.\n";
+                 app.total_score += points;
+                 std::cout << "Bonk! Enemy hit. +" << points << " Points (Total: " << app.total_score << ")\n";
             }
         }
     }
@@ -703,6 +706,7 @@ void update_title(App& app) {
     std::ostringstream t;
     t << "QuatGolf | " << static_cast<int>(app.current_fps) << " FPS"
       << " | Hole " << hole.number << " Par " << hole.par
+      << " | Score: " << app.total_score
       << " | " << qg::game::CLUBS[app.selected_club].name
       << " | Strokes: " << app.stroke_count
       << " | " << static_cast<int>(dist_to_pin) << "m to pin"

--- a/src/games/shared/cpp/game/EnemyManager.h
+++ b/src/games/shared/cpp/game/EnemyManager.h
@@ -57,7 +57,7 @@ public:
         }
     }
 
-    bool check_collision(const math::Vec3& pos, float r, math::Vec3& normal) {
+    int check_collision(const math::Vec3& pos, float r, math::Vec3& normal) {
         float depth;
         for (auto& e : enemies) {
             if (e->check_collision(pos, r, normal, depth)) {
@@ -65,11 +65,12 @@ public:
                 if (e->state != EnemyState::Panic) {
                     e->state = EnemyState::Panic;
                     e->state_timer = 0;
+                    return 100; // 100 points for first hit
                 }
-                return true;
+                return 10; // 10 points for subsequent hits? Or just 0?
             }
         }
-        return false;
+        return 0;        
     }
 };
 


### PR DESCRIPTION
Adds rudimentary scoring system: 100 points for first hit on an enemy (triggering Panic), 10 points for subsequent hits. Score is displayed in window title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized gameplay/UI change; primary risk is minor API signature change for `EnemyManager::check_collision`, but it appears only used by QuatGolf.
> 
> **Overview**
> QuatGolf now tracks a running *points* score for ball–enemy collisions: `EnemyManager::check_collision` changes from a boolean to returning awarded points (100 on first hit that triggers `Panic`, 10 on subsequent hits, 0 otherwise).
> 
> `main.cpp` adds `total_score`, increments it on collision, prints a points message, and shows the current score in the SDL window title.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c6ead8c4729059a0daf8f11905eeb772a39cd01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->