### PR TITLE
refactor: decompose Game god object into SpawnManager and CombatManager

### DIFF
--- a/src/games/Duum/src/combat_manager.py
+++ b/src/games/Duum/src/combat_manager.py
@@ -1,0 +1,24 @@
+"""Duum-specific combat manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from games.shared.combat_manager import CombatManagerBase
+
+from . import constants as C  # noqa: N812
+
+
+class DuumCombatManager(CombatManagerBase):
+    """Combat manager configured for Duum."""
+
+    def __init__(
+        self,
+        entity_manager: Any,
+        particle_system: Any,
+        sound_manager: Any,
+        on_kill: Any | None = None,
+    ) -> None:
+        super().__init__(
+            entity_manager, particle_system, sound_manager, C, on_kill=on_kill
+        )

--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -4,7 +4,6 @@ import logging
 import math
 import random
 import traceback
-from contextlib import suppress
 
 import pygame
 
@@ -14,7 +13,6 @@ from games.shared.config import RaycasterConfig
 from games.shared.constants import (
     BEAST_TIMER_MAX,
     BEAST_TIMER_MIN,
-    COMBO_TIMER_FRAMES,
     FOG_REVEAL_RADIUS,
     GROAN_TIMER_DELAY,
     MINIGUN_BULLETS_PER_SHOT,
@@ -24,6 +22,7 @@ from games.shared.constants import (
     PORTAL_RADIUS_SQ,
     GameState,
 )
+from games.shared.event_bus import EventBus
 from games.shared.fps_game_base import FPSGameBase
 from games.shared.raycaster import Raycaster
 from games.shared.sound_manager_base import SoundManagerBase
@@ -128,15 +127,24 @@ class Game(FPSGameBase):
 
         self.game_over_timer = 0
 
-        # Managers (decomposed from Game god object)
-        self.combat_manager = DuumCombatManager(self)
-        self.spawn_manager = DuumSpawnManager(self)
-
-        # Audio
+        # Audio (must be initialized before managers that depend on it)
         self.sound_manager = (
             sound_manager if sound_manager is not None else SoundManager()
         )
         self.sound_manager.start_music()
+
+        # Event Bus -- lightweight pub/sub for decoupling subsystems
+        self.event_bus = EventBus()
+        self._wire_event_bus()
+
+        # Managers (decomposed from Game god object -- constructor injection)
+        self.spawn_manager = DuumSpawnManager(self.entity_manager)
+        self.combat_manager = DuumCombatManager(
+            self.entity_manager,
+            self.particle_system,
+            self.sound_manager,
+            on_kill=lambda bot: self.event_bus.emit("bot_killed", x=bot.x, y=bot.y),
+        )
 
         # Input
         self.joystick = None
@@ -181,6 +189,20 @@ class Game(FPSGameBase):
             YELLOW=C.YELLOW,
         )
 
+    def _wire_event_bus(self) -> None:
+        """Subscribe subsystems to game events via the event bus."""
+        self.event_bus.subscribe(
+            "bot_killed",
+            lambda **kw: self.sound_manager.play_sound("scream"),
+        )
+
+    def _sync_combat_state(self) -> None:
+        """Synchronize kill/combo state from the combat manager back to Game."""
+        self.kills = self.combat_manager.kills
+        self.kill_combo_count = self.combat_manager.kill_combo_count
+        self.kill_combo_timer = self.combat_manager.kill_combo_timer
+        self.last_death_pos = self.combat_manager.last_death_pos
+
     def start_game(self) -> None:
         """Start new game"""
         self.level = self.selected_start_level
@@ -204,6 +226,12 @@ class Game(FPSGameBase):
         self.breath_timer = 0
         self.groan_timer = 0
         self.beast_timer = 0
+
+        # Reset combat manager state
+        self.combat_manager.kills = 0
+        self.combat_manager.kill_combo_count = 0
+        self.combat_manager.kill_combo_timer = 0
+        self.combat_manager.last_death_pos = None
 
         # Create map with selected size
         self.game_map = Map(self.selected_map_size)
@@ -261,7 +289,9 @@ class Game(FPSGameBase):
 
         # Delegate spawning to SpawnManager
         self.entity_manager.reset()
-        self.spawn_manager.spawn_all(player_pos)
+        self.spawn_manager.spawn_all(
+            player_pos, self.game_map, self.level, self.selected_difficulty
+        )
 
         # Start Music
         music_tracks = [
@@ -574,426 +604,62 @@ class Game(FPSGameBase):
         angle_offset: float = 0.0,
         is_laser: bool = False,
     ) -> None:
-        """Check if player's shot hit a bot"""
+        """Delegate hitscan hit detection to the combat manager."""
         assert self.player is not None
         assert self.raycaster is not None
