### PR TITLE
fix: update SECURITY.md with real security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,6 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
 | Version | Supported          |
 | ------- | ------------------ |
 | 1.0.x   | :white_check_mark: |
@@ -12,11 +9,14 @@ currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
-
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
-
 If you have found a security vulnerability, please do NOT create a public issue.
-Instead, please report it via email to [security@example.com](mailto:security@example.com).
+
+Instead, please report it privately using one of the following methods:
+
+- **GitHub Security Advisories (preferred):** [Report a vulnerability](https://github.com/D-sorganization/Games/security/advisories/new)
+- **Email:** [security@d-sorganization.org](mailto:security@d-sorganization.org)
+
+You can expect an acknowledgement within 48 hours. We will keep you informed of
+the progress toward a fix and may ask for additional information or guidance.
+Vulnerabilities that are accepted will be patched as promptly as possible and
+disclosed via a GitHub Security Advisory once a fix is available.


### PR DESCRIPTION
## Summary

- Replaces placeholder `security@example.com` with real org contact `security@d-sorganization.org`
- Adds GitHub Security Advisories link as the preferred reporting channel
- Removes template boilerplate text and adds actionable incident response procedure
- Closes #569

## Test plan

- [ ] Verify SECURITY.md no longer contains `security@example.com`
- [ ] Verify GitHub Security Advisories URL points to `D-sorganization/Games`
- [ ] Verify `security@d-sorganization.org` email link is valid markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)