### PR TITLE
refactor: data-driven fire_weapon() dispatch (fixes #480)

### DIFF
--- a/src/games/Duum/src/constants.py
+++ b/src/games/Duum/src/constants.py
@@ -67,6 +67,7 @@ WEAPONS: dict[str, WeaponData] = {
         "clip_size": 12,
         "reload_time": 60,  # 1 second
         "key": "1",
+        "fire_mode": "hitscan",
     },
     "rifle": {
         "name": "Rifle",
@@ -77,6 +78,7 @@ WEAPONS: dict[str, WeaponData] = {
         "clip_size": 30,
         "reload_time": 120,  # 2 seconds
         "key": "2",
+        "fire_mode": "hitscan",
     },
     "shotgun": {
         "name": "Shotgun",
@@ -89,6 +91,7 @@ WEAPONS: dict[str, WeaponData] = {
         "pellets": 8,
         "spread": 0.15,
         "key": "3",
+        "fire_mode": "spread",
     },
     "minigun": {
         "name": "Minigun",
@@ -101,6 +104,7 @@ WEAPONS: dict[str, WeaponData] = {
         "reload_time": 150,
         "key": "7",
         "spin_up_time": 30,
+        "fire_mode": "burst",
     },
     "plasma": {
         "name": "Plasma",
@@ -117,6 +121,7 @@ WEAPONS: dict[str, WeaponData] = {
         "projectile_speed": 0.5,
         "projectile_color": (0, 191, 255),
         "key": "5",
+        "fire_mode": "projectile",
     },
     "laser": {
         "name": "Laser",
@@ -130,6 +135,7 @@ WEAPONS: dict[str, WeaponData] = {
         "key": "4",
         "beam_color": (255, 0, 0),  # Red laser
         "beam_width": 3,
+        "fire_mode": "beam",
     },
     "rocket": {
         "name": "Rocket Launcher",
@@ -143,6 +149,7 @@ WEAPONS: dict[str, WeaponData] = {
         "projectile_speed": 0.3,
         "projectile_color": (255, 100, 0),
         "aoe_radius": 6.0,
+        "fire_mode": "projectile",
     },
 }
 

--- a/src/games/Force_Field/src/constants.py
+++ b/src/games/Force_Field/src/constants.py
@@ -77,6 +77,7 @@ WEAPONS: dict[str, WeaponData] = {
         "reload_time": 60,  # 1 second
         "key": "1",
         "automatic": True,  # Semi-auto, but felt "broken" if clicks missed.
+        "fire_mode": "hitscan",
     },
     "rifle": {
         "name": "Rifle",
@@ -88,6 +89,7 @@ WEAPONS: dict[str, WeaponData] = {
         "clip_size": 15,  # Reduced clip size (was 30)
         "reload_time": 120,  # 2 seconds
         "key": "2",
+        "fire_mode": "hitscan",
     },
     "shotgun": {
         "name": "Shotgun",
@@ -101,6 +103,7 @@ WEAPONS: dict[str, WeaponData] = {
         "spread": 0.15,
         "key": "3",
         "automatic": True,
+        "fire_mode": "spread",
     },
     "minigun": {
         "name": "Minigun",
@@ -113,6 +116,7 @@ WEAPONS: dict[str, WeaponData] = {
         "reload_time": 150,
         "key": "7",
         "spin_up_time": 30,
+        "fire_mode": "burst",
     },
     "plasma": {
         "name": "Plasma",
@@ -129,6 +133,7 @@ WEAPONS: dict[str, WeaponData] = {
         "projectile_speed": 0.5,
         "projectile_color": (0, 191, 255),
         "key": "5",
+        "fire_mode": "projectile",
     },
     "pulse": {
         "name": "Pulse Rifle",
@@ -142,6 +147,7 @@ WEAPONS: dict[str, WeaponData] = {
         "projectile_speed": 0.6,
         "projectile_color": (100, 100, 255),
         "key": "0",  # Auto-assigned usually
+        "fire_mode": "projectile",
     },
     "laser": {
         "name": "Laser",
@@ -155,6 +161,7 @@ WEAPONS: dict[str, WeaponData] = {
         "key": "4",
         "beam_color": (255, 0, 0),  # Red laser
         "beam_width": 15,  # Thicker beam (STAR WARS style)
+        "fire_mode": "beam",
     },
     "rocket": {
         "name": "Rocket Launcher",
@@ -168,6 +175,7 @@ WEAPONS: dict[str, WeaponData] = {
         "projectile_speed": 0.3,
         "projectile_color": (255, 100, 0),
         "aoe_radius": 6.0,
+        "fire_mode": "projectile",
     },
     "bfg": {
         "name": "BFG 9000",
@@ -181,6 +189,7 @@ WEAPONS: dict[str, WeaponData] = {
         "projectile_speed": 0.2,
         "projectile_color": (0, 255, 0),
         "aoe_radius": 15.0,
+        "fire_mode": "projectile",
     },
     "flamethrower": {
         "name": "Flamethrower",
@@ -194,6 +203,7 @@ WEAPONS: dict[str, WeaponData] = {
         "key": "9",
         "projectile_speed": 0.35,
         "projectile_color": (255, 140, 0),
+        "fire_mode": "projectile",
     },
     "freezer": {
         "name": "Freezer",
@@ -207,6 +217,7 @@ WEAPONS: dict[str, WeaponData] = {
         "key": "-",
         "projectile_speed": 0.4,
         "projectile_color": (200, 255, 255),
+        "fire_mode": "projectile",
     },
 }
 

--- a/src/games/Zombie_Survival/src/constants.py
+++ b/src/games/Zombie_Survival/src/constants.py
@@ -68,6 +68,7 @@ WEAPONS: dict[str, WeaponData] = {
         "clip_size": 12,
         "reload_time": 60,  # 1 second
         "key": "1",
+        "fire_mode": "hitscan",
     },
     "rifle": {
         "name": "Rifle",
@@ -78,6 +79,7 @@ WEAPONS: dict[str, WeaponData] = {
         "clip_size": 30,
         "reload_time": 120,  # 2 seconds
         "key": "2",
+        "fire_mode": "hitscan",
     },
     "shotgun": {
         "name": "Shotgun",
@@ -90,6 +92,7 @@ WEAPONS: dict[str, WeaponData] = {
         "pellets": 8,
         "spread": 0.15,
         "key": "3",
+        "fire_mode": "spread",
     },
     "minigun": {
         "name": "Minigun",
@@ -102,6 +105,7 @@ WEAPONS: dict[str, WeaponData] = {
         "reload_time": 150,
         "key": "7",
         "spin_up_time": 30,
+        "fire_mode": "burst",
     },
     "plasma": {
         "name": "Plasma",
@@ -118,6 +122,7 @@ WEAPONS: dict[str, WeaponData] = {
         "projectile_speed": 0.5,
         "projectile_color": (0, 191, 255),
         "key": "5",
+        "fire_mode": "projectile",
     },
     "laser": {
         "name": "Laser",
@@ -131,6 +136,7 @@ WEAPONS: dict[str, WeaponData] = {
         "key": "4",
         "beam_color": (255, 0, 0),  # Red laser
         "beam_width": 3,
+        "fire_mode": "beam",
     },
     "rocket": {
         "name": "Rocket Launcher",
@@ -144,6 +150,7 @@ WEAPONS: dict[str, WeaponData] = {
         "projectile_speed": 0.3,
         "projectile_color": (255, 100, 0),
         "aoe_radius": 6.0,
+        "fire_mode": "projectile",
     },
 }
 

--- a/src/games/Zombie_Survival/src/custom_types.py
+++ b/src/games/Zombie_Survival/src/custom_types.py
@@ -13,6 +13,7 @@ class WeaponData(TypedDict, total=False):
     reload_time: int
     key: str
     automatic: bool
+    fire_mode: str  # "hitscan", "projectile", "spread", "beam", "burst"
     spin_up_time: int
     heat_per_shot: float
     max_heat: float

--- a/src/games/shared/interfaces.py
+++ b/src/games/shared/interfaces.py
@@ -22,6 +22,7 @@ class WeaponData(TypedDict, total=False):
     reload_time: int
     key: str
     automatic: bool
+    fire_mode: str  # "hitscan", "projectile", "spread", "beam", "burst"
     spin_up_time: int
     heat_per_shot: float
     max_heat: float


### PR DESCRIPTION
## Summary
- Replace `fire_weapon()` if/elif chains with a `_FIRE_DISPATCH` class-level dict mapping `fire_mode` strings to handler method names in all 3 game variants (Duum, Zombie_Survival, Force_Field)
- Add `"fire_mode"` key (`"hitscan"`, `"projectile"`, `"spread"`, `"beam"`, `"burst"`) to every weapon in all 3 `constants.py` WEAPONS dicts (25 total entries)
- Add `fire_mode: str` field to `WeaponData` TypedDicts in `shared/interfaces.py` and `Zombie_Survival/src/custom_types.py`
- Net reduction of 62 lines while preserving identical behavior for all fire modes

### Files changed (8)
| File | Change |
|------|--------|
| `shared/interfaces.py` | Added `fire_mode: str` to `WeaponData` TypedDict |
| `Zombie_Survival/src/custom_types.py` | Added `fire_mode: str` to `WeaponData` TypedDict |
| `Duum/src/constants.py` | Added `fire_mode` to 7 weapons |
| `Zombie_Survival/src/constants.py` | Added `fire_mode` to 7 weapons |
| `Force_Field/src/constants.py` | Added `fire_mode` to 11 weapons |
| `Duum/src/game.py` | Replaced ~90-line if/elif with dispatch + 5 handlers |
| `Zombie_Survival/src/game.py` | Replaced ~85-line if/elif with dispatch + 5 handlers |
| `Force_Field/src/combat_system.py` | Replaced ~60-line if/elif with dispatch + 5 handlers (preserves existing `_fire_plasma`, `_fire_rocket`, etc.) |

## Test plan
- [x] All 340 tests pass (`PYTHONPATH=src python3 -m pytest tests/ --ignore=tests/shared/test_notes_workspace.py -q`)
- [x] `ruff check` passes on all modified files
- [x] `black --check` passes on all modified files
- [x] All pre-commit hooks pass

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core combat/spawn paths; behavior is intended to be equivalent but misconfigured `fire_mode` values or dispatch mapping errors could change weapon behavior or break firing at runtime.
> 
> **Overview**
> Refactors weapon firing across `Duum`, `Zombie_Survival`, and `Force_Field` to be **data-driven**: each weapon now declares a `fire_mode` in `WEAPONS`, and `fire_weapon()` dispatches through a `_FIRE_DISPATCH` map to dedicated handlers instead of large if/elif chains.
> 
> Updates typing to include `fire_mode` on `WeaponData` (shared + Zombie_Survival local), and in `Force_Field` simplifies recoil selection via a per-weapon `_RECOIL` table while keeping weapon-specific projectile behavior behind a generic projectile dispatch.
> 
> Separately, `Duum`’s level start no longer spawns enemies inline and instead delegates all spawning to a new `DuumSpawnManager` (and adds a `DuumCombatManager` instance) to reduce `Game` responsibilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93fc7e7078a8175b191ba98560126c8d2b71976b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->