### PR TITLE
ci: update official GitHub action versions

### DIFF
--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -20,15 +20,15 @@ on:
 
   # Also run on a schedule to catch any missed PRs
   schedule:
-    - cron: "0 8 * * 2"  # Every 2 hours (reduced from 15 min for cost control)
+    - cron: "0 8 * * 2" # Every 2 hours (reduced from 15 min for cost control)
 
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to trigger CI for (optional)'
+        description: "PR number to trigger CI for (optional)"
         required: false
       force:
-        description: 'Force trigger even if checks exist'
+        description: "Force trigger even if checks exist"
         required: false
         type: boolean
         default: false
@@ -51,7 +51,7 @@ jobs:
         github.event.pull_request.user.type == 'Bot'))
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 5

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -16,15 +16,15 @@ jobs:
   generate-assessments:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -7,30 +7,30 @@ on:
   workflow_dispatch:
     inputs:
       max_issues:
-        description: 'Maximum issues to process (1-3)'
+        description: "Maximum issues to process (1-3)"
         required: false
-        default: '1'
+        default: "1"
         type: choice
         options:
-          - '1'
-          - '2'
-          - '3'
+          - "1"
+          - "2"
+          - "3"
       priority_filter:
-        description: 'Priority filter'
+        description: "Priority filter"
         required: false
-        default: 'all'
+        default: "all"
         type: choice
         options:
-          - 'critical'
-          - 'high'
-          - 'all'
+          - "critical"
+          - "high"
+          - "all"
       dry_run:
-        description: 'Dry run (preview only, no assignments)'
+        description: "Dry run (preview only, no assignments)"
         required: false
         default: false
         type: boolean
       specific_issue:
-        description: 'Specific issue number (overrides other filters)'
+        description: "Specific issue number (overrides other filters)"
         required: false
         type: string
   schedule:
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Find and Assign Issues
         id: assign

--- a/.github/workflows/Jules-Auto-Rebase.yml
+++ b/.github/workflows/Jules-Auto-Rebase.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Jules-Auto-Refactor.yml
+++ b/.github/workflows/Jules-Auto-Refactor.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -26,13 +26,13 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to repair'
+        description: "Branch to repair"
         required: true
         type: string
       max_iterations:
-        description: 'Maximum repair iterations'
+        description: "Maximum repair iterations"
         required: false
-        default: '5'
+        default: "5"
         type: string
 
 permissions:
@@ -123,17 +123,17 @@ jobs:
             echo "exceeded=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
         with:
           ref: ${{ steps.branch.outputs.branch }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install Tools
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -5,12 +5,12 @@ on:
   workflow_dispatch:
     inputs:
       assessment_file:
-        description: 'Path to assessment file'
+        description: "Path to assessment file"
         required: false
-        default: 'docs/assessments/Code_Quality_Review_Latest.md'
+        default: "docs/assessments/Code_Quality_Review_Latest.md"
         type: string
       dry_run:
-        description: 'Dry run - analyze only'
+        description: "Dry run - analyze only"
         required: false
         default: false
         type: boolean
@@ -28,15 +28,15 @@ jobs:
   fix-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -85,43 +85,43 @@ jobs:
           DATE=$(date +%Y-%m-%d)
           REPO="${{ github.repository }}"
           API_BASE="https://jules.googleapis.com/v1alpha"
-          
+
           # Check if API key is configured
           if [ -z "$JULES_API_KEY" ]; then
             echo "::warning::JULES_API_KEY not configured. Skipping Jules task."
             exit 0
           fi
-          
+
           echo "Looking up repository source..."
           SOURCES=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/sources" || echo '{"sources":[]}')
-          
+
           OWNER=$(echo "$REPO" | cut -d'/' -f1)
           REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
-          
+
           SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.githubRepo.owner == \"$OWNER\" and .githubRepo.repo == \"$REPO_NAME\") | .name" | head -1)
-          
+
           if [ -z "$SOURCE_ID" ] || [ "$SOURCE_ID" = "null" ]; then
             echo "::warning::Repository $REPO not found in Jules sources."
             exit 0
           fi
-          
+
           echo "Found source: $SOURCE_ID"