-        try:
-            weapon_range = self.player.get_current_weapon_range()
-            if is_secondary:
-                weapon_range = 100
-
-            weapon_damage = self.player.get_current_weapon_damage()
-
-            # Aim Logic
-            current_spread = C.SPREAD_ZOOM if self.player.zoomed else C.SPREAD_BASE
-            if angle_offset == 0.0:
-                spread_offset = random.uniform(-current_spread, current_spread)
-                aim_angle = self.player.angle + spread_offset
-            else:
-                aim_angle = self.player.angle + angle_offset
-
-            aim_angle %= 2 * math.pi
-
-            # 1. Cast ray to find wall distance
-            # Use Raycaster to avoid code duplication
-            wall_dist, _, _, _, _ = self.raycaster.cast_ray(
-                self.player.x, self.player.y, aim_angle
-            )
-
-            # Cap at weapon range
-            if wall_dist > weapon_range:
-                wall_dist = float(weapon_range)
-
-            closest_bot = None
-            closest_dist = float("inf")
-            is_headshot = False
-
-            # 2. Check bots
-            # Optimization: Use squared distance check first
-            wall_dist_sq = wall_dist * wall_dist
-
-            for bot in self.bots:
-                if not bot.alive:
-                    continue
-
-                dx = bot.x - self.player.x
-                dy = bot.y - self.player.y
-                dist_sq = dx * dx + dy * dy
-
-                if dist_sq > wall_dist_sq:
-                    continue
-
-                distance = math.sqrt(dist_sq)
-
-                bot_angle = math.atan2(dy, dx)
-                angle = bot_angle if bot_angle >= 0 else bot_angle + 2 * math.pi
-                bot_angle_norm = angle
-
-                angle_diff = abs(bot_angle_norm - aim_angle)
-                if angle_diff > math.pi:
-                    angle_diff = 2 * math.pi - angle_diff
-
-                if angle_diff < 0.15:
-                    if distance < closest_dist:
-                        closest_bot = bot
-                        closest_dist = distance
-                        is_headshot = angle_diff < C.HEADSHOT_THRESHOLD
-
-            if is_secondary:
-                impact_dist = wall_dist
-                if closest_bot and closest_dist < wall_dist:
-                    impact_dist = closest_dist
-
-                ray_angle = self.player.angle
-                impact_x = self.player.x + math.cos(ray_angle) * impact_dist
-                impact_y = self.player.y + math.sin(ray_angle) * impact_dist
-
-                try:
-                    self.explode_laser(impact_x, impact_y)
-                except Exception:
-                    logger.exception("Error in explode_laser")
-
-                self.particle_system.add_laser(
-                    start=(C.SCREEN_WIDTH - 200, C.SCREEN_HEIGHT - 180),
-                    end=(C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2),
-                    color=(0, 255, 255),
-                    timer=C.LASER_DURATION,
-                    width=C.LASER_WIDTH,
-                )
-                return
-
-            if is_laser:
-                self.particle_system.add_laser(
-                    start=(C.SCREEN_WIDTH - 200, C.SCREEN_HEIGHT - 180),
-                    end=(C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2),
-                    color=(255, 0, 0),
-                    timer=5,
-                    width=3,
-                )
-
-            if closest_bot:
-                range_factor = max(0.3, 1.0 - (closest_dist / weapon_range))
-
-                dx = closest_bot.x - self.player.x
-                dy = closest_bot.y - self.player.y
-                bot_angle = math.atan2(dy, dx)
-                angle = bot_angle if bot_angle >= 0 else bot_angle + 2 * math.pi
-                bot_angle_norm = angle
-
-                angle_diff = abs(bot_angle_norm - self.player.angle)
-                if angle_diff > math.pi:
-                    angle_diff = 2 * math.pi - angle_diff
-
-                accuracy_factor = max(0.5, 1.0 - (angle_diff / 0.15))
-
-                final_damage = int(weapon_damage * range_factor * accuracy_factor)
-
-                closest_bot.take_damage(final_damage, is_headshot=is_headshot)
-
-                damage_dealt = final_damage
-
-                if self.show_damage:
-                    self.damage_texts.append(
-                        {
-                            "x": C.SCREEN_WIDTH // 2 + random.randint(-20, 20),
-                            "y": C.SCREEN_HEIGHT // 2 - 50,
-                            "text": str(damage_dealt) + ("!" if is_headshot else ""),
-                            "color": C.RED if is_headshot else C.DAMAGE_TEXT_COLOR,
-                            "timer": 60,
-                            "vy": -1.0,
-                        }
-                    )
-
-                self.particle_system.add_explosion(
-                    C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2, count=5
-                )
-
-                for _ in range(10):
-                    self.particle_system.add_particle(
-                        x=C.SCREEN_WIDTH // 2,
-                        y=C.SCREEN_HEIGHT // 2,
-                        dx=random.uniform(-5, 5),
-                        dy=random.uniform(-5, 5),
-                        color=C.BLUE_BLOOD,
-                        timer=C.PARTICLE_LIFETIME,
-                        size=random.randint(2, 5),
-                    )
-
-                if not closest_bot.alive:
-                    self.kills += 1
-                    self.kill_combo_count += 1
-                    self.kill_combo_timer = COMBO_TIMER_FRAMES
-                    self.last_death_pos = (closest_bot.x, closest_bot.y)
-                    self.sound_manager.play_sound("scream")
-
-            # Visual Traces
-            # Calculate Screen Hit Point
-            # We know the object hit is at distance closest_dist (bot) or wall_dist
-            # (wall)
-
-            # Simple screen projection for trace endpoint
-            # In a raycaster, x is derived from angle difference
-            angle_diff = aim_angle - self.player.angle
-            # Normalize to -PI to PI
-            angle_diff = (angle_diff + math.pi) % (2 * math.pi) - math.pi
-
-            # Project to screen X
-            # Screen width corresponds to FOV.
-            # x = (0.5 - angle_diff / FOV) * SCREEN_WIDTH
-            # But wait, angle increases counter-clockwise?
-            # Usually raycaster:
-            # screen_x 0 -> angle + FOV/2, screen_x Width -> angle - FOV/2
-            # Let's approximate:
-            screen_hit_x = (0.5 - angle_diff / C.FOV) * C.SCREEN_WIDTH
-
-            # Project to screen Y
-            # y = H/2 + (player_z - hit_z) / dist * height_scale + pitch_offset
-            # Assuming hit is at same height roughly (center of screen vertically if 0)
-            # But we have pitch.
-            # pitch_view adds offset in pixels.
-            # Wall height on screen is proportional to 1/dist.
-            # Let's aim for the "center" of the hit view.
-            screen_hit_y = C.SCREEN_HEIGHT // 2 + self.player.pitch
-
-            # Weapon Start Position (Bottom Center-ish)
-            weapon_start_x = C.SCREEN_WIDTH * 0.6  # Slightly right
-            weapon_start_y = C.SCREEN_HEIGHT
-
-            # Adjust start for "hand" position
-            self.particle_system.add_trace(
-                start=(weapon_start_x, weapon_start_y),
-                end=(screen_hit_x, screen_hit_y),
-                color=(255, 255, 100),  # Pale yellow trace
-                timer=5,
-                width=1,
-            )
-
-            if not closest_bot:
-                # Wall Hit Effect at screen_hit_x, screen_hit_y
-                # Add sparks
-                hit_world_x = self.player.x + math.cos(aim_angle) * wall_dist
-                hit_world_y = self.player.y + math.sin(aim_angle) * wall_dist
-
-                self.particle_system.add_world_explosion(
-                    hit_world_x,
-                    hit_world_y,
-                    0.5,
-                    count=10,
-                    color=(255, 200, 100),
-                    speed=0.1,
-                )
-
-                for _ in range(5):
-                    self.particle_system.add_particle(
-                        x=screen_hit_x,
-                        y=screen_hit_y,
-                        dx=random.uniform(-3, 3),
-                        dy=random.uniform(-3, 3),
-                        color=(255, 200, 100),  # Spark color
-                        timer=20,
-                        size=random.randint(1, 3),
-                    )
-
-        except Exception:
-            logger.exception("Error in check_shot_hit")
+        self.damage_texts = self.combat_manager.check_shot_hit(
+            player=self.player,
+            raycaster=self.raycaster,
+            bots=self.bots,
+            damage_texts=self.damage_texts,
+            show_damage=self.show_damage,
+            is_secondary=is_secondary,
+            angle_offset=angle_offset,
+            is_laser=is_laser,
+        )
+        self._sync_combat_state()
 
     def handle_bomb_explosion(self) -> None:
-        """Handle bomb explosion logic"""
+        """Delegate bomb explosion to the combat manager."""
         assert self.player is not None
