### PR TITLE
feat: add notes workspace with recycle bin (fixes #440)

### DIFF
--- a/src/games/shared/notes_workspace.py
+++ b/src/games/shared/notes_workspace.py
@@ -1,0 +1,214 @@
+"""Project-local notes workspace with recycle bin support.
+
+Provides a file-based notes system with CRUD operations, soft-delete
+via recycle bin semantics, and restore support. Designed for project-local
+persistence with reversible operations.
+
+Usage:
+    workspace = NotesWorkspace("/path/to/project")
+    note_id = workspace.create("My note title", "Note content here")
+    workspace.delete(note_id)       # Moves to recycle bin
+    workspace.restore(note_id)      # Restores from recycle bin
+    workspace.purge(note_id)        # Permanently deletes from bin
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from games.shared.contracts import ContractViolation, precondition
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Note:
+    """A single note with metadata."""
+
+    id: str
+    title: str
+    content: str
+    created_at: str
+    updated_at: str
+    deleted_at: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Note:
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+def _now_iso() -> str:
+    """Return current UTC time as ISO 8601 string."""
+    return datetime.now(tz=UTC).isoformat()
+
+
+class NotesWorkspace:
+    """File-based notes workspace with recycle bin.
+
+    Storage layout:
+        {workspace_dir}/
+            notes/          # Active notes (one JSON file each)
+            trash/          # Soft-deleted notes
+    """
+
+    def __init__(self, workspace_dir: str | Path) -> None:
+        self._root = Path(workspace_dir)
+        self._notes_dir = self._root / "notes"
+        self._trash_dir = self._root / "trash"
+        self._notes_dir.mkdir(parents=True, exist_ok=True)
+        self._trash_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- CRUD ---
+
+    @precondition(
+        lambda self, title, content="": bool(title.strip()),
+        "title must not be blank",
+    )
+    def create(self, title: str, content: str = "") -> str:
+        """Create a new note and persist it. Returns the note ID."""
+        now = _now_iso()
+        note = Note(
+            id=uuid.uuid4().hex[:12],
+            title=title.strip(),
+            content=content,
+            created_at=now,
+            updated_at=now,
+        )
+        self._save_note(note, self._notes_dir)
+        logger.info("Created note %s: %s", note.id, note.title)
+        return note.id
+
+    def get(self, note_id: str) -> Note | None:
+        """Retrieve an active note by ID, or None if not found."""
+        return self._load_note(note_id, self._notes_dir)
+
+    def list_notes(self) -> list[Note]:
+        """List all active (non-deleted) notes, newest first."""
+        notes = self._load_all(self._notes_dir)
+        notes.sort(key=lambda n: n.updated_at, reverse=True)
+        return notes
+
+    @precondition(
+        lambda self, note_id, **kw: bool(note_id),
+        "note_id must not be empty",
+    )
+    def update(
+        self,
+        note_id: str,
+        title: str | None = None,
+        content: str | None = None,
+    ) -> bool:
+        """Update title and/or content. Returns True if updated."""
+        note = self._load_note(note_id, self._notes_dir)
+        if note is None:
+            return False
+        if title is not None:
+            if not title.strip():
+                raise ContractViolation("title must not be blank")
+            note.title = title.strip()
+        if content is not None:
+            note.content = content
+        note.updated_at = _now_iso()
+        self._save_note(note, self._notes_dir)
+        logger.info("Updated note %s", note_id)
+        return True
+
+    # --- Recycle Bin ---
+
+    def delete(self, note_id: str) -> bool:
+        """Soft-delete: move note from notes/ to trash/. Returns True if moved."""
+        note = self._load_note(note_id, self._notes_dir)
+        if note is None:
+            return False
+        note.deleted_at = _now_iso()
+        self._save_note(note, self._trash_dir)
+        self._delete_file(note_id, self._notes_dir)
+        logger.info("Deleted note %s to recycle bin", note_id)
+        return True
+
+    def restore(self, note_id: str) -> bool:
+        """Restore a note from the recycle bin. Returns True if restored."""
+        note = self._load_note(note_id, self._trash_dir)
+        if note is None:
+            return False
+        note.deleted_at = None
+        note.updated_at = _now_iso()
+        self._save_note(note, self._notes_dir)
+        self._delete_file(note_id, self._trash_dir)
+        logger.info("Restored note %s from recycle bin", note_id)
+        return True
+
+    def list_trash(self) -> list[Note]:
+        """List all notes in the recycle bin, most recently deleted first."""
+        notes = self._load_all(self._trash_dir)
+        notes.sort(key=lambda n: n.deleted_at or "", reverse=True)
+        return notes
+
+    def purge(self, note_id: str) -> bool:
+        """Permanently delete a note from the recycle bin. Returns True if purged."""
+        if not self._note_path(note_id, self._trash_dir).exists():
+            return False
+        self._delete_file(note_id, self._trash_dir)
+        logger.info("Purged note %s permanently", note_id)
+        return True
+
+    def empty_trash(self) -> int:
+        """Permanently delete all notes in the recycle bin. Returns count purged."""
+        trashed = self._load_all(self._trash_dir)
+        for note in trashed:
+            self._delete_file(note.id, self._trash_dir)
+        logger.info("Emptied recycle bin (%d notes purged)", len(trashed))
+        return len(trashed)
+
+    # --- Bulk ---
+
+    def clear(self) -> int:
+        """Move all active notes to the recycle bin. Returns count deleted."""
+        active = self.list_notes()
+        for note in active:
+            self.delete(note.id)
+        return len(active)
+
+    # --- Persistence helpers ---
+
+    def _note_path(self, note_id: str, directory: Path) -> Path:
+        return directory / f"{note_id}.json"
+
+    def _save_note(self, note: Note, directory: Path) -> None:
+        path = self._note_path(note.id, directory)
+        path.write_text(json.dumps(note.to_dict(), indent=2), encoding="utf-8")
+
+    def _load_note(self, note_id: str, directory: Path) -> Note | None:
+        path = self._note_path(note_id, directory)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return Note.from_dict(data)
+        except (json.JSONDecodeError, KeyError):
+            logger.warning("Corrupt note file: %s", path)
+            return None
+
+    def _load_all(self, directory: Path) -> list[Note]:
+        notes = []
+        for path in directory.glob("*.json"):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                notes.append(Note.from_dict(data))
+            except (json.JSONDecodeError, KeyError):
+                logger.warning("Skipping corrupt note: %s", path)
+        return notes
+
+    def _delete_file(self, note_id: str, directory: Path) -> None:
+        path = self._note_path(note_id, directory)
+        if path.exists():
+            path.unlink()

--- a/tests/shared/test_notes_workspace.py
+++ b/tests/shared/test_notes_workspace.py
@@ -1,0 +1,286 @@
+"""Tests for NotesWorkspace — project-local notes with recycle bin.
+
+Covers: create, read, update, delete (soft), restore, purge, clear,
+persistence across instances, and Design by Contract violations.
+"""
+
+import pytest
+
+from games.shared.contracts import ContractViolation
+from games.shared.notes_workspace import Note, NotesWorkspace
+
+# --- Fixtures ---
+
+
+@pytest.fixture()
+def ws(tmp_path):
+    """Fresh workspace in a temporary directory."""
+    return NotesWorkspace(tmp_path / ".games_workspace")
+
+
+# --- Note dataclass ---
+
+
+class TestNote:
+    def test_to_dict_roundtrip(self):
+        note = Note(
+            id="abc123",
+            title="Hello",
+            content="World",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+        data = note.to_dict()
+        restored = Note.from_dict(data)
+        assert restored.id == note.id
+        assert restored.title == note.title
+        assert restored.content == note.content
+        assert restored.tags == []
+        assert restored.deleted_at is None
+
+    def test_from_dict_ignores_extra_keys(self):
+        data = {
+            "id": "x",
+            "title": "t",
+            "content": "c",
+            "created_at": "now",
+            "updated_at": "now",
+            "extra_field": "ignored",
+        }
+        note = Note.from_dict(data)
+        assert note.id == "x"
+
+    def test_tags_default_empty(self):
+        note = Note(id="a", title="b", content="c", created_at="", updated_at="")
+        assert note.tags == []
+
+
+# --- Create ---
+
+
+class TestCreate:
+    def test_create_returns_id(self, ws):
+        nid = ws.create("Test Note", "Some content")
+        assert isinstance(nid, str)
+        assert len(nid) == 12
+
+    def test_create_persists(self, ws):
+        nid = ws.create("Persisted", "Data here")
+        note = ws.get(nid)
+        assert note is not None
+        assert note.title == "Persisted"
+        assert note.content == "Data here"
+
+    def test_create_strips_title(self, ws):
+        nid = ws.create("  padded  ", "")
+        note = ws.get(nid)
+        assert note.title == "padded"
+
+    def test_create_blank_title_raises(self, ws):
+        with pytest.raises(ContractViolation):
+            ws.create("", "content")
+
+    def test_create_whitespace_title_raises(self, ws):
+        with pytest.raises(ContractViolation):
+            ws.create("   ", "content")
+
+    def test_create_sets_timestamps(self, ws):
+        nid = ws.create("Timed")
+        note = ws.get(nid)
+        assert note.created_at == note.updated_at
+        assert "T" in note.created_at  # ISO format
+
+
+# --- Read ---
+
+
+class TestRead:
+    def test_get_nonexistent_returns_none(self, ws):
+        assert ws.get("nonexistent") is None
+
+    def test_list_notes_empty(self, ws):
+        assert ws.list_notes() == []
+
+    def test_list_notes_order(self, ws):
+        import time
+
+        ws.create("First")
+        time.sleep(0.01)
+        ws.create("Second")
+        notes = ws.list_notes()
+        assert len(notes) == 2
+        assert notes[0].title == "Second"  # newest first
+
+    def test_list_notes_excludes_deleted(self, ws):
+        nid = ws.create("To Delete")
+        ws.delete(nid)
+        assert ws.list_notes() == []
+
+
+# --- Update ---
+
+
+class TestUpdate:
+    def test_update_title(self, ws):
+        nid = ws.create("Original")
+        assert ws.update(nid, title="Updated")
+        assert ws.get(nid).title == "Updated"
+
+    def test_update_content(self, ws):
+        nid = ws.create("Note", "old")
+        ws.update(nid, content="new")
+        assert ws.get(nid).content == "new"
+
+    def test_update_advances_timestamp(self, ws):
+        import time
+
+        nid = ws.create("Note")
+        old_ts = ws.get(nid).updated_at
+        time.sleep(0.01)
+        ws.update(nid, content="changed")
+        assert ws.get(nid).updated_at > old_ts
+
+    def test_update_nonexistent_returns_false(self, ws):
+        assert ws.update("nope", title="x") is False
+
+    def test_update_blank_title_raises(self, ws):
+        nid = ws.create("Note")
+        with pytest.raises(ContractViolation):
+            ws.update(nid, title="")
+
+    def test_update_empty_id_raises(self, ws):
+        with pytest.raises(ContractViolation):
+            ws.update("", title="x")
+
+
+# --- Delete (soft) ---
+
+
+class TestDelete:
+    def test_delete_moves_to_trash(self, ws):
+        nid = ws.create("Trashable")
+        assert ws.delete(nid)
+        assert ws.get(nid) is None
+        trash = ws.list_trash()
+        assert len(trash) == 1
+        assert trash[0].id == nid
+
+    def test_delete_sets_deleted_at(self, ws):
+        nid = ws.create("Note")
+        ws.delete(nid)
+        trashed = ws.list_trash()[0]
+        assert trashed.deleted_at is not None
+
+    def test_delete_nonexistent_returns_false(self, ws):
+        assert ws.delete("nope") is False
+
+    def test_delete_idempotent(self, ws):
+        nid = ws.create("Note")
+        assert ws.delete(nid)
+        assert ws.delete(nid) is False
+
+
+# --- Restore ---
+
+
+class TestRestore:
+    def test_restore_moves_back(self, ws):
+        nid = ws.create("Restorable")
+        ws.delete(nid)
+        assert ws.restore(nid)
+        assert ws.get(nid) is not None
+        assert ws.list_trash() == []
+
+    def test_restore_clears_deleted_at(self, ws):
+        nid = ws.create("Note")
+        ws.delete(nid)
+        ws.restore(nid)
+        note = ws.get(nid)
+        assert note.deleted_at is None
+
+    def test_restore_nonexistent_returns_false(self, ws):
+        assert ws.restore("nope") is False
+
+
+# --- Purge ---
+
+
+class TestPurge:
+    def test_purge_permanently_deletes(self, ws):
+        nid = ws.create("Gone")
+        ws.delete(nid)
+        assert ws.purge(nid)
+        assert ws.list_trash() == []
+        assert ws.get(nid) is None
+
+    def test_purge_nonexistent_returns_false(self, ws):
+        assert ws.purge("nope") is False
+
+
+# --- Empty Trash ---
+
+
+class TestEmptyTrash:
+    def test_empty_trash(self, ws):
+        ws.create("A")
+        ws.create("B")
+        ws.clear()
+        count = ws.empty_trash()
+        assert count == 2
+        assert ws.list_trash() == []
+
+    def test_empty_trash_when_empty(self, ws):
+        assert ws.empty_trash() == 0
+
+
+# --- Clear ---
+
+
+class TestClear:
+    def test_clear_moves_all_to_trash(self, ws):
+        ws.create("A")
+        ws.create("B")
+        ws.create("C")
+        count = ws.clear()
+        assert count == 3
+        assert ws.list_notes() == []
+        assert len(ws.list_trash()) == 3
+
+    def test_clear_empty_workspace(self, ws):
+        assert ws.clear() == 0
+
+
+# --- Persistence ---
+
+
+class TestPersistence:
+    def test_survives_reinstantiation(self, tmp_path):
+        ws_dir = tmp_path / ".games_workspace"
+        ws1 = NotesWorkspace(ws_dir)
+        nid = ws1.create("Persistent", "content")
+
+        ws2 = NotesWorkspace(ws_dir)
+        note = ws2.get(nid)
+        assert note is not None
+        assert note.title == "Persistent"
+
+    def test_trash_survives_reinstantiation(self, tmp_path):
+        ws_dir = tmp_path / ".games_workspace"
+        ws1 = NotesWorkspace(ws_dir)
+        nid = ws1.create("Trashed")
+        ws1.delete(nid)
+
+        ws2 = NotesWorkspace(ws_dir)
+        trash = ws2.list_trash()
+        assert len(trash) == 1
+        assert trash[0].id == nid
+
+    def test_corrupt_file_skipped(self, tmp_path):
+        ws_dir = tmp_path / ".games_workspace"
+        ws = NotesWorkspace(ws_dir)
+        ws.create("Good")
+        # Write a corrupt file
+        (ws_dir / "notes" / "corrupt.json").write_text("not json", encoding="utf-8")
+        notes = ws.list_notes()
+        assert len(notes) == 1
+        assert notes[0].title == "Good"


### PR DESCRIPTION
## Summary

- New module `src/games/shared/notes_workspace.py` implementing file-based project-local notes with recycle bin
- `Note` dataclass with JSON serialization and full CRUD operations
- Soft-delete via recycle bin semantics: `delete()` moves to trash, `restore()` brings back, `purge()` permanently removes
- `clear()` bulk-moves all active notes to trash, `empty_trash()` purges all
- DbC via `@precondition` decorators (blank title, empty ID)
- Corrupt JSON files gracefully skipped with warning
- 35 pytest tests covering all operations, persistence, and contract violations

## Test plan

- [x] 35/35 pytest tests pass locally
- [x] All pre-commit hooks pass (ruff, black, no-print-in-src)
- [ ] CI/CD pipeline passes

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem persistence and destructive operations (`purge`/`empty_trash`) could lead to unexpected data loss or edge cases around corrupt files and concurrent edits, though changes are isolated and well-tested.
> 
> **Overview**
> Introduces `NotesWorkspace`, a new file-backed notes store that persists each note as JSON under `notes/` and supports full lifecycle operations: `create`, `get`, `list_notes`, `update`, soft-delete to `trash/` via `delete`, restore via `restore`, and permanent deletion via `purge`/`empty_trash` (plus bulk `clear`).
> 
> Adds a `Note` dataclass with JSON serialization helpers, basic DbC validation (non-blank titles, non-empty IDs), and handling for corrupt JSON files by skipping/returning `None` with warnings, alongside a comprehensive test suite covering CRUD, recycle-bin behavior, persistence across reinstantiation, and contract violations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e266b16e194601e1176aa02ca3158d3a23948aa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->