-          
+
           # Create session prompt
           PROMPT=$(cat << 'PROMPT_EOF'
           You are the CODE QUALITY FIXER agent.
-          
+
           Fix issues in the assessment file. Priority: CRITICAL > HIGH > MEDIUM > LOW
-          
+
           Rules:
           - DO NOT modify test assertions
           - DO NOT disable linting rules without justification
           - Run: ruff check . --fix && black .
-          
+
           Document fixes in docs/assessments/issues/
           PROMPT_EOF
           )
-          
+
           echo "Creating Jules session..."
           REQUEST_JSON=$(jq -n \
             --arg prompt "$PROMPT" \
@@ -136,36 +136,36 @@ jobs:
               },
               # automationMode: "AUTO_CREATE_PR"
             }')
-          
+
           echo "Request: $REQUEST_JSON"
-          
+
           HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
             -H "X-Goog-Api-Key: $JULES_API_KEY" \
             -H "Content-Type: application/json" \
             -d "$REQUEST_JSON" \
             "$API_BASE/sessions")
-          
+
           SESSION_RESPONSE=$(cat /tmp/session_response.json)
           echo "HTTP Status: $HTTP_CODE"
-          
+
           if [ "$HTTP_CODE" != "200" ]; then
             echo "::error::Jules API returned HTTP $HTTP_CODE"
             exit 1
           fi
-          
+
           SESSION_ID=$(echo "$SESSION_RESPONSE" | jq -r '.name')
           echo "Created session: $SESSION_ID"
-          
+
           # Poll for completion
           MAX_WAIT=1800
           POLL_INTERVAL=30
           ELAPSED=0
-          
+
           while [ $ELAPSED -lt $MAX_WAIT ]; do
             SESSION_STATUS=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/$SESSION_ID")
             STATE=$(echo "$SESSION_STATUS" | jq -r '.state')
             echo "Session state: $STATE (elapsed: ${ELAPSED}s)"
-          
+
             case "$STATE" in
               "COMPLETED"|"SUBMITTED")
                 echo "Session completed successfully!"
@@ -179,7 +179,7 @@ jobs:
             sleep $POLL_INTERVAL
             ELAPSED=$((ELAPSED + POLL_INTERVAL))
           done
-          
+
 
 
           ruff check . --fix || true

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       days_to_review:
-        description: 'Days to review'
+        description: "Days to review"
         required: false
-        default: '2'
+        default: "2"
         type: string
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
@@ -22,15 +22,15 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -131,7 +131,6 @@ jobs:
           sleep $POLL_INTERVAL
           ELAPSED=$((ELAPSED + POLL_INTERVAL))
           done
-
 
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -20,7 +20,7 @@ jobs:
     name: Find Incomplete Implementations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -2,7 +2,7 @@ name: Jules Comprehensive Assessment
 
 on:
   schedule:
-    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
+    - cron: "0 8 * * 2" # Weekly on Tuesday at 8 AM UTC (midnight PST)
   workflow_dispatch:
 
 permissions:
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -25,12 +25,12 @@ jobs:
         run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -64,7 +64,7 @@ jobs:
         run: |
           echo "Collecting incomplete implementation patterns..."
           mkdir -p .jules/completist_data
-          
+
           # Find TODO/FIXME markers
           grep -rn "TODO\|FIXME\|XXX\|HACK\|TEMP" --include="*.py" --include="*.ts" --include="*.js" . \
             --exclude-dir=".git" --exclude-dir="venv" --exclude-dir="node_modules" \
@@ -110,7 +110,7 @@ jobs:
           commit_message: "docs(assessment): pre-assessment data collection"
           branch: "automation/assessment-${{ steps.date.outputs.date }}"
           create_branch: true
-          push_options: '--force'
+          push_options: "--force"
 
       # ---------------------------------------------------------
       # Component 3: Jules Comprehensive Assessment (API)
@@ -148,9 +148,9 @@ jobs:
 
           ## Mission
           Perform a thorough audit of the repository, combining General Code Quality (A-O), Completist Analysis, and Pragmatic Programmer review.
-          
+
           ## Requirements