-        self.particle_system.add_particle(
-            x=C.SCREEN_WIDTH // 2,
-            y=C.SCREEN_HEIGHT // 2,
-            dx=0,
-            dy=0,
-            color=C.WHITE,
-            timer=40,
-            size=3000,
+        self.damage_texts = self.combat_manager.handle_bomb_explosion(
+            player=self.player,
+            bots=self.bots,
+            damage_texts=self.damage_texts,
         )
-
-        # 3D Explosion
-        self.particle_system.add_world_explosion(
-            self.player.x, self.player.y, 0.5, count=100, color=C.ORANGE, speed=0.5
-        )
-
-        for _ in range(300):
-            angle = random.uniform(0, 2 * math.pi)
-            speed = random.uniform(5, 25)
-            color = random.choice([C.ORANGE, C.RED, C.YELLOW, C.DARK_RED, (50, 50, 50)])
-            self.particle_system.add_particle(
-                x=C.SCREEN_WIDTH // 2,
-                y=C.SCREEN_HEIGHT // 2,
-                dx=math.cos(angle) * speed,
-                dy=math.sin(angle) * speed,
-                color=color,
-                timer=random.randint(40, 100),
-                size=random.randint(5, 25),
-            )
-
-        for bot in self.bots:
-            if not bot.alive:
-                continue
-            dx = bot.x - self.player.x
-            dy = bot.y - self.player.y
-            dist = math.sqrt(dx * dx + dy * dy)
-            if dist < C.BOMB_RADIUS:
-                if bot.take_damage(1000):
-                    self.sound_manager.play_sound("scream")
-                    self.kills += 1
-                    self.kill_combo_count += 1
-                    self.kill_combo_timer = COMBO_TIMER_FRAMES
-                    self.last_death_pos = (bot.x, bot.y)
-
-                if dist < 5.0:
-                    self.particle_system.add_explosion(
-                        C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2, count=3
-                    )
-
-        try:
-            self.sound_manager.play_sound("bomb")
-        except BaseException:
-            logger.exception("Bomb Audio Failed")
-
-        self.damage_texts.append(
-            {
-                "x": C.SCREEN_WIDTH // 2,
-                "y": C.SCREEN_HEIGHT // 2 - 100,
-                "text": "BOMB DROPPED!",
-                "color": C.ORANGE,
-                "timer": 120,
-                "vy": -0.5,
-            }
-        )
+        self._sync_combat_state()
 
     def explode_laser(self, impact_x: float, impact_y: float) -> None:
-        """Trigger Massive Laser Explosion at Impact Point"""
-        try:
-            self.sound_manager.play_sound("boom_real")
-        except Exception:
-            logger.exception("Boom sound failed")
-
-        try:
-            # 3D Explosion
-            self.particle_system.add_world_explosion(
-                impact_x, impact_y, 0.5, count=80, color=(0, 255, 255), speed=0.4
-            )
-
-            hits = 0
-            for bot in self.bots:
-                # Optimized alive check
-                if bot.alive:
-                    dist = math.sqrt((bot.x - impact_x) ** 2 + (bot.y - impact_y) ** 2)
-                    if dist < C.LASER_AOE_RADIUS:
-                        damage = 500
-                        killed = bot.take_damage(damage)
-                        hits += 1
-
-                        if killed:
-                            with suppress(Exception):
-                                self.sound_manager.play_sound("scream")
-                            self.kills += 1
-                            self.kill_combo_count += 1
-                            self.kill_combo_timer = COMBO_TIMER_FRAMES
-                            self.last_death_pos = (bot.x, bot.y)
-
-                        for _ in range(10):
-                            self.particle_system.add_particle(
-                                x=C.SCREEN_WIDTH // 2,
-                                y=C.SCREEN_HEIGHT // 2,
-                                dx=random.uniform(-10, 10),
-                                dy=random.uniform(-10, 10),
-                                color=(
-                                    random.randint(200, 255),
-                                    0,
-                                    random.randint(200, 255),
-                                ),
-                                timer=40,
-                                size=random.randint(4, 8),
-                            )
-
-            if hits > 0:
-                self.damage_texts.append(
-                    {
-                        "x": C.SCREEN_WIDTH // 2,
-                        "y": C.SCREEN_HEIGHT // 2 - 80,
-                        "text": "LASER ANNIHILATION!",
-                        "color": (255, 0, 255),
-                        "timer": 60,
-                        "vy": -2,
-                    }
-                )
-        except Exception:
-            logger.exception("Critical Laser Error")
+        """Delegate laser explosion to the combat manager."""
+        self.damage_texts = self.combat_manager.explode_laser(
+            impact_x, impact_y, self.damage_texts
+        )
+        self._sync_combat_state()
 
     def explode_plasma(self, projectile: Projectile) -> None:
-        """Trigger plasma AOE explosion"""
-        self._explode_generic(projectile, C.PLASMA_AOE_RADIUS, "plasma")
+        """Delegate plasma explosion to the combat manager."""
+        assert self.player is not None
+        self.damage_flash_timer = self.combat_manager.explode_generic(
+            projectile,
+            C.PLASMA_AOE_RADIUS,
+            "plasma",
+            self.player,
+            self.damage_flash_timer,
+        )
+        self._sync_combat_state()
 
     def explode_rocket(self, projectile: Projectile) -> None:
-        """Trigger rocket AOE explosion"""
-        # Rocket has larger AOE
-        radius = C.WEAPONS["rocket"].get("aoe_radius", 6.0)
-        self._explode_generic(projectile, radius, "rocket")
-
-    def _explode_generic(
-        self, projectile: Projectile, radius: float, weapon_type: str
-    ) -> None:
-        """Generic explosion logic"""
+        """Delegate rocket explosion to the combat manager."""
         assert self.player is not None
-        dist_to_player = math.sqrt(
-            (projectile.x - self.player.x) ** 2 + (projectile.y - self.player.y) ** 2
+        radius = float(C.WEAPONS["rocket"].get("aoe_radius", 6.0))
+        self.damage_flash_timer = self.combat_manager.explode_generic(
+            projectile,
+            radius,
+            "rocket",
+            self.player,
+            self.damage_flash_timer,
         )
-        if dist_to_player < 15:
-            self.damage_flash_timer = 15
-
-        # Visuals
-        color = C.CYAN if weapon_type == "plasma" else C.ORANGE
-        self.particle_system.add_world_explosion(
-            projectile.x, projectile.y, projectile.z, count=50, color=color, speed=0.3
-        )
-
-        if dist_to_player < 20:
-            count = 5 if weapon_type == "rocket" else 3
-            self.particle_system.add_explosion(
-                C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2, count=count
-            )
-
-            # Add some colored particles
-            for _ in range(20):
-                self.particle_system.add_particle(
-                    x=C.SCREEN_WIDTH // 2,
-                    y=C.SCREEN_HEIGHT // 2,
-                    dx=random.uniform(-10, 10),
-                    dy=random.uniform(-10, 10),
-                    color=color,
-                    timer=40,
-                    size=random.randint(4, 8),
-                )
-
-        try:
-            self.sound_manager.play_sound(
-                "boom_real" if weapon_type == "rocket" else "shoot_plasma"
-            )
-        except Exception:
-            pass
-
-        for bot in self.bots:
-            if not bot.alive:
-                continue
-            dx = bot.x - projectile.x
-            dy = bot.y - projectile.y
-            dist = math.sqrt(dx * dx + dy * dy)
-
-            if dist < radius:
-                # Falloff damage
-                damage_factor = 1.0 - (dist / radius)
-                damage = int(projectile.damage * damage_factor)
-
-                if bot.take_damage(damage):
-                    self.sound_manager.play_sound("scream")
-                    self.kills += 1
-                    self.kill_combo_count += 1
-                    self.kill_combo_timer = COMBO_TIMER_FRAMES
-                    self.last_death_pos = (bot.x, bot.y)
+        self._sync_combat_state()
 
     def update_game(self) -> None:
         """Update game state"""
@@ -1279,6 +945,9 @@ class Game(FPSGameBase):
                         }
                     )
                 self.kill_combo_count = 0
