### PR TITLE
refactor: replace enemy type if/elif dispatch with data-driven strategy

### DIFF
--- a/src/games/Force_Field/src/bot.py
+++ b/src/games/Force_Field/src/bot.py
@@ -48,6 +48,19 @@ class Bot:
     frozen: bool
     frozen_timer: int
 
+    # Dispatch table: enemy_type -> method name for type-specific behavior.
+    # Each handler accepts (game_map, player, dist_sq, other_bots) and returns
+    # Projectile | None.  Adding a new enemy type only requires a new handler
+    # method and one entry here.
+    _BEHAVIOR_DISPATCH: dict[str, str] = {
+        "ball": "_update_behavior_ball",
+        "ninja": "_update_behavior_ninja",
+        "beast": "_update_behavior_beast",
+        "minigunner": "_update_behavior_minigunner",
+        "sniper": "_update_behavior_sniper",
+        "ice_zombie": "_update_behavior_standard",
+    }
+
     def __init__(
         self,
         x: float,
@@ -140,26 +153,13 @@ class Bot:
         # Face player
         self.angle = float(math.atan2(dy, dx))
 
-        # Behavior dispatch
-        if self.enemy_type == "ball":
-            # Ball needs actual distance for velocity normalization
-            distance = math.sqrt(dist_sq)
-            return self._update_behavior_ball(game_map, player, dx, dy, distance)
-        elif self.enemy_type == "ninja":
-            return self._update_behavior_ninja(game_map, player, dist_sq, other_bots)
-        elif self.enemy_type == "beast":
-            return self._update_behavior_beast(game_map, player, dist_sq, other_bots)
-        elif self.enemy_type == "minigunner":
-            return self._update_behavior_minigunner(
-                game_map, player, dist_sq, other_bots
-            )
-        elif self.enemy_type == "sniper":
-            return self._update_behavior_sniper(game_map, player, dist_sq, other_bots)
-        elif self.enemy_type == "ice_zombie":
-            # Ice Zombies are slower but maybe have an aura or ranged attack?
-            # For now, just standard behavior but they look cool.
-            return self._update_behavior_standard(game_map, player, dist_sq, other_bots)
+        # Dispatch to type-specific behavior
+        handler_name = self._BEHAVIOR_DISPATCH.get(self.enemy_type)
+        if handler_name is not None:
+            handler = getattr(self, handler_name)
+            return handler(game_map, player, dist_sq, other_bots)
 
+        # Default behavior for types without a dedicated handler
         return self._update_behavior_standard(game_map, player, dist_sq, other_bots)
 
     def _check_status_effects(self) -> bool:
@@ -242,9 +242,26 @@ class Bot:
         self.shoot_animation = 1.0
         return projectile
 
+    # ------------------------------------------------------------------
+    # Behavior handlers (uniform signature for dispatch table)
+    #
+    # Each handler accepts (game_map, player, dist_sq, other_bots) and
+    # returns Projectile | None.
+    # ------------------------------------------------------------------
+
     def _update_behavior_ball(
-        self, game_map: Map, player: Player, dx: float, dy: float, dist: float
+        self,
+        game_map: Map,
+        player: Player,
+        dist_sq: float,
+        other_bots: list[Bot],  # noqa: ARG002
     ) -> Projectile | None:
+        """Rolling momentum logic -- accelerate, bounce off walls, crush player."""
+        # Compute dx/dy/dist from dist_sq for velocity normalization
+        dx = player.x - self.x
+        dy = player.y - self.y
+        dist = math.sqrt(dist_sq)
+
         # Accelerate towards player
         accel = 0.001 * self.speed
 


### PR DESCRIPTION
## Summary
- Replace if/elif chains dispatching on `self.enemy_type` with a class-level `_BEHAVIOR_DISPATCH` dict in all 3 bot.py files (Duum, Force_Field, Zombie_Survival)
- Each behavior handler now has a uniform signature `(game_map, player, dist_sq, other_bots) -> Projectile | None`, enabling table-driven dispatch via `getattr(self, handler_name)`
- Adding a new enemy type now only requires writing the handler method and adding one dict entry -- no more modifying control flow

## Changes per game
| Game | Enemy types in dispatch table |
|------|-------------------------------|
| Duum | ball, ninja, beast, minigunner |
| Force_Field | ball, ninja, beast, minigunner, sniper, ice_zombie |
| Zombie_Survival | ball, ninja, beast, minigunner, sniper |

## Test plan
- [x] All 356 existing tests pass
- [x] ruff check passes (no lint errors)
- [x] black formatting check passes (no changes needed)
- [ ] CI/CD pipeline passes

Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core enemy AI update paths across three games; while largely a refactor, small signature/flow changes (e.g., attack timer handling and per-type fallthrough) could subtly alter combat behavior.
> 
> **Overview**
> Refactors `Bot.update()` in `Duum`, `Force_Field`, and `Zombie_Survival` to replace `if/elif` enemy-type branching with a class-level `_BEHAVIOR_DISPATCH` table that routes to per-type behavior handlers via `getattr`.
> 
> Unifies behavior handlers to a common `(game_map, player, dist_sq, other_bots) -> Projectile | None` signature and introduces a shared `_update_behavior_standard()` fallback for non-special enemies, moving attack-timer decrement/standard attack-or-move logic out of the main `update()` flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60258e05eb04e8802e28497434b78e1f539c6ce3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->