### PR TITLE
refactor: convert 121 print() calls to logging (fixes #465)

### DIFF
--- a/convert_icon.py
+++ b/convert_icon.py
@@ -1,4 +1,9 @@
+import logging
+
 from PIL import Image
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 src = r"c:\Users\diete\Repositories\Games\launcher_assets\force_field_icon.png"
 dst = r"c:\Users\diete\Repositories\Games\games\Force_Field\force_field_icon.ico"
@@ -6,6 +11,6 @@ dst = r"c:\Users\diete\Repositories\Games\games\Force_Field\force_field_icon.ico
 try:
     img = Image.open(src)
     img.save(dst, format="ICO", sizes=[(256, 256)])
-    print(f"Converted {src} to {dst}")
+    logger.info("Converted %s to %s", src, dst)
 except Exception as e:
-    print(f"Error: {e}")
+    logger.error("Error: %s", e)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,10 @@
+import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def get_test_environment(game_path: Path, root_dir: Path) -> dict[str, str]:
@@ -19,31 +22,29 @@ def get_test_environment(game_path: Path, root_dir: Path) -> dict[str, str]:
 
 def run_game_tests(name: str, game_path: Path, root_dir: Path) -> bool:
     """Run tests for a single game and return success status."""
-    print(f"=== Running tests for {name} ===")
+    logger.info("=== Running tests for %s ===", name)
     test_path = game_path / "tests"
 
     if not test_path.exists():
-        print(f"No tests found for {name} at {test_path}")
+        logger.warning("No tests found for %s at %s", name, test_path)
         return True
 
     env = get_test_environment(game_path, root_dir)
 
     try:
         cmd = [sys.executable, "-m", "pytest", str(test_path)]
-        print(f"Running: {' '.join(cmd)}")
+        logger.info("Running: %s", " ".join(cmd))
         result = subprocess.run(cmd, env=env, capture_output=False)
 
         if result.returncode != 0:
-            print(f"Tests failed for {name}")
+            logger.error("Tests failed for %s", name)
             return False
         else:
-            print(f"Tests passed for {name}")
+            logger.info("Tests passed for %s", name)
             return True
     except Exception as e:
-        print(f"Error running tests for {name}: {e}")
+        logger.error("Error running tests for %s: %s", name, e)
         return False
-    finally:
-        print("\n")
 
 
 def run_tests() -> None:
@@ -69,4 +70,5 @@ def run_tests() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     run_tests()

--- a/scripts/generate_issues_report.py
+++ b/scripts/generate_issues_report.py
@@ -4,7 +4,10 @@ Generate a report of issues to be created based on assessment scores.
 """
 
 import json
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -12,14 +15,14 @@ def main():
     output_path = Path("docs/assessments/ISSUES_TO_CREATE.md")
 
     if not summary_path.exists():
-        print(f"Error: {summary_path} not found.")
+        logger.error("%s not found.", summary_path)
         return
 
     try:
         with open(summary_path) as f:
             data = json.load(f)
     except Exception as e:
-        print(f"Error loading JSON: {e}")
+        logger.error("Error loading JSON: %s", e)
         return
 
     category_scores = data.get("category_scores", {})
@@ -38,14 +41,16 @@ def main():
             f.write("# Issues to Create\n\n")
             f.write("\n".join(issues))
             f.write("\n")
-            print(
-                f"Found {len(issues)} categories with score < 5. "
-                f"Report saved to {output_path}"
+            logger.info(
+                "Found %d categories with score < 5. Report saved to %s",
+                len(issues),
+                output_path,
             )
         else:
             f.write("No categories scored below 5. No issues to create.\n")
-            print(f"No categories scored below 5. Report saved to {output_path}")
+            logger.info("No categories scored below 5. Report saved to %s", output_path)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     main()

--- a/scripts/mypy_autofix_agent.py
+++ b/scripts/mypy_autofix_agent.py
@@ -23,12 +23,15 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import logging
 import re
 import subprocess
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -330,7 +333,7 @@ def fix_union_attr(lines: list[str], error: MypyError) -> Fix | None:
     lines.insert(idx, assert_line)
 
     narrowing_desc = (
-        f"Add isinstance({var_name}, {target_type})" " narrowing for union-attr"
+        f"Add isinstance({var_name}, {target_type}) narrowing for union-attr"
     )
     return Fix(
         file=error.file,
@@ -521,16 +524,16 @@ def run_agent(
 
     # Step 1: Run mypy
     if verbose:
-        print(f">>> Running mypy on targets: {targets or 'default'}...")
+        logger.info("Running mypy on targets: %s...", targets or "default")
     output = run_mypy(config_file, targets)
     errors = parse_mypy_output(output)
     report.total_errors = len(errors)
 
     if verbose:
-        print(f">>> Found {len(errors)} mypy errors")
+        logger.info("Found %d mypy errors", len(errors))
 
     if not errors:
-        print("No mypy errors found.")
+        logger.info("No mypy errors found.")
         return report
 
     # Step 2: Group errors by file
@@ -596,10 +599,12 @@ def run_agent(
                     f"  [{fix.strategy}] {fix.file}:{fix.line} - {fix.description}"
                 )
                 if verbose:
-                    print(
-                        f"  FIX: {fix.file}:{fix.line}"
-                        f" [{fix.strategy}]"
-                        f" {fix.description}"
+                    logger.info(
+                        "  FIX: %s:%d [%s] %s",
+                        fix.file,
+                        fix.line,
+                        fix.strategy,
+                        fix.description,
                     )
             else:
                 skip_msg = (
@@ -621,31 +626,31 @@ def run_agent(
     return report
 
 
-def print_report(report: AgentReport) -> None:
-    """Print a human-readable report."""
-    print("\n" + "=" * 60)
-    print("  MYPY AUTOFIX AGENT REPORT")
-    print("=" * 60)
-    print(f"  Total mypy errors found:  {report.total_errors}")
-    print(f"  Errors fixed:             {report.errors_fixed}")
-    print(f"    Real fixes:             {report.real_fixes}")
-    print(f"    Suppressions:           {report.suppressions}")
-    print(f"  Files modified:           {len(report.files_modified)}")
+def log_report(report: AgentReport) -> None:
+    """Log a human-readable report."""
+    logger.info("=" * 60)
+    logger.info("  MYPY AUTOFIX AGENT REPORT")
+    logger.info("=" * 60)
+    logger.info("  Total mypy errors found:  %d", report.total_errors)
+    logger.info("  Errors fixed:             %d", report.errors_fixed)
+    logger.info("    Real fixes:             %d", report.real_fixes)
+    logger.info("    Suppressions:           %d", report.suppressions)
+    logger.info("  Files modified:           %d", len(report.files_modified))
 
     if report.fixes_applied:
-        print("\n  Fixes applied:")
+        logger.info("  Fixes applied:")
         for fix_desc in report.fixes_applied:
-            print(f"  {fix_desc}")
+            logger.info("  %s", fix_desc)
 
     if report.skipped_reasons:
-        print(f"\n  Skipped ({len(report.skipped_reasons)}):")
+        logger.info("  Skipped (%d):", len(report.skipped_reasons))
         # Only show first 10 skipped reasons
         for reason in report.skipped_reasons[:10]:
-            print(f"    - {reason}")
+            logger.info("    - %s", reason)
         if len(report.skipped_reasons) > 10:
-            print(f"    ... and {len(report.skipped_reasons) - 10} more")
+            logger.info("    ... and %d more", len(report.skipped_reasons) - 10)
 
-    print("=" * 60)
+    logger.info("=" * 60)
 
 
 def main() -> int:
@@ -697,7 +702,7 @@ def main() -> int:
         targets=args.targets,
     )
 
-    print_report(report)
+    log_report(report)
 
     # Exit code: 0 if any fixes were applied, 1 if no fixes possible
     if report.errors_fixed > 0:
@@ -708,4 +713,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     sys.exit(main())

--- a/scripts/pragmatic_programmer_review.py
+++ b/scripts/pragmatic_programmer_review.py
@@ -20,6 +20,7 @@ import argparse
 import ast
 import hashlib
 import json
+import logging
 import re
 import sys
 from collections import defaultdict
@@ -31,19 +32,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-
-# Mock imports/utils if shared/python doesn't exist in all repos
-# We will define minimal utils here to ensure standalone execution
-def setup_script_logging(name):
-    import logging
-
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
-    return logging.getLogger(name)
-
-
-logger = setup_script_logging(__name__)
+logger = logging.getLogger(__name__)
 
 # Constants for Principles
 PRINCIPLES = {
@@ -115,7 +104,6 @@ def check_dry_violations(files: list[Path]) -> list[dict]:
     issues = []
     chunk_size = 6
     code_blocks = defaultdict(list)
-    # magic_numbers removed (unused)
 
     for file_path in files:
         try:
@@ -244,7 +232,7 @@ def check_testing(root_path: Path) -> list[dict]:
 
 
 def run_review(root_path: Path):
-    logger.info(f"Running Pragmatic Review on {root_path}")
+    logger.info("Running Pragmatic Review on %s", root_path)
     files = find_python_files(root_path)
 
     all_issues = []
@@ -297,7 +285,11 @@ if __name__ == "__main__":
     parser.add_argument("--json-output", type=Path)
     args = parser.parse_args()
 
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+
     repo_root = Path.cwd()
     results = run_review(repo_root)
     generate_markdown_report(results, args.output)
-    print(f"Report generated at {args.output}")
+    logger.info("Report generated at %s", args.output)

--- a/scripts/run_all_assessments.py
+++ b/scripts/run_all_assessments.py
@@ -3,9 +3,12 @@
 Run all assessments (A-O) and generate individual reports.
 """
 
+import logging
 import subprocess
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Mapping of assessment ID to name
 ASSESSMENTS = {
@@ -39,19 +42,20 @@ def main():
         output_file = output_dir / f"Assessment_{assessment_id}_{name}.md"
         cmd = base_cmd + ["--assessment", assessment_id, "--output", str(output_file)]
 
-        print(f"Running Assessment {assessment_id} ({name})...")
+        logger.info("Running Assessment %s (%s)...", assessment_id, name)
         try:
             subprocess.run(cmd, check=True)
         except subprocess.CalledProcessError:
-            print(f"ERROR: Assessment {assessment_id} failed.")
+            logger.error("Assessment %s failed.", assessment_id)
             failed.append(assessment_id)
 
     if failed:
-        print(f"\nFailed assessments: {', '.join(failed)}")
+        logger.error("Failed assessments: %s", ", ".join(failed))
         sys.exit(1)
 
-    print("\nAll assessments completed successfully.")
+    logger.info("All assessments completed successfully.")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     main()

--- a/scripts/setup/create_icon_and_shortcut.py
+++ b/scripts/setup/create_icon_and_shortcut.py
@@ -3,15 +3,18 @@
 Create a proper ICO file from PNG and desktop shortcut for Games Launcher
 """
 
+import logging
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
+logger = logging.getLogger(__name__)
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.shared.subprocess_utils import run_powershell
+from scripts.shared.subprocess_utils import run_powershell  # noqa: E402
 
 # Global variables for PIL availability
 PIL_AVAILABLE = False
@@ -39,10 +42,10 @@ def get_desktop_path() -> Path:
             if desktop_path:
                 return Path(desktop_path)
     except Exception as e:
-        print(f"⚠️  Failed to get Desktop path via PowerShell: {e}")
+        logger.warning("Failed to get Desktop path via PowerShell: %s", e)
 
     # Fallback to home/Desktop if PowerShell fails
-    print("⚠️  Using fallback Desktop path")
+    logger.warning("Using fallback Desktop path")
     return Path.home() / "Desktop"
 
 
@@ -51,7 +54,7 @@ def create_ico_from_png(png_path: Path, ico_path: Path) -> bool:
     global PIL_AVAILABLE, PIL_Image
 
     if not PIL_AVAILABLE or PIL_Image is None:
-        print("PIL/Pillow not available, trying alternative method...")
+        logger.warning("PIL/Pillow not available, trying alternative method...")
         return False
 
     try:
@@ -77,11 +80,11 @@ def create_ico_from_png(png_path: Path, ico_path: Path) -> bool:
                 append_images=images[1:],
             )
 
-            print(f"✅ Successfully created ICO file: {ico_path}")
+            logger.info("Successfully created ICO file: %s", ico_path)
             return True
 
     except Exception as e:
-        print(f"❌ Error creating ICO file: {e}")
+        logger.error("Error creating ICO file: %s", e)
         return False
 
 
@@ -96,16 +99,16 @@ def create_desktop_shortcut() -> bool:
     desktop_path = get_desktop_path()
     shortcut_path = desktop_path / "Games Launcher.lnk"
 
-    print("🎮 Creating Games Launcher desktop shortcut...")
-    print(f"📁 Current directory: {current_dir}")
-    print(f"🖥️  Desktop path: {desktop_path}")
-    print(f"🎯 Launcher path: {launcher_path}")
-    print(f"🖼️  PNG icon: {png_icon_path}")
-    print(f"🎨 ICO icon: {ico_icon_path}")
+    logger.info("Creating Games Launcher desktop shortcut...")
+    logger.info("Current directory: %s", current_dir)
+    logger.info("Desktop path: %s", desktop_path)
+    logger.info("Launcher path: %s", launcher_path)
+    logger.info("PNG icon: %s", png_icon_path)
+    logger.info("ICO icon: %s", ico_icon_path)
 
     # Check if PNG icon exists
     if not png_icon_path.exists():
-        print(f"❌ PNG icon not found: {png_icon_path}")
+        logger.error("PNG icon not found: %s", png_icon_path)
         return False
 
     # Create ICO file from PNG
@@ -125,9 +128,9 @@ $Shortcut.WindowStyle = 1
 
     if ico_created and ico_icon_path.exists():
         ps_script += f"$Shortcut.IconLocation = '{ico_icon_path}'\n"
-        print("🎨 Using custom ICO icon")
+        logger.info("Using custom ICO icon")
     else:
-        print("⚠️  Using default Python icon")
+        logger.warning("Using default Python icon")
 
     ps_script += "$Shortcut.Save()\n"
     ps_script += f"Write-Host 'Desktop shortcut created: {shortcut_path}'\n"
@@ -137,20 +140,20 @@ $Shortcut.WindowStyle = 1
         result = run_powershell(ps_script, capture_output=True, text=True)
 
         if result.returncode == 0:
-            print("✅ PowerShell execution successful:")
-            print(result.stdout)
+            logger.info("PowerShell execution successful:")
+            logger.info(result.stdout)
 
             if shortcut_path.exists():
-                print("🎉 Desktop shortcut created successfully!")
-            print(f"📍 Location: {shortcut_path}")
+                logger.info("Desktop shortcut created successfully!")
+            logger.info("Location: %s", shortcut_path)
             return True
         else:
-            print("❌ Shortcut file not found after creation")
+            logger.error("Shortcut file not found after creation")
             return False
 
     except subprocess.CalledProcessError as e:
-        print(f"❌ PowerShell error: {e}")
-        print(f"Error output: {e.stderr}")
+        logger.error("PowerShell error: %s", e)
+        logger.error("Error output: %s", e.stderr)
         return False
 
 
@@ -158,32 +161,35 @@ def main() -> None:
     """Main function"""
     global PIL_AVAILABLE, PIL_Image
 
-    print("🚀 Games Launcher Desktop Shortcut Creator")
-    print("=" * 50)
+    logger.info("Games Launcher Desktop Shortcut Creator")
+    logger.info("=" * 50)
 
     if not PIL_AVAILABLE:
-        print("⚠️  PIL/Pillow not installed. Installing...")
+        logger.warning("PIL/Pillow not installed. Installing...")
         try:
             subprocess.check_call([sys.executable, "-m", "pip", "install", "Pillow"])
-            print("✅ Pillow installed successfully!")
+            logger.info("Pillow installed successfully!")
             # Re-import after installation and update global state
             from PIL import Image as _PIL_Image
 
             PIL_Image = _PIL_Image
             PIL_AVAILABLE = True
-            print("📦 Pillow imported successfully!")
+            logger.info("Pillow imported successfully!")
         except Exception as e:
-            print(f"❌ Failed to install Pillow: {e}")
-            print("Continuing without custom icon conversion...")
+            logger.error("Failed to install Pillow: %s", e)
+            logger.warning("Continuing without custom icon conversion...")
 
     success = create_desktop_shortcut()
 
     if success:
-        print("\n🎉 SUCCESS! Your Games Launcher shortcut is ready!")
-        print("Look for 'Games Launcher' on your desktop with a cool Force Field icon!")
+        logger.info("SUCCESS! Your Games Launcher shortcut is ready!")
+        logger.info(
+            "Look for 'Games Launcher' on your desktop with a cool Force Field icon!"
+        )
     else:
-        print("\n❌ Something went wrong. Check the error messages above.")
+        logger.error("Something went wrong. Check the error messages above.")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     main()

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -12,14 +12,17 @@ Usage:
     python scripts/setup_hooks.py
 """
 
+import logging
 import subprocess
 import sys
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 
 def run_command(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
     """Run a command and return the result."""
-    print(f"  Running: {' '.join(cmd)}")
+    logger.info("  Running: %s", " ".join(cmd))
     return subprocess.run(cmd, check=check, capture_output=True, text=True)
 
 
@@ -34,31 +37,31 @@ def check_pre_commit_installed() -> bool:
 
 def install_pre_commit() -> None:
     """Install pre-commit via pip."""
-    print("\n[1/4] Installing pre-commit...")
+    logger.info("[1/4] Installing pre-commit...")
     if check_pre_commit_installed():
-        print("  pre-commit is already installed")
+        logger.info("  pre-commit is already installed")
     else:
         run_command([sys.executable, "-m", "pip", "install", "pre-commit"])
-        print("  pre-commit installed successfully")
+        logger.info("  pre-commit installed successfully")
 
 
 def install_hooks() -> None:
     """Install pre-commit hooks."""
-    print("\n[2/4] Installing pre-commit hooks...")
+    logger.info("[2/4] Installing pre-commit hooks...")
     run_command(["pre-commit", "install"])
-    print("  pre-commit hooks installed")
+    logger.info("  pre-commit hooks installed")
 
 
 def install_push_hooks() -> None:
     """Install pre-push hooks."""
-    print("\n[3/4] Installing pre-push hooks...")
+    logger.info("[3/4] Installing pre-push hooks...")
     run_command(["pre-commit", "install", "--hook-type", "pre-push"])
-    print("  pre-push hooks installed")
+    logger.info("  pre-push hooks installed")
 
 
 def install_dev_dependencies() -> None:
     """Install development dependencies for hooks."""
-    print("\n[4/4] Installing hook dependencies...")
+    logger.info("[4/4] Installing hook dependencies...")
     deps = [
         "ruff>=0.14.0",
         "black>=26.0.0",
@@ -69,36 +72,36 @@ def install_dev_dependencies() -> None:
         "pydantic",
     ]
     run_command([sys.executable, "-m", "pip", "install"] + deps)
-    print("  Dependencies installed")
+    logger.info("  Dependencies installed")
 
 
 def verify_installation() -> None:
     """Verify hooks are installed correctly."""
-    print("\n" + "=" * 60)
-    print("VERIFICATION")
-    print("=" * 60)
+    logger.info("=" * 60)
+    logger.info("VERIFICATION")
+    logger.info("=" * 60)
 
     git_hooks_dir = Path(".git/hooks")
     pre_commit_hook = git_hooks_dir / "pre-commit"
     pre_push_hook = git_hooks_dir / "pre-push"
 
     if pre_commit_hook.exists():
-        print(f"  [OK] pre-commit hook: {pre_commit_hook}")
+        logger.info("  [OK] pre-commit hook: %s", pre_commit_hook)
     else:
-        print(f"  [MISSING] pre-commit hook: {pre_commit_hook}")
+        logger.warning("  [MISSING] pre-commit hook: %s", pre_commit_hook)
 
     if pre_push_hook.exists():
-        print(f"  [OK] pre-push hook: {pre_push_hook}")
+        logger.info("  [OK] pre-push hook: %s", pre_push_hook)
     else:
-        print(f"  [MISSING] pre-push hook: {pre_push_hook}")
+        logger.warning("  [MISSING] pre-push hook: %s", pre_push_hook)
 
 
-def print_summary() -> None:
-    """Print usage summary."""
-    print("\n" + "=" * 60)
-    print("HOOK SUMMARY")
-    print("=" * 60)
-    print("""
+def log_summary() -> None:
+    """Log usage summary."""
+    logger.info("=" * 60)
+    logger.info("HOOK SUMMARY")
+    logger.info("=" * 60)
+    summary = """
 PRE-COMMIT (runs on every commit, <15 seconds):
   - ruff (lint + auto-fix)
   - black (format)
@@ -117,14 +120,16 @@ MANUAL COMMANDS:
   pre-commit run --all-files      # Run all pre-commit hooks
   pre-commit run --hook-stage pre-push  # Run pre-push hooks manually
   pre-commit autoupdate           # Update hook versions
-""")
+"""
+    for line in summary.strip().splitlines():
+        logger.info(line)
 
 
 def main() -> None:
     """Main entry point."""
-    print("=" * 60)
-    print("INSTALLING GIT HOOKS")
-    print("=" * 60)
+    logger.info("=" * 60)
+    logger.info("INSTALLING GIT HOOKS")
+    logger.info("=" * 60)
 
     try:
         install_pre_commit()
@@ -132,19 +137,20 @@ def main() -> None:
         install_push_hooks()
         install_dev_dependencies()
         verify_installation()
-        print_summary()
-        print("\n[SUCCESS] All hooks installed successfully!")
-        print("Your commits will now be checked locally before reaching CI.")
+        log_summary()
+        logger.info("[SUCCESS] All hooks installed successfully!")
+        logger.info("Your commits will now be checked locally before reaching CI.")
 
     except subprocess.CalledProcessError as e:
-        print(f"\n[ERROR] Command failed: {e}")
-        print(f"  stdout: {e.stdout}")
-        print(f"  stderr: {e.stderr}")
+        logger.error("Command failed: %s", e)
+        logger.error("  stdout: %s", e.stdout)
+        logger.error("  stderr: %s", e.stderr)
         sys.exit(1)
     except Exception as e:
-        print(f"\n[ERROR] Unexpected error: {e}")
+        logger.error("Unexpected error: %s", e)
         sys.exit(1)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     main()

--- a/scripts/shared/logging_config.py
+++ b/scripts/shared/logging_config.py
@@ -4,6 +4,7 @@ import logging
 
 
 def setup_script_logging(
+    name: str = __name__,
     level: int = logging.INFO,
     format_string: str = "%(levelname)s: %(message)s",
 ) -> logging.Logger:
@@ -11,11 +12,12 @@ def setup_script_logging(
     Configure logging for scripts with consistent formatting.
 
     Args:
-        level: The logging level to use
-        format_string: The format string for log messages
+        name: Logger name (typically ``__name__`` from the caller).
+        level: The logging level to use.
+        format_string: The format string for log messages.
 
     Returns:
-        A logger instance for the calling module
+        A logger instance for the calling module.
     """
     logging.basicConfig(level=level, format=format_string)
-    return logging.getLogger(__name__)
+    return logging.getLogger(name)

--- a/src/games/Force_Field/repro_map.py
+++ b/src/games/Force_Field/repro_map.py
@@ -1,14 +1,17 @@
+import logging
 import os
 import sys
+
+logger = logging.getLogger(__name__)
 
 # Add current dir to path
 sys.path.insert(0, os.getcwd())
 
-from src.map import Map
+from src.map import Map  # noqa: E402
 
 
 def test_map_size() -> None:
-    print("Testing Map Generation for Small Areas...")
+    logger.info("Testing Map Generation for Small Areas...")
     small_maps = 0
     total = 100
 
@@ -24,11 +27,12 @@ def test_map_size() -> None:
                     walkable += 1
 
         if walkable < 200:
-            print(f"Iter {i}: Map has only {walkable} walkable tiles!")
+            logger.warning("Iter %d: Map has only %d walkable tiles!", i, walkable)
             small_maps += 1
 
-    print(f"Total small maps (<200 tiles) out of {total}: {small_maps}")
+    logger.info("Total small maps (<200 tiles) out of %d: %d", total, small_maps)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     test_map_size()

--- a/src/games/Wizard_of_Wor/wizard_of_wor/create_asset.py
+++ b/src/games/Wizard_of_Wor/wizard_of_wor/create_asset.py
@@ -1,7 +1,10 @@
+import logging
 import os
 import random
 
 import pygame
+
+logger = logging.getLogger(__name__)
 
 
 def create_title_image() -> None:
@@ -57,8 +60,9 @@ def create_title_image() -> None:
     # Save
     path = os.path.join(os.path.dirname(__file__), "title.png")
     pygame.image.save(surface, path)
-    print(f"Created {path}")
+    logger.info("Created %s", path)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     create_title_image()

--- a/tools/generate_enemies.py
+++ b/tools/generate_enemies.py
@@ -1,5 +1,8 @@
+import logging
 import os
 import sys
+
+logger = logging.getLogger(__name__)
 
 # Add Tools repo to Python path
 # Try to find Tools repo relative to this script
@@ -27,9 +30,9 @@ try:
     )
     from humanoid_character_builder.core.body_parameters import BuildType
 
-    print("Successfully imported humanoid_character_builder")
+    logger.info("Successfully imported humanoid_character_builder")
 except ImportError as e:
-    print(f"Error importing humanoid_character_builder: {e}")
+    logger.error("Error importing humanoid_character_builder: %s", e)
     sys.exit(1)
 
 # Output to src/games/QuatGolf/assets/enemies relative to this script
@@ -39,7 +42,7 @@ OUTPUT_DIR = os.path.join(
 
 
 def generate_enemy(name, params):
-    print(f"Generating {name}...")
+    logger.info("Generating %s...", name)
     builder = CharacterBuilder()
     result = builder.build(params)
 
@@ -58,7 +61,7 @@ def generate_enemy(name, params):
     params.name = name
 
     result.export_urdf(enemy_dir)
-    print(f"Saved to {enemy_dir}/{name}.urdf")
+    logger.info("Saved to %s/%s.urdf", enemy_dir, name)
 
 
 def main():
@@ -97,4 +100,5 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     main()

--- a/tools/generate_icons.py
+++ b/tools/generate_icons.py
@@ -1,6 +1,9 @@
+import logging
 from pathlib import Path
 
 import pygame
+
+logger = logging.getLogger(__name__)
 
 # Initialize Pygame
 pygame.init()
@@ -28,7 +31,7 @@ COLORS = {
 def save_icon(surface: pygame.Surface, name: str) -> None:
     path = OUTPUT_DIR / f"{name}.png"
     pygame.image.save(surface, str(path))
-    print(f"Saved {path}")
+    logger.info("Saved %s", path)
 
 
 def create_force_field_icon() -> None:
@@ -160,6 +163,7 @@ def create_zombie_games_icon() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     create_force_field_icon()
     create_doom_icon()
     create_peanut_butter_panic_icon()

--- a/tools/scientific_auditor.py
+++ b/tools/scientific_auditor.py
@@ -1,7 +1,10 @@
 import ast
 import json
+import logging
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 RISKS = []
 
@@ -70,11 +73,12 @@ def main() -> None:
             sys.stderr.write(f"Error analyzing {py_file}: {e}\n")
 
     if RISKS:
-        print(json.dumps(RISKS, indent=2))  # noqa: T201
+        sys.stdout.write(json.dumps(RISKS, indent=2) + "\n")
         sys.exit(1)
     else:
-        print("[]")  # noqa: T201
+        sys.stdout.write("[]\n")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     main()


### PR DESCRIPTION
## Summary

- Replace all 121 `print()` statements across 14 files with proper `logging` module calls
- Add `logging.basicConfig()` to all entry-point scripts
- Update shared logging config to accept caller `name` for properly-named loggers
- Use `sys.stdout.write()` for machine-readable JSON output (scientific_auditor)
- Rename `print_report()` / `print_summary()` to `log_report()` / `log_summary()`

## Test plan

- [x] All 14 modified files pass `python3 -m py_compile`
- [x] Zero remaining `print()` calls in `src/`, `tools/`, `scripts/`, root scripts
- [x] All pre-commit hooks pass (ruff, black, no-print-in-src)
- [ ] CI/CD pipeline passes

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical logging refactors with minimal logic changes; primary risk is altered CLI/output behavior that could affect tooling expecting exact stdout formatting.
> 
> **Overview**
> Standardizes script output by replacing `print()` calls with `logging` across various root, `scripts/`, `tools/`, and game utility modules, and adding `logging.basicConfig(...)` in entry points to ensure consistent formatting.
> 
> Cleans up a couple of related behaviors: `mypy_autofix_agent` switches its report output to `log_report()` and `setup_hooks` logs its usage summary, `logging_config.setup_script_logging` now accepts a caller-provided logger name, and `scientific_auditor` emits machine-readable JSON via `sys.stdout.write()` instead of `print()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad93fce074690336ee92f1b627e957ebf2329c6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->