-          
+
           ### 1. General Assessment (Categories A-O) - CRITICAL
           **You must NOT perform a generic assessment.**
           For EACH category from A to O:
@@ -158,14 +158,14 @@ jobs:
           2. **Follow Instructions Exactly**: Each prompt file contains specific tables, scoring criteria, and output formats. You MUST follow them.
           3. **Full Review**: Do not "lazy bypass". If the prompt asks for a "Critical Path Analysis", do it. If it asks for a "Findings Table" with specific columns, create it.
           4. **Output**: Save the detailed report to `docs/assessments/Assessment_X_Category.md` (or matching the pattern in the prompt).
-          
+
           If a specific prompt file is missing, perform a standard thorough assessment for that category, but prioritize the existing prompt files.
-          
+
           ### 2. Completist Audit
           - Review data in `.jules/completist_data/` (todos, not_implemented, etc).
           - Create `docs/assessments/completist/Completist_Report_DATE.md`.
           - Summarize critical gaps and technical debt.
-          
+
           ### 3. Pragmatic Programmer Review
           - I have already run a script to generate `docs/assessments/pragmatic_programmer/review_*.md`.
           - Please READ this file if it exists and incorporate its findings into your Comprehensive Report.
@@ -174,14 +174,14 @@ jobs:
           - Create `docs/assessments/Comprehensive_Assessment.md`.
           - Include a unified scorecard: General Grades + Completist Score + Pragmatic Score.
           - Top 10 unified recommendations.
-          
+
           ## PR Title Instruction
           The Pull Request Title MUST be exactly:
           [REPO_NAME_PLACEHOLDER] [docs] Assessment Generation - DATE_PLACEHOLDER
-          
+
           PROMPT_EOF
           )
-          
+
           # Inject Variables into Prompt
           PROMPT="${PROMPT//REPO_NAME_PLACEHOLDER/$REPO_NAME}"
           PROMPT="${PROMPT//DATE_PLACEHOLDER/$DATE}"
@@ -249,19 +249,19 @@ jobs:
           DATE=$(date +%Y-%m-%d)
           EXPECTED_TITLE="[${{ github.event.repository.name }}] [docs] Assessment Generation - $DATE"
           BRANCH="automation/assessment-$DATE"
-          
+
           echo "Looking for PR on branch $BRANCH or by app/jules..."
-          
+
           # Try 1: By Branch
           PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
-          
+
           # Try 2: By Author (Recent)
           if [ -z "$PR" ]; then
             # Wait a moment for creation if needed
             sleep 5
             PR=$(gh pr list --author "app/jules" --state open --sort created --limit 1 --json number --jq '.[0].number')
           fi
-          
+
           if [ -n "$PR" ]; then
             echo "Found PR #$PR. Updating title..."
             gh pr edit "$PR" --title "$EXPECTED_TITLE"

--- a/.github/workflows/Jules-Consolidator.yml
+++ b/.github/workflows/Jules-Consolidator.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run'
+        description: "Dry run"
         required: false
-        default: 'false'
+        default: "false"
         type: boolean
   schedule:
-    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
+    - cron: "0 8 * * 2" # Weekly on Tuesday at 8 AM UTC (midnight PST)
 
 concurrency:
   group: jules-consolidator
