### PR TITLE
fix: extract magic numbers into named constants

### DIFF
--- a/src/games/Duum/src/constants.py
+++ b/src/games/Duum/src/constants.py
@@ -137,6 +137,7 @@ DEFAULT_MAP_SIZE = 40
 # Balancing
 BOT_SPEED = 0.02  # Slower enemies (was 0.03)
 PLAYER_HEALTH = 100
+CHEAT_AMMO_AMOUNT = 999  # Full ammo granted by IDFA cheat code
 BASE_BOT_HEALTH = 30
 BASE_BOT_DAMAGE = 2  # Reduced from 3
 BOT_ATTACK_RANGE = 5

--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -116,7 +116,7 @@ class Game(FPSGameBase):
         self.entity_manager = EntityManager()
         self.raycaster: Raycaster | None = None
         self.portal: Portal | None = None
-        self.health = 100
+        self.health = C.PLAYER_HEALTH
         self.lives = C.DEFAULT_LIVES
 
         # Unlocked weapons tracking
@@ -384,7 +384,7 @@ class Game(FPSGameBase):
                             self.unlocked_weapons = set(C.WEAPONS.keys())
                             if self.player:
                                 for w in self.player.ammo:
-                                    self.player.ammo[w] = 999
+                                    self.player.ammo[w] = C.CHEAT_AMMO_AMOUNT
                             self.add_message("ALL WEAPONS UNLOCKED", C.YELLOW)
                             self.current_cheat_input = ""
                             self.cheat_mode_active = False
@@ -394,7 +394,7 @@ class Game(FPSGameBase):
                             msg = "GOD MODE ON" if self.god_mode else "GOD MODE OFF"
                             self.add_message(msg, C.YELLOW)
                             if self.player:
-                                self.player.health = 100
+                                self.player.health = C.PLAYER_HEALTH
                                 self.player.god_mode = self.god_mode
                             self.current_cheat_input = ""
                             self.cheat_mode_active = False

--- a/src/games/Force_Field/src/constants.py
+++ b/src/games/Force_Field/src/constants.py
@@ -149,6 +149,7 @@ DEFAULT_MAP_SIZE = 40
 # Balancing
 BOT_SPEED = 0.02  # Slower enemies (was 0.03)
 PLAYER_HEALTH = 100
+CHEAT_AMMO_AMOUNT = 999  # Full ammo granted by IDFA cheat code
 BASE_BOT_HEALTH = 30
 BASE_BOT_DAMAGE = 2  # Reduced from 3
 BOT_ATTACK_RANGE = 5

--- a/src/games/Force_Field/src/game.py
+++ b/src/games/Force_Field/src/game.py
@@ -119,7 +119,7 @@ class Game(FPSGameBase):
         self.combat_system = CombatSystem(self)
         self.raycaster: Raycaster | None = None
         self.portal: Portal | None = None
-        self.health = 100
+        self.health = C.PLAYER_HEALTH
         self.lives = C.DEFAULT_LIVES
 
         # Unlocked weapons tracking - start with basic weapons
@@ -661,8 +661,10 @@ class Game(FPSGameBase):
                     color = C.GREEN
 
                     if bot.enemy_type == "health_pack":
-                        if self.player.health < 100:
-                            self.player.health = min(100, self.player.health + 50)
+                        if self.player.health < C.PLAYER_HEALTH:
+                            self.player.health = min(
+                                C.PLAYER_HEALTH, self.player.health + 50
+                            )
                             pickup_msg = "HEALTH +50"
                     elif bot.enemy_type == "ammo_box":
                         for w in self.player.ammo:

--- a/src/games/Wizard_of_Wor/wizard_of_wor/constants.py
+++ b/src/games/Wizard_of_Wor/wizard_of_wor/constants.py
@@ -94,3 +94,7 @@ UP = (0, -1)
 DOWN = (0, 1)
 LEFT = (-1, 0)
 RIGHT = (1, 0)
+
+# UI bar widths (pixels)
+SHIELD_BAR_WIDTH = 140  # Width of the shield status bar
+WIZARD_ARRIVAL_BAR_WIDTH = 180  # Width of the wizard warmup progress bar

