### PR TITLE
refactor: replace SoundManager singleton with dependency injection

### DIFF
--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -14,6 +14,7 @@ from games.shared.config import RaycasterConfig
 from games.shared.constants import GameState
 from games.shared.fps_game_base import FPSGameBase
 from games.shared.raycaster import Raycaster
+from games.shared.sound_manager_base import SoundManagerBase
 
 from . import constants as C  # noqa: N812
 from .bot import Bot
@@ -34,8 +35,17 @@ logger = logging.getLogger(__name__)
 class Game(FPSGameBase):
     """Main game class"""
 
-    def __init__(self) -> None:
-        """Initialize game"""
+    def __init__(
+        self,
+        sound_manager: SoundManagerBase | None = None,
+    ) -> None:
+        """Initialize game.
+
+        Args:
+            sound_manager: Optional sound manager instance.  If not
+                provided, a default SoundManager is created.  Pass a
+                NullSoundManager for testing or headless environments.
+        """
         self.C = C
         flags = pygame.SCALED | pygame.RESIZABLE
         self.screen = pygame.display.set_mode((C.SCREEN_WIDTH, C.SCREEN_HEIGHT), flags)
@@ -106,7 +116,9 @@ class Game(FPSGameBase):
         self.game_over_timer = 0
 
         # Audio
-        self.sound_manager = SoundManager()
+        self.sound_manager = (
+            sound_manager if sound_manager is not None else SoundManager()
+        )
         self.sound_manager.start_music()
 
         # Input

--- a/src/games/Force_Field/src/game.py
+++ b/src/games/Force_Field/src/game.py
@@ -14,6 +14,7 @@ from games.shared.interfaces import Portal
 
 # Shared components
 from games.shared.raycaster import Raycaster
+from games.shared.sound_manager_base import SoundManagerBase
 
 from . import constants as C  # noqa: N812
 from .bot import Bot
@@ -35,8 +36,17 @@ logger = logging.getLogger(__name__)
 class Game(FPSGameBase):
     """Main game class"""
 
-    def __init__(self) -> None:
-        """Initialize game"""
+    def __init__(
+        self,
+        sound_manager: SoundManagerBase | None = None,
+    ) -> None:
+        """Initialize game.
+
+        Args:
+            sound_manager: Optional sound manager instance.  If not
+                provided, a default SoundManager is created.  Pass a
+                NullSoundManager for testing or headless environments.
+        """
         self.C = C
         flags = pygame.SCALED | pygame.RESIZABLE
         self.screen = pygame.display.set_mode((C.SCREEN_WIDTH, C.SCREEN_HEIGHT), flags)
@@ -110,7 +120,9 @@ class Game(FPSGameBase):
         self.game_over_timer = 0
 
         # Audio
-        self.sound_manager = SoundManager()
+        self.sound_manager = (
+            sound_manager if sound_manager is not None else SoundManager()
+        )
         self.sound_manager.start_music()
 
         # Input

--- a/src/games/Zombie_Survival/src/game.py
+++ b/src/games/Zombie_Survival/src/game.py
@@ -14,6 +14,7 @@ from games.shared.constants import GameState
 from games.shared.fps_game_base import FPSGameBase
 from games.shared.interfaces import Portal
 from games.shared.raycaster import Raycaster
+from games.shared.sound_manager_base import SoundManagerBase
 
 from . import constants as C  # noqa: N812
 from .bot import Bot
@@ -33,8 +34,17 @@ logger = logging.getLogger(__name__)
 class Game(FPSGameBase):
     """Main game class"""
 
-    def __init__(self) -> None:
-        """Initialize game"""
+    def __init__(
+        self,
+        sound_manager: SoundManagerBase | None = None,
+    ) -> None:
+        """Initialize game.
+
+        Args:
+            sound_manager: Optional sound manager instance.  If not
+                provided, a default SoundManager is created.  Pass a
+                NullSoundManager for testing or headless environments.
+        """
         self.C = C
         flags = pygame.SCALED | pygame.RESIZABLE
         self.screen = pygame.display.set_mode((C.SCREEN_WIDTH, C.SCREEN_HEIGHT), flags)
@@ -100,7 +110,9 @@ class Game(FPSGameBase):
         self.game_over_timer = 0
 
         # Audio
-        self.sound_manager = SoundManager()
+        self.sound_manager = (
+            sound_manager if sound_manager is not None else SoundManager()
+        )
         self.sound_manager.start_music()
 
         # Input