@@ -28,7 +28,7 @@ jobs:
       pr_list: ${{ steps.list.outputs.prs }}
       should_consolidate: ${{ steps.list.outputs.should_consolidate }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: List PRs
         id: list
@@ -47,7 +47,7 @@ jobs:
     if: needs.discover.outputs.should_consolidate == 'true' && inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       severity_threshold:
-        description: 'Minimum severity to report'
+        description: "Minimum severity to report"
         required: false
-        default: 'medium'
+        default: "medium"
         type: choice
         options:
           - low
@@ -31,11 +31,11 @@ jobs:
     name: Critical Code Review
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/Jules-Curie.yml
+++ b/.github/workflows/Jules-Curie.yml
@@ -3,7 +3,7 @@ name: Jules Curie (Data Hygiene)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
+    - cron: "0 8 * * 2" # Weekly on Tuesday at 8 AM UTC (midnight PST)
 
 permissions:
   contents: write
@@ -12,13 +12,13 @@ jobs:
   hygiene-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v6
+
       - name: Find Large Files (>10MB)
         id: large_files
         run: |
           find . -type f -size +10M -not -path "./.git/*" > large_files.txt
-          
+
       - name: Curie Journal Entry
         run: |
           echo "## $(date +'%Y-%m-%d') - Monthly Hygiene Check" >> .jules/curie.md

--- a/.github/workflows/Jules-Documentation-Auditor.yml
+++ b/.github/workflows/Jules-Documentation-Auditor.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2 # We need at least 2 commits to run diff (HEAD and HEAD^)
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Setup Node
         if: steps.changes.outputs.files != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with: { node-version: "20" }
 
       - name: Install & Auth Jules

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -24,12 +24,12 @@ jobs:
     # Only run for trusted branches (main/master)
     if: inputs.failed_branch == 'main' || inputs.failed_branch == 'master'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.failed_branch }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with: { node-version: "20" }
       - run: npm install -g @google/jules
       - run: jules auth --token ${{ secrets.JULES_API_KEY }}

--- a/.github/workflows/Jules-Hypatia.yml
+++ b/.github/workflows/Jules-Hypatia.yml
@@ -2,7 +2,7 @@ name: Jules Hypatia (Librarian)
 
 on:
   schedule:
-    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
+    - cron: "0 8 * * 2" # Weekly on Tuesday at 8 AM UTC (midnight PST)
   workflow_dispatch: # Allow manual trigger
 
 permissions:
@@ -12,7 +12,7 @@ jobs:
   archive-stale-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Identify Stale Documentation
         id: find_stale

--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -41,7 +41,7 @@ jobs:
     if: needs.check-mention.outputs.should_run == 'true' && !github.event.issue.pull_request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       max_issues:
-        description: 'Maximum issues to fix per run'
+        description: "Maximum issues to fix per run"
         required: false
-        default: '5'
+        default: "5"
         type: string
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
@@ -26,15 +26,15 @@ jobs:
   resolve-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -97,42 +97,42 @@ jobs:
           DATE=$(date +%Y-%m-%d)
           REPO="${{ github.repository }}"
           API_BASE="https://jules.googleapis.com/v1alpha"
-          
+
           # Check if API key is configured
           if [ -z "$JULES_API_KEY" ]; then
             echo "::warning::JULES_API_KEY not configured. Skipping Jules task."
             exit 0
           fi
-          
+
           echo "Looking up repository source..."
           SOURCES=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/sources" || echo '{"sources":[]}')
-          
+
           OWNER=$(echo "$REPO" | cut -d'/' -f1)
           REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
-          
+
           SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.githubRepo.owner == \"$OWNER\" and .githubRepo.repo == \"$REPO_NAME\") | .name" | head -1)
-          
+
           if [ -z "$SOURCE_ID" ] || [ "$SOURCE_ID" = "null" ]; then
             echo "::warning::Repository $REPO not found in Jules sources."
             exit 0
           fi
-          
+
           echo "Found source: $SOURCE_ID"
-          
+
           # Create session prompt
           PROMPT=$(cat << 'PROMPT_EOF'
           '
           You are the ISSUE RESOLVER agent. FIX identified issues from .jules/resolver_data/.
-          
+
           1. Identify TOP $MAX_ISSUES priority items
           2. ACTUALLY FIX THEM - make code changes
           3. Run: ruff check . --fix && black .
           4. Document in docs/assessments/issues/resolved/
-          
+
           Include "Fixes #NUM" for issues you completely resolve.
           PROMPT_EOF
           )
-          
+
           echo "Creating Jules session..."
           REQUEST_JSON=$(jq -n \
             --arg prompt "$PROMPT" \
@@ -147,36 +147,36 @@ jobs:
               },
               # automationMode: "AUTO_CREATE_PR"
             }')
-          
+
           echo "Request: $REQUEST_JSON"
-          
+
           HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
             -H "X-Goog-Api-Key: $JULES_API_KEY" \
             -H "Content-Type: application/json" \
             -d "$REQUEST_JSON" \
             "$API_BASE/sessions")
