### PR TITLE
fix: bump requires-python to >=3.11 to match datetime.UTC usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "games"
 version = "0.0.0"
 description = "Game collection"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 
 
 [tool.setuptools.packages.find]
@@ -14,12 +14,12 @@ where = ["src"]
 include = ["games*"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py311"
 select = ["E", "F", "B", "UP", "I"]
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py311']
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- `notes_workspace.py` uses `datetime.UTC` (Python 3.11+) but `pyproject.toml` claimed `requires-python = ">=3.8"`
- Test collection fails on Python < 3.11 because `from datetime import UTC` raises `ImportError`
- Bumped `requires-python`, ruff `target-version`, and black `target-version` to `py311`

Closes #564

## Test plan
- [ ] CI tests pass (no more `ImportError` on `from datetime import UTC`)
- [ ] Ruff linting passes with `target-version = "py311"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)