### PR TITLE
fix: replace datetime.UTC with timezone.utc for Python 3.10 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "games"
 version = "0.0.0"
 description = "Game collection"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 
 [tool.setuptools.packages.find]
@@ -14,12 +14,12 @@ where = ["src"]
 include = ["games*"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 select = ["E", "F", "B", "UP", "I"]
 
 [tool.black]
 line-length = 88
-target-version = ['py311']
+target-version = ['py310']
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,8 +2,8 @@
 # Configuration for the Ruff linter
 # Matches standards defined in ci-standard.yml
 
-# Target Python 3.11 (matches your CI environment)
-target-version = "py311"
+# Target Python 3.10 (actual CI environment; see issue #574)
+target-version = "py310"
 line-length = 88  # Matches Black standard (88 chars)
 
 # Exclude generated code and standard noise

--- a/src/games/shared/notes_workspace.py
+++ b/src/games/shared/notes_workspace.py
@@ -18,7 +18,7 @@ import json
 import logging
 import uuid
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from games.shared.contracts import ContractViolation, precondition
@@ -48,7 +48,7 @@ class Note:
 
 def _now_iso() -> str:
     """Return current UTC time as ISO 8601 string."""
-    return datetime.now(tz=UTC).isoformat()
+    return datetime.now(tz=timezone.utc).isoformat()
 
 
 class NotesWorkspace:


### PR DESCRIPTION
## Summary

- Replaces `from datetime import UTC` with `from datetime import datetime, timezone` in `src/games/shared/notes_workspace.py`
- Replaces `datetime.now(tz=UTC)` with `datetime.now(tz=timezone.utc)` — `timezone.utc` is available since Python 3.2
- Lowers `target-version` in both `ruff.toml` and `pyproject.toml` from `py311` to `py310` to prevent ruff rule `UP017` from auto-reverting the fix
- Lowers `requires-python` in `pyproject.toml` from `>=3.11` to `>=3.10` to match actual CI environment

`datetime.UTC` was introduced in Python 3.11 and causes `ImportError: cannot import name 'UTC' from 'datetime'` on the Python 3.10 CI runtime.

Closes #574

## Test plan

- [ ] `python3 -m ruff check src/games/shared/notes_workspace.py` passes
- [ ] `python3 -m ruff format --check src/games/shared/notes_workspace.py` passes
- [ ] `tests/shared/test_notes_workspace.py` collects and passes on Python 3.10
- [ ] CI passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)