-          
+
           SESSION_RESPONSE=$(cat /tmp/session_response.json)
           echo "HTTP Status: $HTTP_CODE"
-          
+
           if [ "$HTTP_CODE" != "200" ]; then
             echo "::error::Jules API returned HTTP $HTTP_CODE"
             exit 1
           fi
-          
+
           SESSION_ID=$(echo "$SESSION_RESPONSE" | jq -r '.name')
           echo "Created session: $SESSION_ID"
-          
+
           # Poll for completion
           MAX_WAIT=1800
           POLL_INTERVAL=30
           ELAPSED=0
-          
+
           while [ $ELAPSED -lt $MAX_WAIT ]; do
             SESSION_STATUS=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/$SESSION_ID")
             STATE=$(echo "$SESSION_STATUS" | jq -r '.state')
             echo "Session state: $STATE (elapsed: ${ELAPSED}s)"
-          
+
             case "$STATE" in
               "COMPLETED"|"SUBMITTED")
                 echo "Session completed successfully!"
@@ -190,8 +190,6 @@ jobs:
             sleep $POLL_INTERVAL
             ELAPSED=$((ELAPSED + POLL_INTERVAL))
           done
-          
-
 
       - name: Run Linters
         continue-on-error: true

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       target_path:
-        description: 'Path to analyze'
+        description: "Path to analyze"
         required: false
-        default: 'games/'
+        default: "games/"
         type: string
 
 permissions:
@@ -26,11 +26,11 @@ jobs:
     name: Generate Plain Language Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/Jules-PR-AutoFix.yml
+++ b/.github/workflows/Jules-PR-AutoFix.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Checkout PR Branch
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.branch.outputs.branch }}
           fetch-depth: 0
@@ -139,7 +139,7 @@ jobs:
 
       - name: Setup Python
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -8,17 +8,17 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run - analyze only without creating PR'
+        description: "Dry run - analyze only without creating PR"
         required: false
-        default: 'true'
+        default: "true"
         type: choice
         options:
-          - 'true'
-          - 'false'
+          - "true"
+          - "false"
       branch_pattern:
-        description: 'Pattern to match branches for consolidation'
+        description: "Pattern to match branches for consolidation"
         required: false
-        default: 'jules/'
+        default: "jules/"
         type: string
 
 permissions:
@@ -34,7 +34,7 @@ jobs:
     name: Compile Related PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Jules-Render-Healer.yml
+++ b/.github/workflows/Jules-Render-Healer.yml
@@ -14,7 +14,7 @@ jobs:
       'failure'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: npm install -g @google/jules
 
       - name: Heal Deployment
@@ -25,15 +25,15 @@ jobs:
           # REST API Implementation
           REPO="${{ github.repository }}"
           API_BASE="https://jules.googleapis.com/v1alpha"
-          
+
           echo "Looking up repository source..."
           SOURCES=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/sources" || echo '{"sources":[]}')
-          
+
           OWNER=$(echo "$REPO" | cut -d'/' -f1)
           REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
-          
+
           SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.githubRepo.owner == \"$OWNER\" and .githubRepo.repo == \"$REPO_NAME\") | .name" | head -1)
-          
+
           if [ -z "$SOURCE_ID" ] || [ "$SOURCE_ID" = "null" ]; then
             echo "::warning::Repository $REPO not found in Jules sources."
             exit 0
@@ -52,10 +52,9 @@ jobs:
               },
               automationMode: "AUTO_CREATE_PR"
             }')
-          
+
           # Fire and forget session creation
           curl -sf -X POST -H "X-Goog-Api-Key: $JULES_API_KEY" \
              -H "Content-Type: application/json" \
              -d "$REQUEST_JSON" \
              "$API_BASE/sessions"
-

--- a/.github/workflows/Jules-Review-Fix.yml
+++ b/.github/workflows/Jules-Review-Fix.yml
@@ -30,10 +30,10 @@ jobs:
             exit 1 # Fail the step to stop execution safely
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with: { node-version: "20" }
       - run: npm install -g @google/jules
 

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -15,15 +15,15 @@ jobs:
   security-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -123,7 +123,6 @@ jobs:
           sleep $POLL_INTERVAL
           ELAPSED=$((ELAPSED + POLL_INTERVAL))
           done
