### PR TITLE
Pin all dependencies to exact versions for reproducibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-pygame
-opencv-python
-numpy
-pytest
-pytest-cov
-pytest-timeout
-types-PyYAML
-types-requests
+pygame==2.6.1
+opencv-python==4.13.0.92
+numpy==2.4.2
+pytest==9.0.2
+pytest-cov==7.0.0
+pytest-timeout==2.4.0
+types-PyYAML==6.0.12.20250915
+types-requests==2.32.4.20260107


### PR DESCRIPTION
## Summary

- Pins `pygame==2.6.1`, `opencv-python==4.13.0.92`, and `numpy==2.4.2` (the three packages called out in #584)
- Also pins the remaining deps (`pytest`, `pytest-cov`, `pytest-timeout`, `types-PyYAML`, `types-requests`) for full reproducibility
- All pinned versions are consistent with the existing `requirements.lock` (generated by pip-compile with Python 3.13)

Closes #584

## Test plan

- [ ] Confirm `pip install -r requirements.txt` installs without conflicts
- [ ] Confirm existing test suite passes after install
- [ ] Confirm `black --check .` and `ruff check .` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)