### PR TITLE
feat: pluggable map generation via strategy pattern (fixes #484)

### DIFF
--- a/src/games/shared/map_generators.py
+++ b/src/games/shared/map_generators.py
@@ -1,0 +1,148 @@
+"""Pluggable map generation strategies.
+
+Provides a Protocol-based strategy pattern for map generation,
+allowing different algorithms to be injected into MapBase.
+
+Usage:
+    from games.shared.map_generators import CellularAutomataGenerator
+    from games.shared.map_base import MapBase
+
+    # Default behavior (cellular automata):
+    m = MapBase(50)
+
+    # Custom generator:
+    gen = CellularAutomataGenerator(wall_chance=0.50, iterations=7)
+    m = MapBase(50, generator=gen)
+
+    # Empty map for testing:
+    from games.shared.map_generators import EmptyMapGenerator
+    m = MapBase(50, generator=EmptyMapGenerator())
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Protocol
+
+
+class MapGenerator(Protocol):
+    """Protocol for map generation strategies.
+
+    Implementations must provide a ``generate`` method that fills a
+    pre-allocated grid **in-place**.  The grid is a list-of-lists of
+    ``int`` with dimensions ``size x size``, initialized to all zeros.
+    """
+
+    def generate(self, grid: list[list[int]], size: int) -> None:
+        """Generate map content in-place on the grid.
+
+        Args:
+            grid: 2-D grid (size x size) to populate. Modified in place.
+            size: Side length of the square grid.
+        """
+        ...
+
+
+class CellularAutomataGenerator:
+    """Cellular automata cave/room generator.
+
+    This is the **default** generator extracted from the original
+    ``MapBase.create_map()`` implementation.  It produces organic-looking
+    cave structures by:
+
+    1. Seeding random walls (controlled by *wall_chance*).
+    2. Running cellular automata smoothing (controlled by *iterations*).
+
+    Note: room overlay and connectivity enforcement remain in ``MapBase``
+    so that every generator benefits from them.
+    """
+
+    def __init__(self, wall_chance: float = 0.45, iterations: int = 5) -> None:
+        self.wall_chance = wall_chance
+        self.iterations = iterations
+
+    def generate(self, grid: list[list[int]], size: int) -> None:
+        """Populate *grid* using cellular automata."""
+        self._seed_walls(grid, size)
+        self._set_borders(grid, size)
+        self._smooth(grid, size)
+
+    # -- helpers -------------------------------------------------------------
+
+    def _seed_walls(self, grid: list[list[int]], size: int) -> None:
+        """Fill every cell with a random wall/open value."""
+        for i in range(size):
+            for j in range(size):
+                grid[i][j] = 1 if random.random() < self.wall_chance else 0
+
+    @staticmethod
+    def _set_borders(grid: list[list[int]], size: int) -> None:
+        """Force all border cells to walls."""
+        for i in range(size):
+            grid[0][i] = 1
+            grid[size - 1][i] = 1
+            grid[i][0] = 1
+            grid[i][size - 1] = 1
+
+    def _smooth(self, grid: list[list[int]], size: int) -> None:
+        """Run cellular automata smoothing for *self.iterations* passes."""
+        for _ in range(self.iterations):
+            new_grid = _smooth_pass(grid, size)
+            _copy_grid(new_grid, grid, size)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (keep class methods short and low-complexity)
+# ---------------------------------------------------------------------------
+
+
+def _count_wall_neighbors(grid: list[list[int]], row: int, col: int) -> int:
+    """Count how many of the 8 neighbours of (row, col) are walls (> 0)."""
+    count = 0
+    for ni in range(-1, 2):
+        for nj in range(-1, 2):
+            if ni == 0 and nj == 0:
+                continue
+            if grid[row + ni][col + nj] > 0:
+                count += 1
+    return count
+
+
+def _smooth_pass(grid: list[list[int]], size: int) -> list[list[int]]:
+    """Return a new grid after one cellular-automata smoothing pass."""
+    new_grid = [row[:] for row in grid]
+    for i in range(1, size - 1):
+        for j in range(1, size - 1):
+            neighbors = _count_wall_neighbors(grid, i, j)
+            if neighbors > 4:
+                new_grid[i][j] = 1
+            elif neighbors < 4:
+                new_grid[i][j] = 0
+    return new_grid
+
+
+def _copy_grid(src: list[list[int]], dst: list[list[int]], size: int) -> None:
+    """Copy every cell from *src* into *dst* in-place."""
+    for i in range(size):
+        for j in range(size):
+            dst[i][j] = src[i][j]
+
+
+# ---------------------------------------------------------------------------
+# EmptyMapGenerator
+# ---------------------------------------------------------------------------
+
+
+class EmptyMapGenerator:
+    """Generates an empty map with only border walls.
+
+    Useful for deterministic testing and custom scenarios where a
+    blank canvas is desired.
+    """
+
+    def generate(self, grid: list[list[int]], size: int) -> None:
+        """Fill *grid* with zeros and wall-only borders."""
+        for y in range(size):
+            for x in range(size):
+                is_border = x == 0 or y == 0 or x == size - 1 or y == size - 1
+                grid[y][x] = 1 if is_border else 0

--- a/tests/shared/test_map_generators.py
+++ b/tests/shared/test_map_generators.py
@@ -1,0 +1,216 @@
+"""Tests for the pluggable map generation strategy pattern."""
+
+from __future__ import annotations
+
+from games.shared.map_base import MapBase
+from games.shared.map_generators import (
+    CellularAutomataGenerator,
+    EmptyMapGenerator,
+)
+
+# ---------------------------------------------------------------------------
+# CellularAutomataGenerator
+# ---------------------------------------------------------------------------
+
+
+class TestCellularAutomataGenerator:
+    """Tests for the default cellular automata generator."""
+
+    def test_produces_border_walls(self) -> None:
+        """Generated grid must have walls on all four borders."""
+        gen = CellularAutomataGenerator()
+        size = 20
+        grid = [[0] * size for _ in range(size)]
+        gen.generate(grid, size)
+
+        for i in range(size):
+            assert grid[0][i] > 0, f"Top border at col {i} should be wall"
+            assert grid[size - 1][i] > 0, f"Bottom border at col {i}"
+            assert grid[i][0] > 0, f"Left border at row {i}"
+            assert grid[i][size - 1] > 0, f"Right border at row {i}"
+
+    def test_produces_open_spaces(self) -> None:
+        """Interior should contain at least some open (0-valued) cells."""
+        gen = CellularAutomataGenerator()
+        size = 20
+        grid = [[0] * size for _ in range(size)]
+        gen.generate(grid, size)
+
+        open_count = sum(
+            1 for i in range(1, size - 1) for j in range(1, size - 1) if grid[i][j] == 0
+        )
+        assert open_count > 0
+
+    def test_custom_wall_chance_higher(self) -> None:
+        """Higher wall_chance should tend to produce more walls."""
+        import random
+
+        size = 30
+        dense = CellularAutomataGenerator(wall_chance=0.80, iterations=1)
+        sparse = CellularAutomataGenerator(wall_chance=0.10, iterations=1)
+
+        grid_dense = [[0] * size for _ in range(size)]
+        grid_sparse = [[0] * size for _ in range(size)]
+
+        # Use fixed seeds so the comparison is deterministic
+        random.seed(42)
+        dense.generate(grid_dense, size)
+        random.seed(42)
+        sparse.generate(grid_sparse, size)
+
+        walls_dense = sum(cell > 0 for row in grid_dense for cell in row)
+        walls_sparse = sum(cell > 0 for row in grid_sparse for cell in row)
+
+        assert walls_dense > walls_sparse
+
+    def test_modifies_grid_in_place(self) -> None:
+        """Generator must write into the provided grid, not replace it."""
+        gen = CellularAutomataGenerator()
+        size = 15
+        grid = [[0] * size for _ in range(size)]
+        original_id = id(grid)
+        gen.generate(grid, size)
+        assert id(grid) == original_id
+
+
+# ---------------------------------------------------------------------------
+# EmptyMapGenerator
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyMapGenerator:
+    """Tests for the border-only (empty) generator."""
+
+    def test_borders_are_walls(self) -> None:
+        """All border cells must be walls (value 1)."""
+        gen = EmptyMapGenerator()
+        size = 15
+        grid = [[0] * size for _ in range(size)]
+        gen.generate(grid, size)
+
+        for i in range(size):
+            assert grid[0][i] == 1
+            assert grid[size - 1][i] == 1
+            assert grid[i][0] == 1
+            assert grid[i][size - 1] == 1
+
+    def test_interior_is_empty(self) -> None:
+        """All interior cells must be open (value 0)."""
+        gen = EmptyMapGenerator()
+        size = 15
+        grid = [[9] * size for _ in range(size)]  # prefill with junk
+        gen.generate(grid, size)
+
+        for i in range(1, size - 1):
+            for j in range(1, size - 1):
+                assert grid[i][j] == 0, f"Interior cell ({i},{j}) should be 0"
+
+    def test_modifies_grid_in_place(self) -> None:
+        """Generator must write into the provided grid, not replace it."""
+        gen = EmptyMapGenerator()
+        size = 10
+        grid = [[0] * size for _ in range(size)]
+        original_id = id(grid)
+        gen.generate(grid, size)
+        assert id(grid) == original_id
+
+
+# ---------------------------------------------------------------------------
+# MapBase integration with generators
+# ---------------------------------------------------------------------------
+
+
+class TestMapBaseWithGenerator:
+    """Tests that MapBase correctly delegates to a pluggable generator."""
+
+    def test_default_generator_is_cellular_automata(self) -> None:
+        """MapBase without explicit generator should use CellularAutomataGenerator."""
+        m = MapBase(20, generate=False)
+        assert isinstance(m.generator, CellularAutomataGenerator)
+
+    def test_custom_generator_is_stored(self) -> None:
+        """Explicit generator should be stored on the instance."""
+        gen = EmptyMapGenerator()
+        m = MapBase(15, generate=False, generator=gen)
+        assert m.generator is gen
+
+    def test_empty_generator_produces_valid_map(self) -> None:
+        """MapBase with EmptyMapGenerator should still produce a connected map."""
+        m = MapBase(20, generator=EmptyMapGenerator())
+
+        # After rooms and connectivity, map should still have open space
+        open_count = sum(1 for row in m.grid for cell in row if cell == 0)
+        assert open_count > 0
+
+    def test_empty_generator_map_has_border_walls(self) -> None:
+        """Map generated with EmptyMapGenerator should retain border walls."""
+        m = MapBase(20, generator=EmptyMapGenerator())
+        size = m.size
+        for i in range(size):
+            assert m.grid[0][i] > 0
+            assert m.grid[size - 1][i] > 0
+            assert m.grid[i][0] > 0
+            assert m.grid[i][size - 1] > 0
+
+    def test_custom_protocol_generator(self) -> None:
+        """Any object satisfying the MapGenerator protocol should work."""
+
+        class CheckerboardGenerator:
+            """Fills the grid with a checkerboard of walls and open cells."""
+
+            def generate(self, grid: list[list[int]], size: int) -> None:
+                for y in range(size):
+                    for x in range(size):
+                        if x == 0 or y == 0 or x == size - 1 or y == size - 1:
+                            grid[y][x] = 1
+                        else:
+                            grid[y][x] = (x + y) % 2
+
+        m = MapBase(20, generator=CheckerboardGenerator())
+        # Should succeed without error; connectivity enforcement will
+        # close off isolated cells, so we just verify it ran.
+        assert m.size == 20
+        assert any(cell == 0 for row in m.grid for cell in row)
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    """Ensure existing code that never passes a generator still works."""
+
+    def test_mapbase_positional_args_unchanged(self) -> None:
+        """MapBase(size) and MapBase(size, generate=False) still work."""
+        m1 = MapBase(10)
+        assert m1.size == 10
+        m2 = MapBase(10, generate=False)
+        assert all(cell == 0 for row in m2.grid for cell in row)
+
+    def test_mapbase_generate_true_produces_map(self) -> None:
+        """Default generate=True should produce a non-empty map."""
+        m = MapBase(20)
+        wall_count = sum(1 for row in m.grid for cell in row if cell > 0)
+        assert wall_count > 0
+
+    def test_subclass_without_generator_works(self) -> None:
+        """A subclass calling super().__init__(size) should work unchanged."""
+
+        class GameMap(MapBase):
+            def __init__(self, size: int = 20) -> None:
+                super().__init__(size)
+
+        m = GameMap(20)
+        assert m.size == 20
+        assert isinstance(m.generator, CellularAutomataGenerator)
+
+    def test_subclass_generate_false_works(self) -> None:
+        """A subclass passing generate=False should still work."""
+
+        class GameMap(MapBase):
+            def __init__(self, size: int = 20) -> None:
+                super().__init__(size, generate=False)
+
+        m = GameMap(15)
+        assert all(cell == 0 for row in m.grid for cell in row)


### PR DESCRIPTION
## Summary
- Extract the cellular automata algorithm from `MapBase.create_map()` into a `CellularAutomataGenerator` class behind a `MapGenerator` Protocol
- Add `generator` parameter to `MapBase.__init__()`, defaulting to `CellularAutomataGenerator()` for full backward compatibility
- Include `EmptyMapGenerator` for deterministic testing and custom scenarios
- Any class with a `generate(grid, size)` method satisfies the protocol -- no inheritance required

## Changes
- **New file**: `src/games/shared/map_generators.py` -- `MapGenerator` Protocol, `CellularAutomataGenerator`, `EmptyMapGenerator`, and helper functions
- **Modified**: `src/games/shared/map_base.py` -- accepts optional `generator` kwarg, delegates terrain generation to strategy
- **New file**: `tests/shared/test_map_generators.py` -- 16 tests covering generators, MapBase integration, and backward compatibility

## Backward compatibility
All three game-specific `Map` subclasses (Duum, Force_Field, Zombie_Survival) continue to work without any changes. Existing code that calls `MapBase(size)` or `MapBase(size, generate=False)` behaves identically.

## Test plan
- [x] All 16 new tests pass (`test_map_generators.py`)
- [x] All 15 existing `test_map_base.py` tests pass unchanged
- [x] Full suite: 356 tests pass
- [x] Ruff + Black linting clean
- [ ] Verify CI passes

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core map creation by refactoring generation behind a strategy interface; although default behavior is preserved, any subtle differences in grid mutation/order could affect downstream gameplay or tests.
> 
> **Overview**
> **Map generation is now pluggable**: `MapBase` accepts an optional `generator` and delegates base terrain creation to `generator.generate(grid, size)`, defaulting to `CellularAutomataGenerator()` to preserve existing behavior.
> 
> Adds `map_generators.py` with a `MapGenerator` Protocol, extracted `CellularAutomataGenerator` (configurable `wall_chance`/`iterations`), and an `EmptyMapGenerator` for deterministic/blank starts; room overlay and connectivity enforcement remain in `MapBase`. Includes a new test suite covering generator behavior, `MapBase` integration, and backward compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5629bcfe0c36c52b36a398fc919caacc766f388. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->