--- a/src/games/Wizard_of_Wor/wizard_of_wor/game.py
+++ b/src/games/Wizard_of_Wor/wizard_of_wor/game.py
@@ -33,7 +33,9 @@ from constants import (
     RESPAWN_SHIELD_FRAMES,
     SCREEN_HEIGHT,
     SCREEN_WIDTH,
+    SHIELD_BAR_WIDTH,
     WHITE,
+    WIZARD_ARRIVAL_BAR_WIDTH,
     YELLOW,
 )
 from dungeon import Dungeon
@@ -573,7 +575,7 @@ class WizardOfWorGame:
                     1.0,
                     self.player.invulnerable_timer / RESPAWN_SHIELD_FRAMES,
                 )
-            bar_width = 140
+            bar_width = SHIELD_BAR_WIDTH
             bar_height = 10
             bar_x = GAME_AREA_X
             bar_y = GAME_AREA_Y + GAME_AREA_HEIGHT + 16
@@ -595,7 +597,7 @@ class WizardOfWorGame:
         total_enemies = sum(1 for e in self.enemies)
         if total_enemies > 0:
             progress = 1 - (alive_enemies / max(1, total_enemies))
-            bar_width = 180
+            bar_width = WIZARD_ARRIVAL_BAR_WIDTH
             bar_height = 8
             bar_x = GAME_AREA_X + 220
             bar_y = GAME_AREA_Y + GAME_AREA_HEIGHT + 16

--- a/src/games/Zombie_Survival/src/constants.py
+++ b/src/games/Zombie_Survival/src/constants.py
@@ -221,6 +221,7 @@ DEFAULT_MAP_SIZE = 40
 # Balancing
 BOT_SPEED = 0.02  # Slower enemies (was 0.03)
 PLAYER_HEALTH = 100
+CHEAT_AMMO_AMOUNT = 999  # Full ammo granted by IDFA cheat code
 BASE_BOT_HEALTH = 30
 BASE_BOT_DAMAGE = 2  # Reduced from 3
 BOT_ATTACK_RANGE = 5

--- a/src/games/Zombie_Survival/src/game.py
+++ b/src/games/Zombie_Survival/src/game.py
@@ -110,7 +110,7 @@ class Game(FPSGameBase):
         self.entity_manager = EntityManager()
         self.raycaster: Raycaster | None = None
         self.portal: Portal | None = None
-        self.health = 100
+        self.health = C.PLAYER_HEALTH
         self.lives = C.DEFAULT_LIVES
 
         # Unlocked weapons tracking - start with basic weapons
@@ -375,7 +375,7 @@ class Game(FPSGameBase):
                             self.unlocked_weapons = set(C.WEAPONS.keys())
                             if self.player:
                                 for w in self.player.ammo:
-                                    self.player.ammo[w] = 999
+                                    self.player.ammo[w] = C.CHEAT_AMMO_AMOUNT
                             self.add_message("ALL WEAPONS UNLOCKED", C.YELLOW)
                             self.current_cheat_input = ""
                             self.cheat_mode_active = False
@@ -385,7 +385,7 @@ class Game(FPSGameBase):
                             msg = "GOD MODE ON" if self.god_mode else "GOD MODE OFF"
                             self.add_message(msg, C.YELLOW)
                             if self.player:
-                                self.player_health = 100
+                                self.player_health = C.PLAYER_HEALTH
                                 self.player.god_mode = self.god_mode
                             self.current_cheat_input = ""
                             self.cheat_mode_active = False


### PR DESCRIPTION
## Summary

Closes #580

- Added `CHEAT_AMMO_AMOUNT = 999` to Duum, Force_Field, and Zombie_Survival `constants.py` files, replacing bare `999` literals in cheat code handlers (IDFA full-ammo cheat)
- Replaced `self.health = 100` initializations with `C.PLAYER_HEALTH` in all three FPS `game.py` files (constant already existed, was just not being used)
- Replaced `self.player.health = 100` in IDDQD (god-mode) cheat handler with `C.PLAYER_HEALTH` in Duum and Zombie_Survival
- Replaced `100` health-cap comparisons in Force_Field pickup handler with `C.PLAYER_HEALTH`
- Added `SHIELD_BAR_WIDTH = 140` and `WIZARD_ARRIVAL_BAR_WIDTH = 180` to Wizard_of_Wor `constants.py`, replaced inline `bar_width = 140/180` literals in `game.py`

## Test plan

- [ ] `black --check .` passes (verified locally)
- [ ] `ruff check .` passes (verified locally)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)