### PR TITLE
feat(visuals): Particle Effects

### DIFF
--- a/src/games/QuatGolf/src/main.cpp
+++ b/src/games/QuatGolf/src/main.cpp
@@ -27,6 +27,7 @@
 #include "renderer/Mesh.h"
 #include "renderer/Shader.h"
 #include "game/EnemyManager.h"
+#include "game/ParticleSystem.h"
 #include "renderer/Texture.h"
 
 #include <SDL.h>
@@ -65,6 +66,7 @@ struct App {
     // Entities
     // Entities
     qe::game::EnemyManager enemy_manager;
+    qe::game::ParticleSystem particle_system;
 
     // Ball state
     qg::physics::BallPhysics physics;
@@ -275,6 +277,7 @@ void init_assets(App& app) {
 
     // Humanoid Enemies
     app.enemy_manager.init();
+    app.particle_system.init();
     
     // Spawn a few sample enemies
     app.enemy_manager.spawn("grunt", {2.0f, 0.0f, 2.0f});
@@ -517,9 +520,15 @@ void update(App& app, float dt) {
                  app.ball.velocity = app.ball.velocity * 0.7f;
                  app.total_score += points;
                  std::cout << "Bonk! Enemy hit. +" << points << " Points (Total: " << app.total_score << ")\n";
+                 
+                 // Spawn particles
+                 app.particle_system.spawn(app.ball.position, 20, {1.0f, 0.8f, 0.2f});
             }
         }
     }
+
+    // Update Particles
+    app.particle_system.update(dt);
 
     // Check if ball in water — penalty
     if (app.ball.in_water) {
@@ -625,6 +634,9 @@ void render_world(App& app) {
 
     // Enemies
     app.enemy_manager.draw(app.world_shader);
+
+    // Particles
+    app.particle_system.draw(app.world_shader);
 
     // Terrain
     app.world_shader.set_mat4("uModel", Mat4::identity());

--- a/src/games/shared/cpp/game/ParticleSystem.h
+++ b/src/games/shared/cpp/game/ParticleSystem.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "renderer/Shader.h"
+#include "renderer/Mesh.h"
+#include "math/Vec3.h"
+#include "math/Mat4.h"
+
+#include <vector>
+#include <memory>
+#include <random>
+
+namespace qe {
+namespace game {
+
+struct Particle {
+    math::Vec3 position;
+    math::Vec3 velocity;
+    math::Vec3 color;
+    float life = 0.0f; // Remaining life
+    float max_life = 1.0f;
+    float scale = 0.1f;
+};
+
+class ParticleSystem {
+public:
+    std::vector<Particle> particles;
+    std::shared_ptr<renderer::Mesh> particle_mesh; // Cube?
+
+    ParticleSystem() = default;
+
+    void init() {
+        // Use standard cube for particles
+        particle_mesh = std::make_shared<renderer::Mesh>(renderer::Mesh::create_cube());
+    }
+
+    void spawn(const math::Vec3& pos, int count, const math::Vec3& color) {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_real_distribution<> dis(-1.0, 1.0);
+
+        for (int i = 0; i < count; ++i) {
+            Particle p;
+            p.position = pos;
+            p.velocity = math::Vec3(dis(gen), dis(gen)+2.0f, dis(gen)).normalized() * (dis(gen) + 2.0f); // Upward burst
+            p.color = color;
+            p.life = 1.0f + static_cast<float>(dis(gen)) * 0.5f;
+            p.max_life = p.life;
+            p.scale = 0.05f + static_cast<float>(dis(gen)) * 0.02f;
+            particles.push_back(p);
+        }
+    }
+
+    void update(float dt) {
+        for (auto it = particles.begin(); it != particles.end();) {
+            it->life -= dt;
+            if (it->life <= 0) {
+                it = particles.erase(it);
+            } else {
+                // Physics
+                it->velocity.y -= 9.8f * dt; // Gravity
+                it->position = it->position + it->velocity * dt;
+                
+                // Ground collision (simple)
+                if (it->position.y < 0) {
+                    it->position.y = 0;
+                    it->velocity.y *= -0.5f;
+                    it->velocity.x *= 0.8f;
+                    it->velocity.z *= 0.8f;
+                }
+                ++it;
+            }
+        }
+    }
+
+    void draw(renderer::Shader& shader) {
+        if (!particle_mesh) return;
+
+        // Setup common state
+        shader.set_int("uUseTexture", 0);
+
+        for (const auto& p : particles) {
+            math::Mat4 model = math::Mat4::identity();
+            model = math::Mat4::translate(p.position) * math::Mat4::scale(p.scale);
+            
+            // Billboard rotation (face camera)?
+            // For now just world aligned.
+            
+            shader.set_mat4("uModel", model);
+            shader.set_vec3("uColor", p.color); // Needs fragment shader support or use ambient/diffuse uniform trick
+            
+            particle_mesh->draw();
+        }
+    }
+};
+
+} // namespace game
+} // namespace qe


### PR DESCRIPTION
Adds a geometric ParticleSystem that spawns cube debris when enemies are hit. Features physics (gravity, ground bounce) and lifetime management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new always-updated/drawn particle simulation and per-hit spawning, which may impact performance and relies on shader support for `uColor`.
> 
> **Overview**
> Adds a new shared `ParticleSystem` (CPU-simulated cube particles with random initial velocity, gravity, ground bounce, lifetime expiry, and per-particle draw).
> 
> Integrates it into QuatGolf by initializing it during asset setup, spawning particles when the ball collides with and scores points on an enemy, updating particles every frame, and drawing them in `render_world`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eb0cb8f421d2a008a53463ea4f421f549a3465f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->