### PR TITLE
fix: remove crash_log.txt written to CWD on unhandled exceptions

### DIFF
--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import math
 import random
-import traceback
 
 import pygame
 
@@ -1081,7 +1080,5 @@ class Game(FPSGameBase):
 
                 self.clock.tick(C.FPS)
         except Exception as e:
-            with open("crash_log.txt", "w") as f:
-                f.write(traceback.format_exc())
-            logger.critical("CRASH: %s", e)
+            logger.critical("CRASH: %s", e, exc_info=True)
             raise

--- a/src/games/Zombie_Survival/src/game.py
+++ b/src/games/Zombie_Survival/src/game.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import math
 import random
-import traceback
 from typing import Any
 
 import pygame
@@ -1195,7 +1194,5 @@ class Game(FPSGameBase):
 
                 self.clock.tick(C.FPS)
         except Exception as e:
-            with open("crash_log.txt", "w") as f:
-                f.write(traceback.format_exc())
-            logger.critical("CRASH: %s", e)
+            logger.critical("CRASH: %s", e, exc_info=True)
             raise


### PR DESCRIPTION
## Summary

- Removes bare `open("crash_log.txt", "w")` crash logging from the game loop exception handlers in both `Duum/src/game.py` and `Zombie_Survival/src/game.py`
- Replaces with `logger.critical("CRASH: %s", e, exc_info=True)` so the full traceback is captured by the logging framework
- Removes now-unused `import traceback` from both files

## Motivation

Writing to a bare `crash_log.txt` path fails if CWD is read-only, silently overwrites previous crash data on each run, and is redundant since the logger already records the error. Using `exc_info=True` preserves the full traceback through the logging framework, which can be configured with file handlers (e.g., `RotatingFileHandler`) where needed.

Closes #581

## Test plan

- [ ] Run `black --check .` — passes
- [ ] Run `ruff check .` — passes
- [ ] Verify Duum game loop no longer writes `crash_log.txt` on exception
- [ ] Verify Zombie_Survival game loop no longer writes `crash_log.txt` on exception
- [ ] Confirm logger captures crash traceback via `exc_info=True`

Generated with [Claude Code](https://claude.com/claude-code)