+            # Push combo state back to the combat manager
+            self.combat_manager.kill_combo_timer = self.kill_combo_timer
+            self.combat_manager.kill_combo_count = self.kill_combo_count
 
         # Decay Flash
         if self.flash_intensity > 0:

--- a/src/games/Duum/src/spawn_manager.py
+++ b/src/games/Duum/src/spawn_manager.py
@@ -1,0 +1,35 @@
+"""Duum-specific spawn manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from games.shared.spawn_manager import SpawnManagerBase
+
+from . import constants as C  # noqa: N812
+from .bot import Bot
+
+
+class DuumSpawnManager(SpawnManagerBase):
+    """Spawn manager configured for Duum."""
+
+    BOSS_OPTIONS = ["ball", "beast"]
+    WEAPON_PICKUPS = [
+        "pickup_rifle",
+        "pickup_shotgun",
+        "pickup_plasma",
+        "pickup_minigun",
+    ]
+
+    def __init__(self, entity_manager: Any) -> None:
+        super().__init__(entity_manager, C)
+
+    def _make_bot(
+        self,
+        x: float,
+        y: float,
+        level: int,
+        enemy_type: str,
+        difficulty: str = "NORMAL",
+    ) -> Bot:
+        return Bot(x, y, level, enemy_type, difficulty=difficulty)

--- a/src/games/Force_Field/src/spawn_manager.py
+++ b/src/games/Force_Field/src/spawn_manager.py
@@ -1,0 +1,52 @@
+"""Force Field-specific spawn manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from games.shared.spawn_manager import SpawnManagerBase
+
+from . import constants as C  # noqa: N812
+from .bot import Bot
+
+
+class FFSpawnManager(SpawnManagerBase):
+    """Spawn manager configured for Force Field."""
+
+    SPAWN_EXCLUSIONS = [
+        "boss",
+        "demon",
+        "ball",
+        "beast",
+        "health_pack",
+        "ammo_box",
+        "bomb_item",
+        "pickup_rocket",
+        "pickup_flamethrower",
+        "pickup_pulse",
+        "pickup_freezer",
+    ]
+
+    BOSS_OPTIONS = ["ball", "beast"]
+    WEAPON_PICKUPS = [
+        "pickup_rifle",
+        "pickup_shotgun",
+        "pickup_plasma",
+        "pickup_minigun",
+        "pickup_flamethrower",
+        "pickup_pulse",
+        "pickup_freezer",
+    ]
+
+    def __init__(self, entity_manager: Any) -> None:
+        super().__init__(entity_manager, C)
+
+    def _make_bot(
+        self,
+        x: float,
+        y: float,
+        level: int,
+        enemy_type: str,
+        difficulty: str = "NORMAL",
+    ) -> Bot:
+        return Bot(x, y, level, enemy_type, difficulty=difficulty)

--- a/src/games/Zombie_Survival/src/combat_manager.py
+++ b/src/games/Zombie_Survival/src/combat_manager.py
@@ -1,0 +1,24 @@
+"""Zombie Survival-specific combat manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from games.shared.combat_manager import CombatManagerBase
+
+from . import constants as C  # noqa: N812
+
+
+class ZSCombatManager(CombatManagerBase):
+    """Combat manager configured for Zombie Survival."""
+
+    def __init__(
+        self,
+        entity_manager: Any,
+        particle_system: Any,
+        sound_manager: Any,
+        on_kill: Any | None = None,
+    ) -> None:
+        super().__init__(
+            entity_manager, particle_system, sound_manager, C, on_kill=on_kill
+        )

--- a/src/games/Zombie_Survival/src/spawn_manager.py
+++ b/src/games/Zombie_Survival/src/spawn_manager.py
@@ -1,0 +1,35 @@
+"""Zombie Survival-specific spawn manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from games.shared.spawn_manager import SpawnManagerBase
+
+from . import constants as C  # noqa: N812
+from .bot import Bot
+
+
+class ZSSpawnManager(SpawnManagerBase):
+    """Spawn manager configured for Zombie Survival."""
+
+    BOSS_OPTIONS = ["ball", "beast"]
+    WEAPON_PICKUPS = [
+        "pickup_rifle",
+        "pickup_shotgun",
+        "pickup_plasma",
+        "pickup_minigun",
+    ]
+
+    def __init__(self, entity_manager: Any) -> None:
+        super().__init__(entity_manager, C)
+
+    def _make_bot(
+        self,
+        x: float,
+        y: float,
+        level: int,
+        enemy_type: str,
+        difficulty: str = "NORMAL",
+    ) -> Bot:
+        return Bot(x, y, level, enemy_type, difficulty=difficulty)

