### PR TITLE
feat(optimization): GPU Instancing for Particles

### DIFF
--- a/src/games/QuatGolf/shaders/particle_instanced.frag
+++ b/src/games/QuatGolf/shaders/particle_instanced.frag
@@ -1,0 +1,24 @@
+#version 330 core
+
+in vec3 vWorldPos;
+in vec3 vNormal;
+in vec3 vColor;
+in vec2 vUV;
+
+out vec4 FragColor;
+
+uniform vec3 uLightDir = vec3(0.5, 1.0, 0.3); // Simple directional light
+uniform vec3 uSunColor = vec3(1.0, 1.0, 0.9);
+uniform vec3 uAmbient  = vec3(0.3, 0.3, 0.4);
+
+void main() {
+    // Lambert
+    vec3 N = normalize(vNormal);
+    vec3 L = normalize(uLightDir);
+    float diff = max(dot(N, L), 0.0);
+    
+    vec3 lighting = uAmbient + uSunColor * diff;
+    vec3 finalColor = vColor * lighting;
+    
+    FragColor = vec4(finalColor, 1.0);
+}

--- a/src/games/QuatGolf/shaders/particle_instanced.vert
+++ b/src/games/QuatGolf/shaders/particle_instanced.vert
@@ -1,0 +1,27 @@
+#version 330 core
+
+layout(location = 0) in vec3 aPosition;
+layout(location = 1) in vec3 aNormal;
+layout(location = 2) in vec3 aColor;
+layout(location = 3) in vec2 aUV;
+
+// Instanced Attributes
+layout(location = 4) in mat4 aInstanceModel; // Occupies 4, 5, 6, 7
+layout(location = 8) in vec3 aInstanceColor;
+
+uniform mat4 uViewProjection;
+
+out vec3 vWorldPos;
+out vec3 vNormal;
+out vec3 vColor;
+out vec2 vUV;
+
+void main() {
+    mat4 model = aInstanceModel;
+    vec4 worldPos = model * vec4(aPosition, 1.0);
+    vWorldPos = worldPos.xyz;
+    vNormal = mat3(model) * aNormal;
+    vColor = aInstanceColor;
+    vUV = aUV;
+    gl_Position = uViewProjection * worldPos;
+}

--- a/src/games/QuatGolf/src/main.cpp
+++ b/src/games/QuatGolf/src/main.cpp
@@ -636,7 +636,7 @@ void render_world(App& app) {
     app.enemy_manager.draw(app.world_shader);
 
     // Particles
-    app.particle_system.draw(app.world_shader);
+    app.particle_system.draw(view_proj);
 
     // Terrain
     app.world_shader.set_mat4("uModel", Mat4::identity());

--- a/src/games/shared/cpp/renderer/Mesh.h
+++ b/src/games/shared/cpp/renderer/Mesh.h
@@ -81,6 +81,12 @@ public:
         gl::glBindVertexArray(0);
     }
 
+    void draw_instanced(GLsizei instance_count) const {
+        gl::glBindVertexArray(vao);
+        gl::glDrawElementsInstanced(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, nullptr, instance_count);
+        gl::glBindVertexArray(0);
+    }
+
     void destroy() {
         if (ebo) { gl::glDeleteBuffers(1, &ebo); ebo = 0; }
         if (vbo) { gl::glDeleteBuffers(1, &vbo); vbo = 0; }


### PR DESCRIPTION
Implements glDrawElementsInstanced for particle system to reduce draw calls. Adds new instanced shaders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level OpenGL rendering (VAO/VBO attribute setup, buffer uploads, new shader pipeline), so mistakes can cause rendering corruption or crashes, though the change is scoped to particles.
> 
> **Overview**
> Particle rendering is rewritten to use **GPU instancing**: `ParticleSystem::draw` now batches per-particle model matrices and colors into instance VBOs and renders all particles via a single `glDrawElementsInstanced` call.
> 
> This adds new instanced particle shaders (`particle_instanced.vert`/`.frag`) with simple Lambert lighting and extends `Mesh` with `draw_instanced()`. The QuatGolf render loop is updated to pass the view-projection matrix into the new particle draw API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e9f2be005a6f2e0999643b659d86fe90d491b80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->