-
 
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/Jules-Supersede-Check.yml
+++ b/.github/workflows/Jules-Supersede-Check.yml
@@ -30,7 +30,7 @@ jobs:
       !startsWith(github.event.head_commit.message, '[Jules/')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50 # Get recent history for comparison
 

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -11,7 +11,7 @@ jobs:
   generate-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 2 }
 
       - name: Identify New/Modified Files
@@ -30,7 +30,7 @@ jobs:
           FILES_FLAT=$(echo "$CHANGED_FILES" | tr '\n' ', ')
           echo "files=$FILES_FLAT" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with: { node-version: "20" }
       - run: npm install -g @google/jules
 

--- a/.github/workflows/Maintenance-Global-Control.yml
+++ b/.github/workflows/Maintenance-Global-Control.yml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'Action to perform'
+        description: "Action to perform"
         required: true
-        default: 'pause'
+        default: "pause"
         type: choice
         options:
           - pause
           - resume
       reason:
-        description: 'Reason for pause/resume'
+        description: "Reason for pause/resume"
         required: false
-        default: 'Maintenance'
+        default: "Maintenance"
 
 jobs:
   control:
@@ -23,7 +23,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Update Pause State
         env:

--- a/.github/workflows/Nightly-Doc-Organizer.yml
+++ b/.github/workflows/Nightly-Doc-Organizer.yml
@@ -2,7 +2,7 @@ name: Weekly Documentation Organizer
 
 on:
   schedule:
-    - cron: "0 8 * * 2"  # Weekly on Tuesday at 8 AM UTC (midnight PST)
+    - cron: "0 8 * * 2" # Weekly on Tuesday at 8 AM UTC (midnight PST)
   workflow_dispatch:
 
 permissions:
@@ -14,7 +14,7 @@ jobs:
     if: hashFiles('.github/WORKFLOWS_PAUSED') == ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -27,7 +27,6 @@ jobs:
       (github.event_name == 'pull_request_review_comment') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
     runs-on: ubuntu-latest
-
     steps:
       - name: Filter Bot Comments
         id: filter
@@ -72,7 +71,7 @@ jobs:
             echo "should_skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.filter.outputs.is_bot != 'true' && steps.pr_state.outputs.should_skip != 'true'
         with:
           fetch-depth: 1

--- a/.github/workflows/agent-metrics-dashboard.yml
+++ b/.github/workflows/agent-metrics-dashboard.yml
@@ -16,7 +16,7 @@ jobs:
   generate-metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Collect Agent Metrics
         id: metrics

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,7 +1,7 @@
 name: Auto-Update PRs
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: ["master", "main"]
 
 permissions:
   contents: write
@@ -11,7 +11,7 @@ jobs:
   update-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update PRs with strictly linear history
         uses: chinthakagodawita/autoupdate-action@v1
         env:

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -15,7 +15,7 @@ jobs:
   generate-digest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Analyze CI Failures from Last Week
         id: analyze

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -4,19 +4,19 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.github/**'
+      - "docs/**"
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+      - ".github/**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.github/**'
+      - "docs/**"
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+      - ".github/**"
   workflow_dispatch:
 
 permissions:
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11" }
       - run: pip install ruff==0.14.10 black==26.1.0 mypy==1.13.0 bandit==1.7.7 pydocstyle==6.3.0
 
@@ -98,7 +98,7 @@ jobs:
           cat matlab_quality_report.txt
 
       - name: Upload MATLAB Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: matlab-quality-report
@@ -108,8 +108,8 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11" }
       - name: Install pip-audit
         run: pip install pip-audit
@@ -125,8 +125,8 @@ jobs:
       matrix:
         python: ["3.11"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - run: pip install -r requirements.txt
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Auto-Label PR
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- refresh official GitHub-maintained action pins to current majors
- move checkout/setup actions onto Node 24-ready versions
- update artifact actions where older majors were still pinned

## Testing
- mechanical workflow pin refresh
- repo CI will validate runtime behavior