### PR TITLE
[codex] repository feature inventory tracking refresh

### DIFF
--- a/docs/development/REPOSITORY_FEATURE_INDEX.md
+++ b/docs/development/REPOSITORY_FEATURE_INDEX.md
@@ -1,0 +1,12 @@
+# Repository Feature Index
+
+> Last updated: 2026-02-27
+> Canonical inventory: docs/development/REPOSITORY_FEATURE_INVENTORY_2026-02-27.md
+
+This document is the stable entry point for agent-friendly feature discovery in this repository.
+
+## Maintenance Process
+
+1. Update module-level README files when functionality changes.
+2. Refresh the dated repository inventory under docs/development/.
+3. Keep docs/workflows/WORKFLOW_TRACKING.md synchronized with .github/workflows.

--- a/docs/development/REPOSITORY_FEATURE_INVENTORY_2026-02-27.md
+++ b/docs/development/REPOSITORY_FEATURE_INVENTORY_2026-02-27.md
@@ -1,0 +1,21 @@
+# Repository Feature Inventory (Current Reality)
+
+- Repository: Games
+- Date: 2026-02-27
+- Source of truth: repository directory structure and tracked files
+- Functional modules identified: 1
+- Implemented modules (code detected): 1
+- Modules missing module-level README.md: 1
+- Workflow files present: 42
+
+## Functional Module Map
+
+| Module | Path | Python Files | Web Files (js/ts/tsx) | MATLAB Files | README | Implementation State |
+| --- | --- | --- | --- | --- | --- | --- |
+| games | src/games | 132 | 3 | 0 | No (gap) | implemented |
+
+## Implementation Gaps
+
+1. Module README gaps detected: 1
+2. This inventory is structure-based; deeper behavioral verification should be tracked as follow-up issues when needed.
+3. Keep this file refreshed when modules/surfaces are added or removed.

--- a/docs/workflows/WORKFLOW_TRACKING.md
+++ b/docs/workflows/WORKFLOW_TRACKING.md
@@ -1,16 +1,54 @@
 # Workflow Tracking Document
 
-This document lists all active GitHub Workflows in this repository.
+This document lists GitHub Actions workflows currently present in this repository.
 
-| Workflow Name | Filename | Status | Purpose |
-| :--- | :--- | :--- | :--- |
-| **Control Tower** | `Jules-Control-Tower.yml` | Active | Orchestrates agentic workers. |
-| **PR Compiler** | `Jules-PR-Compiler.yml` | Active | Compiles PR info for fleet management. |
-| **CI Standard** | `ci-standard.yml` | Active | Linting, Formatting, and Type checking. |
-| **Python Tests** | `ci-fast-tests.yml` | Active | Runs unit and integration tests. |
-| **Assessment Generator** | `Jules-Assessment-Generator.yml` | Active | Automated architecture & quality audits. |
+Global status note: Paused for catching up.
 
----
+| Workflow File | Status | Purpose |
+| --- | --- | --- |
+| agent-metrics-dashboard.yml | Defined | See workflow YAML for trigger and responsibility. |
+| auto-update-prs.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Bot-CI-Trigger.yml | Defined | See workflow YAML for trigger and responsibility. |
+| ci-failure-digest.yml | Defined | See workflow YAML for trigger and responsibility. |
+| ci-standard.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Archivist.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Assessment-Generator.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Assessment-Remediator.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Auto-Assign-Issues.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Auto-Rebase.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Auto-Refactor.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Auto-Repair.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Cleaner.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Code-Quality-Fixer.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Code-Quality-Reviewer.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Completist.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Comprehensive-Assessment.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Consolidator.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Control-Tower.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Critics-Comments.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Curie.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Documentation-Auditor.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Documentation-Scribe.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Hotfix-Creator.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Hypatia.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Issue-Mention-Handler.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Issue-Resolver.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Laymans-Terms-Writer.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-PR-AutoFix.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-PR-Cleanup.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-PR-Compiler.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Render-Healer.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Review-Fix.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Sentinel.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Supersede-Check.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Test-Generator.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Jules-Thesis-Defender.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Maintenance-Global-Control.yml | Defined | See workflow YAML for trigger and responsibility. |
+| Nightly-Doc-Organizer.yml | Defined | See workflow YAML for trigger and responsibility. |
+| pr-auto-labeler.yml | Defined | See workflow YAML for trigger and responsibility. |
+| PR-Comment-Responder.yml | Defined | See workflow YAML for trigger and responsibility. |
+| stale-cleanup.yml | Defined | See workflow YAML for trigger and responsibility. |
 
 ## Maintenance
-Update this document whenever a new workflow is added or the status of an existing workflow changes. For global standards, see `Repository_Management/docs/architecture/WORKFLOW_GOVERNANCE.md`.
+
+Update this file whenever workflows are added, removed, enabled, or disabled.


### PR DESCRIPTION
## Summary
Add an agent-friendly repository feature tracking baseline based on current repository structure.

## Changes
- Add docs/development/REPOSITORY_FEATURE_INDEX.md as stable discovery entrypoint.
- Add docs/development/REPOSITORY_FEATURE_INVENTORY_2026-02-27.md with module/surface inventory and README coverage signals.
- Refresh docs/workflows/WORKFLOW_TRACKING.md from current .github/workflows files.

## Why
This establishes a consistent reference map for features and implementation state so automation agents can discover maintained components reliably.

Closes #500