--- a/src/games/shared/sound_manager_base.py
+++ b/src/games/shared/sound_manager_base.py
@@ -1,4 +1,4 @@
-"""Base class for game sound managers with singleton pattern."""
+"""Base class for game sound managers."""
 
 from __future__ import annotations
 
@@ -12,26 +12,13 @@ logger = logging.getLogger(__name__)
 
 
 class SoundManagerBase:
-    """Base class for managing sound effects and music with singleton pattern."""
-
-    _instances: dict[type[SoundManagerBase], SoundManagerBase] = {}
-    initialized: bool
+    """Base class for managing sound effects and music."""
 
     # Subclasses should override this with their sound file mappings
     SOUND_FILES: dict[str, str] = {}
 
-    def __new__(cls) -> SoundManagerBase:  # noqa: PYI034
-        """Create singleton instance."""
-        if cls not in cls._instances:
-            cls._instances[cls] = super().__new__(cls)
-            cls._instances[cls].initialized = False
-        return cls._instances[cls]
-
     def __init__(self) -> None:
         """Initialize SoundManager."""
-        if self.initialized:
-            return
-
         # Re-initialize mixer with lower buffer to reduce latency
         with contextlib.suppress(Exception):
             pygame.mixer.quit()
@@ -46,7 +33,6 @@ class SoundManagerBase:
 
         # Load assets
         self.load_assets()
-        self.initialized = True
 
     def load_assets(self) -> None:
         """Load all sound files from the game's assets directory."""
@@ -129,3 +115,36 @@ class SoundManagerBase:
         """Unpause all sounds and music."""
         if self.sound_enabled:
             pygame.mixer.unpause()
+
+
+class NullSoundManager(SoundManagerBase):
+    """Silent sound manager for testing and headless environments.
+
+    Implements the full SoundManagerBase interface but performs no audio
+    operations, making it safe to use without pygame mixer initialization.
+    """
+
+    def __init__(self) -> None:
+        """Initialize without touching pygame mixer."""
+        self.sounds: dict[str, pygame.mixer.Sound] = {}
+        self.music_channel = None
+        self.sound_enabled = False
+        self.current_music: str | None = None
+
+    def load_assets(self) -> None:
+        """No-op: skip asset loading."""
+
+    def play_sound(self, name: str) -> None:
+        """No-op: skip sound playback."""
+
+    def start_music(self, name: str = "music_loop") -> None:
+        """No-op: skip music playback."""
+
+    def stop_music(self) -> None:
+        """No-op: skip music stop."""
+
+    def pause_all(self) -> None:
+        """No-op: skip pause."""
+
+    def unpause_all(self) -> None:
+        """No-op: skip unpause."""


### PR DESCRIPTION
## Summary
- Remove `__new__` / `_instances` singleton pattern from `SoundManagerBase` so each call creates a fresh instance
- Add `NullSoundManager` class to `sound_manager_base.py` that silently no-ops all audio methods (for testing/headless use)
- Each game's `Game.__init__()` now accepts an optional `sound_manager: SoundManagerBase | None` parameter; when omitted, the default `SoundManager` is created (fully backward compatible)

## Test plan
- [x] All 340 existing tests pass (`pytest tests/ --ignore=tests/shared/test_notes_workspace.py`)
- [x] `ruff check` passes on all modified files
- [x] `black --check` passes on all modified files
- [x] Pre-commit hooks pass (ruff, ruff-format, black, no-wildcard-imports, no-debug, no-print)
- [ ] Verify games still launch and play audio normally (manual)
- [ ] Verify `Game(sound_manager=NullSoundManager())` creates a silent game instance (manual)

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect global pygame mixer initialization behavior and could cause repeated init/quit or resource issues when multiple sound managers are created. Gameplay logic is largely untouched, but startup/audio behavior may change across games and test environments.
> 
> **Overview**
> **Audio initialization is refactored away from a singleton.** `SoundManagerBase` no longer implements a singleton/`initialized` guard, so each instantiation reinitializes the pygame mixer and reloads assets.
> 
> **Games can now inject audio implementations.** `Duum`, `Force_Field`, and `Zombie_Survival` `Game.__init__` accept an optional `sound_manager: SoundManagerBase | None` and default to their existing `SoundManager`; `NullSoundManager` is added to provide a safe no-op audio backend for tests/headless environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad0f9f21dee5b737df5c068e4c189e6c4f80f97e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->