--- a/src/games/shared/combat_manager.py
+++ b/src/games/shared/combat_manager.py
@@ -1,0 +1,579 @@
+"""Base class for combat managers.
+
+Encapsulates hit detection, damage application, kill tracking,
+and explosion logic that was previously duplicated across game.py files.
+
+Subclasses override constants and game-specific behavior as needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import random
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any
+
+from games.shared.constants import COMBO_TIMER_FRAMES
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class CombatManagerBase:
+    """Manages hit detection, damage calculation, and explosions.
+
+    Dependencies are injected via the constructor -- the manager never
+    holds a reference back to the Game object.
+
+    Args:
+        entity_manager: The EntityManager that owns bot/projectile lists.
+        particle_system: The ParticleSystem for visual effects.
+        sound_manager: The SoundManager for audio feedback.
+        constants: The game-specific constants module (C).
+    """
+
+    def __init__(
+        self,
+        entity_manager: Any,
+        particle_system: Any,
+        sound_manager: Any,
+        constants: Any,
+        on_kill: Any | None = None,
+    ) -> None:
+        self.entity_manager = entity_manager
+        self.particle_system = particle_system
+        self.sound_manager = sound_manager
+        self.C = constants
+
+        # Optional callback invoked after each kill: on_kill(bot)
+        self._on_kill = on_kill
+
+        # Kill tracking state -- the game reads these back
+        self.kills = 0
+        self.kill_combo_count = 0
+        self.kill_combo_timer = 0
+        self.last_death_pos: tuple[float, float] | None = None
+
+    # ------------------------------------------------------------------
+    # Kill handling
+    # ------------------------------------------------------------------
+
+    def handle_kill(self, bot: Any) -> None:
+        """Record a kill and update combo state.
+
+        Args:
+            bot: The bot that was killed.
+        """
+        self.kills += 1
+        self.kill_combo_count += 1
+        self.kill_combo_timer = COMBO_TIMER_FRAMES
+        self.last_death_pos = (bot.x, bot.y)
+        with suppress(Exception):
+            self.sound_manager.play_sound("scream")
+        if self._on_kill is not None:
+            self._on_kill(bot)
+
+    # ------------------------------------------------------------------
+    # Hitscan shot detection
+    # ------------------------------------------------------------------
+
+    def check_shot_hit(
+        self,
+        player: Any,
+        raycaster: Any,
+        bots: list[Any],
+        damage_texts: list[dict[str, Any]],
+        show_damage: bool = True,
+        is_secondary: bool = False,
+        angle_offset: float = 0.0,
+        is_laser: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Check if a hitscan shot hit any bot.
+
+        Returns the updated damage_texts list.  The caller owns the list;
+        this method only appends to it.
+
+        Args:
+            player: The player object (must have x, y, angle, zoomed, etc.).
+            raycaster: The Raycaster instance for ray casting.
+            bots: List of bot objects to check against.
+            damage_texts: Mutable list of floating damage text dicts.
+            show_damage: Whether to show damage numbers.
+            is_secondary: Whether this is a secondary fire.
+            angle_offset: Angle offset for spread weapons.
+            is_laser: Whether this is a laser beam.
+
+        Returns:
+            The (possibly modified) damage_texts list.
+        """
+        try:
+            weapon_range = player.get_current_weapon_range()
+            if is_secondary:
+                weapon_range = 100
+
+            weapon_damage = player.get_current_weapon_damage()
+
+            # Aim Logic
+            spread_zoom = getattr(self.C, "SPREAD_ZOOM", 0.01)
+            spread_base = getattr(self.C, "SPREAD_BASE", 0.04)
+            current_spread = spread_zoom if player.zoomed else spread_base
+            if angle_offset == 0.0:
+                spread_offset = random.uniform(-current_spread, current_spread)
+                aim_angle = player.angle + spread_offset
+            else:
+                aim_angle = player.angle + angle_offset
+
+            aim_angle %= 2 * math.pi
+
+            # Cast ray to find wall distance
+            wall_dist, _, _, _, _ = raycaster.cast_ray(player.x, player.y, aim_angle)
+
+            if wall_dist > weapon_range:
+                wall_dist = float(weapon_range)
+
+            closest_bot = None
+            closest_dist = float("inf")
+            is_headshot = False
+
+            wall_dist_sq = wall_dist * wall_dist
+            headshot_threshold = getattr(self.C, "HEADSHOT_THRESHOLD", 0.05)
+
+            for bot in bots:
+                if not bot.alive:
+                    continue
+
+                dx = bot.x - player.x
+                dy = bot.y - player.y
+                dist_sq = dx * dx + dy * dy
+
+                if dist_sq > wall_dist_sq:
+                    continue
+
+                distance = math.sqrt(dist_sq)
+
+                bot_angle = math.atan2(dy, dx)
+                if bot_angle < 0:
+                    bot_angle += 2 * math.pi
+
+                angle_diff = abs(bot_angle - aim_angle)
+                if angle_diff > math.pi:
+                    angle_diff = 2 * math.pi - angle_diff
+
+                if angle_diff < 0.15:
+                    if distance < closest_dist:
+                        closest_bot = bot
+                        closest_dist = distance
+                        is_headshot = angle_diff < headshot_threshold
+
+            if is_secondary:
+                self._handle_secondary_hit(
+                    player, closest_bot, closest_dist, wall_dist, damage_texts
+                )
+                return damage_texts
+
+            if is_laser:
+                self.particle_system.add_laser(
+                    start=(self.C.SCREEN_WIDTH - 200, self.C.SCREEN_HEIGHT - 180),
+                    end=(self.C.SCREEN_WIDTH // 2, self.C.SCREEN_HEIGHT // 2),
+                    color=(255, 0, 0),
+                    timer=5,
+                    width=3,
+                )
+
+            if closest_bot:
+                self._apply_hit_damage(
+                    player,
+                    closest_bot,
+                    closest_dist,
+                    weapon_range,
+                    weapon_damage,
+                    is_headshot,
+                    damage_texts,
+                    show_damage,
+                )
+
+            # Visual traces
+            self._add_shot_visuals(
+                player, aim_angle, closest_bot, closest_dist, wall_dist
+            )
+
+        except Exception:
+            logger.exception("Error in check_shot_hit")
+
+        return damage_texts
+
+    def _handle_secondary_hit(
+        self,
+        player: Any,
+        closest_bot: Any | None,
+        closest_dist: float,
+        wall_dist: float,
+        damage_texts: list[dict[str, Any]],
+    ) -> None:
+        """Handle secondary fire (laser explosion at impact)."""
+        impact_dist = wall_dist
+        if closest_bot and closest_dist < wall_dist:
+            impact_dist = closest_dist
+
+        ray_angle = player.angle
+        impact_x = player.x + math.cos(ray_angle) * impact_dist
+        impact_y = player.y + math.sin(ray_angle) * impact_dist
+
+        try:
+            self.explode_laser(impact_x, impact_y, damage_texts)
+        except Exception:
+            logger.exception("Error in explode_laser")
+
+        laser_duration = getattr(self.C, "LASER_DURATION", 10)
+        laser_width = getattr(self.C, "LASER_WIDTH", 5)
+        self.particle_system.add_laser(
+            start=(self.C.SCREEN_WIDTH - 200, self.C.SCREEN_HEIGHT - 180),
+            end=(self.C.SCREEN_WIDTH // 2, self.C.SCREEN_HEIGHT // 2),
+            color=(0, 255, 255),
+            timer=laser_duration,
+            width=laser_width,
+        )
+
+    def _apply_hit_damage(
+        self,
+        player: Any,
+        bot: Any,
+        distance: float,
+        weapon_range: float,
+        base_damage: int,
+        is_headshot: bool,
+        damage_texts: list[dict[str, Any]],
+        show_damage: bool,
+    ) -> None:
+        """Apply damage to a bot that was hit."""
+        range_factor = max(0.3, 1.0 - (distance / weapon_range))
+
+        dx = bot.x - player.x
+        dy = bot.y - player.y
+        bot_angle = math.atan2(dy, dx)
+        if bot_angle < 0:
+            bot_angle += 2 * math.pi
+
+        angle_diff = abs(bot_angle - player.angle)
+        if angle_diff > math.pi:
+            angle_diff = 2 * math.pi - angle_diff
+
+        accuracy_factor = max(0.5, 1.0 - (angle_diff / 0.15))
+        final_damage = int(base_damage * range_factor * accuracy_factor)
+
+        bot.take_damage(final_damage, is_headshot=is_headshot)
+
+        if show_damage:
+            damage_color = getattr(self.C, "DAMAGE_TEXT_COLOR", (255, 255, 255))
+            damage_texts.append(
+                {
+                    "x": self.C.SCREEN_WIDTH // 2 + random.randint(-20, 20),
+                    "y": self.C.SCREEN_HEIGHT // 2 - 50,
+                    "text": str(final_damage) + ("!" if is_headshot else ""),
+                    "color": self.C.RED if is_headshot else damage_color,
+                    "timer": 60,
+                    "vy": -1.0,
+                }
+            )
+
+        self.particle_system.add_explosion(
+            self.C.SCREEN_WIDTH // 2, self.C.SCREEN_HEIGHT // 2, count=5
+        )
+
+        blood_color = getattr(self.C, "BLUE_BLOOD", (0, 0, 200))
+        particle_lifetime = getattr(self.C, "PARTICLE_LIFETIME", 30)
+        for _ in range(10):
+            self.particle_system.add_particle(
+                x=self.C.SCREEN_WIDTH // 2,
+                y=self.C.SCREEN_HEIGHT // 2,
+                dx=random.uniform(-5, 5),
+                dy=random.uniform(-5, 5),
+                color=blood_color,
+                timer=particle_lifetime,
+                size=random.randint(2, 5),
+            )
+
+        if not bot.alive:
+            self.handle_kill(bot)
+
+    def _add_shot_visuals(
+        self,
+        player: Any,
+        aim_angle: float,
+        closest_bot: Any | None,
+        closest_dist: float,
+        wall_dist: float,
+    ) -> None:
+        """Add tracer and impact visual effects."""
+        fov = getattr(self.C, "FOV", 1.0)
+        angle_diff = aim_angle - player.angle
+        angle_diff = (angle_diff + math.pi) % (2 * math.pi) - math.pi
+
+        screen_hit_x = (0.5 - angle_diff / fov) * self.C.SCREEN_WIDTH
+        screen_hit_y = self.C.SCREEN_HEIGHT // 2 + getattr(player, "pitch", 0)
+
+        weapon_start_x = self.C.SCREEN_WIDTH * 0.6
+        weapon_start_y = self.C.SCREEN_HEIGHT
+
+        self.particle_system.add_trace(
+            start=(weapon_start_x, weapon_start_y),
+            end=(screen_hit_x, screen_hit_y),
+            color=(255, 255, 100),
+            timer=5,
+            width=1,
+        )
+
+        if not closest_bot:
+            hit_world_x = player.x + math.cos(aim_angle) * wall_dist
+            hit_world_y = player.y + math.sin(aim_angle) * wall_dist
+
+            self.particle_system.add_world_explosion(
+                hit_world_x,
+                hit_world_y,
+                0.5,
+                count=10,
+                color=(255, 200, 100),
+                speed=0.1,
+            )
+
+            for _ in range(5):
+                self.particle_system.add_particle(
+                    x=screen_hit_x,
+                    y=screen_hit_y,
+                    dx=random.uniform(-3, 3),
+                    dy=random.uniform(-3, 3),
+                    color=(255, 200, 100),
+                    timer=20,
+                    size=random.randint(1, 3),
+                )
+
+    # ------------------------------------------------------------------
+    # Explosion helpers
+    # ------------------------------------------------------------------
+
+    def handle_bomb_explosion(
+        self,
+        player: Any,
+        bots: list[Any],
+        damage_texts: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Handle bomb explosion centered on the player.
+
+        Returns the updated damage_texts list.
+        """
+        sw2 = self.C.SCREEN_WIDTH // 2
+        sh2 = self.C.SCREEN_HEIGHT // 2
+
+        self.particle_system.add_particle(
+            x=sw2,
+            y=sh2,
+            dx=0,
+            dy=0,
+            color=self.C.WHITE,
+            timer=40,
+            size=3000,
+        )
+
+        # 3D explosion at player pos
+        self.particle_system.add_world_explosion(
+            player.x,
+            player.y,
+            0.5,
+            count=100,
+            color=self.C.ORANGE,
+            speed=0.5,
+        )
+
+        for _ in range(300):
+            angle = random.uniform(0, 2 * math.pi)
+            speed = random.uniform(5, 25)
+            color = random.choice(
+                [
+                    self.C.ORANGE,
+                    self.C.RED,
+                    self.C.YELLOW,
+                    getattr(self.C, "DARK_RED", (139, 0, 0)),
+                    (50, 50, 50),
+                ]
+            )
+            self.particle_system.add_particle(
+                x=sw2,
+                y=sh2,
+                dx=math.cos(angle) * speed,
+                dy=math.sin(angle) * speed,
+                color=color,
+                timer=random.randint(40, 100),
+                size=random.randint(5, 25),
+            )
+
+        bomb_radius = getattr(self.C, "BOMB_RADIUS", 10.0)
+        for bot in bots:
+            if not bot.alive:
+                continue
+            dx = bot.x - player.x
+            dy = bot.y - player.y
+            dist = math.sqrt(dx * dx + dy * dy)
+            if dist < bomb_radius:
+                if bot.take_damage(1000):
+                    self.handle_kill(bot)
+
+                if dist < 5.0:
+                    self.particle_system.add_explosion(sw2, sh2, count=3)
+
+        try:
+            self.sound_manager.play_sound("bomb")
+        except Exception:
+            logger.exception("Bomb Audio Failed")
+
+        damage_texts.append(
+            {
+                "x": sw2,
+                "y": sh2 - 100,
+                "text": "BOMB DROPPED!",
+                "color": self.C.ORANGE,
+                "timer": 120,
+                "vy": -0.5,
+            }
+        )
+        return damage_texts
+
+    def explode_laser(
+        self,
+        impact_x: float,
+        impact_y: float,
+        damage_texts: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Trigger a laser AOE explosion at an impact point."""
+        try:
+            self.sound_manager.play_sound("boom_real")
+        except Exception:
+            logger.exception("Boom sound failed")
+
+        try:
+            self.particle_system.add_world_explosion(
+                impact_x,
+                impact_y,
+                0.5,
+                count=80,
+                color=(0, 255, 255),
+                speed=0.4,
+            )
+
+            sw2 = self.C.SCREEN_WIDTH // 2
+            sh2 = self.C.SCREEN_HEIGHT // 2
+            laser_radius = getattr(self.C, "LASER_AOE_RADIUS", 5.0)
+
+            hits = 0
+            for bot in self.entity_manager.bots:
+                if not getattr(bot, "alive", False):
+                    continue
+                dist = math.sqrt((bot.x - impact_x) ** 2 + (bot.y - impact_y) ** 2)
+                if dist < laser_radius:
+                    killed = bot.take_damage(500)
+                    hits += 1
+
+                    if killed:
+                        self.handle_kill(bot)
+
+                    for _ in range(10):
+                        self.particle_system.add_particle(
+                            x=sw2,
+                            y=sh2,
+                            dx=random.uniform(-10, 10),
+                            dy=random.uniform(-10, 10),
+                            color=(
+                                random.randint(200, 255),
+                                0,
+                                random.randint(200, 255),
+                            ),
+                            timer=40,
+                            size=random.randint(4, 8),
+                        )
+
+            if hits > 0:
+                damage_texts.append(
+                    {
+                        "x": sw2,
+                        "y": sh2 - 80,
+                        "text": "LASER ANNIHILATION!",
+                        "color": (255, 0, 255),
+                        "timer": 60,
+                        "vy": -2,
+                    }
+                )
+        except Exception:
+            logger.exception("Critical Laser Error")
+
+        return damage_texts
+
+    def explode_generic(
+        self,
+        projectile: Any,
+        radius: float,
+        weapon_type: str,
+        player: Any,
+        damage_flash_timer: int,
+    ) -> int:
+        """Generic AOE explosion around a projectile impact.
+
+        Returns the updated damage_flash_timer value.
+        """
+        dist_to_player = math.sqrt(
+            (projectile.x - player.x) ** 2 + (projectile.y - player.y) ** 2
+        )
+        if dist_to_player < 15:
+            damage_flash_timer = 15
+
+        sw2 = self.C.SCREEN_WIDTH // 2
+        sh2 = self.C.SCREEN_HEIGHT // 2
+
+        color = self.C.CYAN if weapon_type == "plasma" else self.C.ORANGE
+        self.particle_system.add_world_explosion(
+            projectile.x,
+            projectile.y,
+            getattr(projectile, "z", 0.5),
+            count=50,
+            color=color,
+            speed=0.3,
+        )
+
+        if dist_to_player < 20:
+            count = 5 if weapon_type == "rocket" else 3
+            self.particle_system.add_explosion(sw2, sh2, count=count)
+
+            for _ in range(20):
+                self.particle_system.add_particle(
+                    x=sw2,
+                    y=sh2,
+                    dx=random.uniform(-10, 10),
+                    dy=random.uniform(-10, 10),
+                    color=color,
+                    timer=40,
+                    size=random.randint(4, 8),
+                )
+
+        try:
+            self.sound_manager.play_sound(
+                "boom_real" if weapon_type == "rocket" else "shoot_plasma"
+            )
+        except Exception:
+            pass
+
+        for bot in self.entity_manager.bots:
+            if not bot.alive:
+                continue
+            dx = bot.x - projectile.x
+            dy = bot.y - projectile.y
+            dist = math.sqrt(dx * dx + dy * dy)
+
+            if dist < radius:
+                damage_factor = 1.0 - (dist / radius)
+                damage = int(projectile.damage * damage_factor)
+
+                if bot.take_damage(damage):
+                    self.handle_kill(bot)
+
+        return damage_flash_timer

--- a/src/games/shared/spawn_manager.py
+++ b/src/games/shared/spawn_manager.py
@@ -1,0 +1,211 @@
+"""Base class for spawn managers.
+
+Encapsulates enemy spawning, position validation, and level scaling
+logic that was previously duplicated across game.py files.
+
+Subclasses override constants and Bot construction as needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SpawnManagerBase:
+    """Manages enemy, boss, pickup, and item spawning for FPS games.
+
+    Dependencies are injected via the constructor -- the manager never
+    holds a reference back to the Game object.
+
+    Args:
+        entity_manager: The EntityManager that owns bot/projectile lists.
+        constants: The game-specific constants module (C).
+    """
+
+    # Subclasses should set these to control spawn behavior.
+    # They can also be overridden per-instance via constructor kwargs.
+    SPAWN_EXCLUSIONS: list[str] = [
+        "boss",
+        "demon",
+        "ball",
+        "beast",
+        "health_pack",
+        "ammo_box",
+        "bomb_item",
+    ]
+
+    BOSS_OPTIONS: list[str] = ["ball", "beast"]
+
+    WEAPON_PICKUPS: list[str] = [
+        "pickup_rifle",
+        "pickup_shotgun",
+        "pickup_plasma",
+        "pickup_minigun",
+    ]
+
+    PICKUP_CHANCE: float = 0.4
+    ITEM_COUNT: int = 8
+
+    def __init__(
+        self,
+        entity_manager: Any,
+        constants: Any,
+    ) -> None:
+        self.entity_manager = entity_manager
+        self.C = constants
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def spawn_all(
+        self,
+        player_pos: tuple[float, float, float],
+        game_map: Any,
+        level: int,
+        difficulty: str,
+    ) -> None:
+        """Spawn all entities for a new level.
+
+        Args:
+            player_pos: (x, y, angle) of the player spawn.
+            game_map: The Map instance.
+            level: Current game level (1-based).
+            difficulty: Difficulty key (e.g. "NORMAL").
+        """
+        self.spawn_enemies(player_pos, game_map, level, difficulty)
+        self.spawn_boss(player_pos, game_map, level, difficulty)
+        self.spawn_pickups(game_map, level)
+        self.spawn_items(game_map, level)
+
+    # ------------------------------------------------------------------
+    # Spawning methods (override in subclasses for game-specific logic)
+    # ------------------------------------------------------------------
+
+    def _make_bot(
+        self,
+        x: float,
+        y: float,
+        level: int,
+        enemy_type: str,
+        difficulty: str = "NORMAL",
+    ) -> Any:
+        """Create a Bot instance.  Subclasses must override this."""
+        raise NotImplementedError("Subclasses must implement _make_bot")
+
+    def _get_num_enemies(self, level: int, difficulty: str) -> int:
+        """Calculate number of enemies to spawn for a level."""
+        score_mult = self.C.DIFFICULTIES[difficulty]["score_mult"]
+        return int(min(50, 5 + level * 2 * score_mult))
+
+    def _get_enemy_type(self) -> str:
+        """Choose a random valid enemy type (excluding bosses/items)."""
+        keys = list(self.C.ENEMY_TYPES.keys())
+        enemy_type = random.choice(keys)
+        while self._is_excluded(enemy_type):
+            enemy_type = random.choice(keys)
+        return enemy_type
+
+    def _is_excluded(self, enemy_type: str) -> bool:
+        """Check if an enemy type should be excluded from regular spawning."""
+        if enemy_type in self.SPAWN_EXCLUSIONS:
+            return True
+        if enemy_type.startswith("pickup"):
+            return True
+        return False
+
+    def spawn_enemies(
+        self,
+        player_pos: tuple[float, float, float],
+        game_map: Any,
+        level: int,
+        difficulty: str,
+    ) -> None:
+        """Spawn regular enemies for the level."""
+        num_enemies = self._get_num_enemies(level, difficulty)
+        safe_radius_sq = getattr(self.C, "SPAWN_SAFE_ZONE_RADIUS", 15.0) ** 2
+
+        for _ in range(num_enemies):
+            placed = False
+            for attempt in range(50):
+                bx = random.randint(2, game_map.size - 2)
+                by = random.randint(2, game_map.size - 2)
+
+                # Relax distance check on later attempts
+                min_dist_sq = safe_radius_sq if attempt < 40 else safe_radius_sq * 0.25
+                dist_sq = (bx - player_pos[0]) ** 2 + (by - player_pos[1]) ** 2
+
+                if dist_sq < min_dist_sq and attempt < 49:
+                    continue
+
+                if not game_map.is_wall(bx, by):
+                    enemy_type = self._get_enemy_type()
+                    self.entity_manager.add_bot(
+                        self._make_bot(
+                            bx + 0.5, by + 0.5, level, enemy_type, difficulty
+                        )
+                    )
+                    placed = True
+                    break
+
+            if not placed:
+                logger.warning("Failed to spawn enemy after 50 attempts.")
+
+    def spawn_boss(
+        self,
+        player_pos: tuple[float, float, float],
+        game_map: Any,
+        level: int,
+        difficulty: str,
+    ) -> None:
+        """Spawn a boss enemy far from the player."""
+        boss_type = random.choice(self.BOSS_OPTIONS)
+        min_boss_dist = getattr(self.C, "MIN_BOSS_DISTANCE", 15.0)
+
+        upper_bound = max(2, game_map.size - 3)
+        for attempt in range(100):
+            cx = random.randint(2, upper_bound)
+            cy = random.randint(2, upper_bound)
+
+            min_boss_dist_sq = (
+                min_boss_dist**2 if attempt < 70 else (min_boss_dist * 0.7) ** 2
+            )
+            dist_sq = (cx - player_pos[0]) ** 2 + (cy - player_pos[1]) ** 2
+
+            if not game_map.is_wall(cx, cy) and dist_sq > min_boss_dist_sq:
+                self.entity_manager.add_bot(
+                    self._make_bot(cx + 0.5, cy + 0.5, level, boss_type, difficulty)
+                )
+                break
+
+    def spawn_pickups(self, game_map: Any, level: int) -> None:
+        """Spawn weapon pickups on the map."""
+        for w_pickup in self.WEAPON_PICKUPS:
+            if random.random() < self.PICKUP_CHANCE:
+                rx = random.randint(5, game_map.size - 5)
+                ry = random.randint(5, game_map.size - 5)
+                if not game_map.is_wall(rx, ry):
+                    self.entity_manager.add_bot(
+                        self._make_bot(rx + 0.5, ry + 0.5, level, w_pickup)
+                    )
+
+    def spawn_items(self, game_map: Any, level: int) -> None:
+        """Spawn health packs, ammo boxes, and bombs."""
+        for _ in range(self.ITEM_COUNT):
+            rx = random.randint(5, game_map.size - 5)
+            ry = random.randint(5, game_map.size - 5)
+            if not game_map.is_wall(rx, ry):
+                choice = random.random()
+                if choice < 0.2:
+                    item_type = "bomb_item"
+                elif choice < 0.7:
+                    item_type = "ammo_box"
+                else:
+                    item_type = "health_pack"
+                self.entity_manager.add_bot(
+                    self._make_bot(rx + 0.5, ry + 0.5, level, item_type)
+                )


### PR DESCRIPTION
## Summary

Fixes #478

- **Extract spawn logic** into `SpawnManagerBase` (shared) with game-specific subclasses (`DuumSpawnManager`, `ZSSpawnManager`, `FFSpawnManager`) that override bot construction and spawn configuration
- **Extract combat resolution** into `CombatManagerBase` (shared) with game-specific subclasses (`DuumCombatManager`, `ZSCombatManager`) handling hitscan hit detection, explosions, and kill tracking via constructor-injected dependencies
- **~810 net lines removed** from game.py files, replaced with thin delegation wrappers; `fire_weapon()` and `_fire_*` dispatch stays in game.py as designed
- Force_Field `CombatSystem` kept as-is (too deeply coupled with FF-specific features like recoil, screen_shake, freezer, pulse, flamethrower)

### New files
| File | Description |
|------|-------------|
| `src/games/shared/spawn_manager.py` | `SpawnManagerBase` — enemy, boss, pickup, item spawning |
| `src/games/shared/combat_manager.py` | `CombatManagerBase` — hitscan, explosions, kill tracking |
| `src/games/Duum/src/spawn_manager.py` | `DuumSpawnManager` subclass |
| `src/games/Duum/src/combat_manager.py` | `DuumCombatManager` subclass |
| `src/games/Zombie_Survival/src/spawn_manager.py` | `ZSSpawnManager` subclass |
| `src/games/Zombie_Survival/src/combat_manager.py` | `ZSCombatManager` subclass |
| `src/games/Force_Field/src/spawn_manager.py` | `FFSpawnManager` subclass |

### Design decisions
- Managers receive dependencies via **constructor injection** (entity_manager, particle_system, sound_manager, constants) — no back-reference to Game
- Kill events bridged to EventBus via `on_kill` callback lambda
- Combo state synchronized bidirectionally: combat_manager tracks kills, game reads back via `_sync_combat_state()`, game pushes timer decrements back

## Test plan
- [x] All 379 tests pass (`PYTHONPATH=src python3 -m pytest tests/ --ignore=tests/shared/test_notes_workspace.py -q`)
- [x] `ruff check src/games/` — all checks passed
- [x] `black --check src/games/` — all files formatted
- [x] Pre-commit hooks pass (ruff, ruff-format, black, no-wildcard-imports, no-debug, no-print)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 6d3896f0c7ac703c46ffcf82e4f41291ae330afa. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->