### PR TITLE
refactor: Fix Law of Demeter violations in game modules

### DIFF
--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -1015,9 +1015,8 @@ class Game(FPSGameBase):
                 self.intro_phase += 1
                 self.intro_start_time = 0
                 # Only release video when transitioning from phase 1 to phase 2
-                if self.intro_phase == 2 and self.ui_renderer.intro_video:
-                    self.ui_renderer.intro_video.release()
-                    self.ui_renderer.intro_video = None
+                if self.intro_phase == 2:
+                    self.ui_renderer.release_intro_video()
 
     def run(self) -> None:
         """Main game loop"""

--- a/src/games/Duum/src/ui_renderer.py
+++ b/src/games/Duum/src/ui_renderer.py
@@ -47,6 +47,25 @@ class UIRenderer(UIRendererBase):
         # Generate vignette
         self._generate_vignette()
 
+    # ------------------------------------------------------------------
+    # Law-of-Demeter delegate methods (avoid callers reaching into
+    # internal attributes like intro_video and start_button directly).
+    # ------------------------------------------------------------------
+
+    def release_intro_video(self) -> None:
+        """Release the intro video capture and clear the reference."""
+        if self.intro_video:
+            self.intro_video.release()
+            self.intro_video = None
+
+    def update_start_button(self, mouse_pos: tuple[int, int]) -> None:
+        """Forward hover-update to the start button."""
+        self.start_button.update(mouse_pos)
+
+    def is_start_button_clicked(self, pos: tuple[int, int]) -> bool:
+        """Return True if *pos* falls inside the start button."""
+        return self.start_button.is_clicked(pos)
+
     def _generate_vignette(self) -> None:
         """Generate a static vignette surface."""
         w, h = C.SCREEN_WIDTH, C.SCREEN_HEIGHT

--- a/src/games/Force_Field/src/game.py
+++ b/src/games/Force_Field/src/game.py
@@ -827,20 +827,14 @@ class Game(FPSGameBase):
         """Handle intro screen events"""
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
-                if self.ui_renderer.intro_video:
-                    self.ui_renderer.intro_video.release()
-                    self.ui_renderer.intro_video = None
+                self.ui_renderer.release_intro_video()
                 self.running = False
             elif event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_SPACE or event.key == pygame.K_ESCAPE:
-                    if self.ui_renderer.intro_video:
-                        self.ui_renderer.intro_video.release()
-                        self.ui_renderer.intro_video = None
+                    self.ui_renderer.release_intro_video()
                     self.state = GameState.MENU
             elif event.type == pygame.MOUSEBUTTONDOWN:
-                if self.ui_renderer.intro_video:
-                    self.ui_renderer.intro_video.release()
-                    self.ui_renderer.intro_video = None
+                self.ui_renderer.release_intro_video()
                 self.state = GameState.MENU
 
     def handle_menu_events(self) -> None:
@@ -858,7 +852,7 @@ class Game(FPSGameBase):
 
     def handle_map_select_events(self) -> None:
         """Handle map selection events"""
-        self.ui_renderer.start_button.update(pygame.mouse.get_pos())
+        self.ui_renderer.update_start_button(pygame.mouse.get_pos())
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 self.running = False
@@ -871,7 +865,7 @@ class Game(FPSGameBase):
                     pygame.mouse.set_visible(False)
                     pygame.event.set_grab(True)
             elif event.type == pygame.MOUSEBUTTONDOWN:
-                if self.ui_renderer.start_button.is_clicked(event.pos):
+                if self.ui_renderer.is_start_button_clicked(event.pos):
                     self.start_game()
                     self.state = GameState.PLAYING
                     pygame.mouse.set_visible(False)
@@ -1004,9 +998,8 @@ class Game(FPSGameBase):
             if elapsed > duration:
                 self.intro_phase += 1
                 self.intro_start_time = 0
-                if self.intro_phase == 2 and self.ui_renderer.intro_video:
-                    self.ui_renderer.intro_video.release()
-                    self.ui_renderer.intro_video = None
+                if self.intro_phase == 2:
+                    self.ui_renderer.release_intro_video()
 
     def run(self) -> None:
         """Main game loop"""

--- a/src/games/Force_Field/src/ui_renderer.py
+++ b/src/games/Force_Field/src/ui_renderer.py
@@ -71,6 +71,25 @@ class UIRenderer(UIRendererBase):
             self.modern_small_font = self.small_font
             self.modern_tiny_font = self.tiny_font
 
+    # ------------------------------------------------------------------
+    # Law-of-Demeter delegate methods (avoid callers reaching into
+    # internal attributes like intro_video and start_button directly).
+    # ------------------------------------------------------------------
+
+    def release_intro_video(self) -> None:
+        """Release the intro video capture and clear the reference."""
+        if self.intro_video:
+            self.intro_video.release()
+            self.intro_video = None
+
+    def update_start_button(self, mouse_pos: tuple[int, int]) -> None:
+        """Forward hover-update to the start button."""
+        self.start_button.update(mouse_pos)
+
+    def is_start_button_clicked(self, pos: tuple[int, int]) -> bool:
+        """Return True if *pos* falls inside the start button."""
+        return self.start_button.is_clicked(pos)
+
     def _get_base_dir(self) -> Path:
         """Override to handle frozen executables."""
         if getattr(sys, "frozen", False):

--- a/src/games/Tetris/src/game_logic.py
+++ b/src/games/Tetris/src/game_logic.py
@@ -53,6 +53,28 @@ class TetrisLogic:
         self.total_tetrises = 0
         self.rewind_history: list[dict[str, Any]] = []
 
+    # ------------------------------------------------------------------
+    # Law-of-Demeter delegate helpers — callers should not reach into
+    # current_piece or rewind_history directly; use these methods.
+    # ------------------------------------------------------------------
+
+    def move_piece_left(self) -> None:
+        """Move the current piece one cell to the left (no collision check)."""
+        self.current_piece.x -= 1
+
+    def move_piece_right(self) -> None:
+        """Move the current piece one cell to the right (no collision check)."""
+        self.current_piece.x += 1
+
+    def move_piece_down(self) -> None:
+        """Move the current piece one cell down and award a soft-drop point."""
+        self.current_piece.y += 1
+        self.score += 1
+
+    def clear_rewind_history(self) -> None:
+        """Discard all saved rewind snapshots."""
+        self.rewind_history.clear()
+
     def new_piece(self) -> Tetromino:
         """Create a new random tetromino"""
         shape_type = random.choice(list(SHAPES.keys()))

--- a/src/games/Tetris/src/input_handler.py
+++ b/src/games/Tetris/src/input_handler.py
@@ -212,6 +212,17 @@ class InputHandler:
 
         return False
 
+    def get_action_label(self, action: str) -> str:
+        """Return the human-readable label for *action*.
+
+        Falls back to the key itself when the action is not found.
+        """
+        return self.controller_action_labels.get(action, action)
+
+    def iter_action_labels(self) -> list[tuple[str, str]]:
+        """Return a list of (action_key, description) pairs for all actions."""
+        return list(self.controller_action_labels.items())
+
     def get_binding_label(self, action: str) -> str:
         """Readable label for a controller binding"""
         binding = self.controller_mapping.get(action)

--- a/src/games/Tetris/src/renderer.py
+++ b/src/games/Tetris/src/renderer.py
@@ -32,6 +32,35 @@ class TetrisRenderer:
         self.small_font = pygame.font.Font(None, 24)
         self.tiny_font = pygame.font.Font(None, 18)
 
+    # ------------------------------------------------------------------
+    # Law-of-Demeter delegate helpers — callers should not reach into
+    # internal font objects; use these methods instead.
+    # ------------------------------------------------------------------
+
+    def render_large_text(
+        self, text: str, antialias: bool, color: tuple[int, int, int]
+    ) -> pygame.Surface:
+        """Render *text* using the large heading font."""
+        return self.font_large.render(text, antialias, color)
+
+    def render_normal_text(
+        self, text: str, antialias: bool, color: tuple[int, int, int]
+    ) -> pygame.Surface:
+        """Render *text* using the normal body font."""
+        return self.font.render(text, antialias, color)
+
+    def render_small_text(
+        self, text: str, antialias: bool, color: tuple[int, int, int]
+    ) -> pygame.Surface:
+        """Render *text* using the small font."""
+        return self.small_font.render(text, antialias, color)
+
+    def render_tiny_text(
+        self, text: str, antialias: bool, color: tuple[int, int, int]
+    ) -> pygame.Surface:
+        """Render *text* using the tiny font."""
+        return self.tiny_font.render(text, antialias, color)
+
     def draw_background(self) -> None:
         """Draw a gradient background for the entire screen"""
         # Create a vertical gradient from dark blue/purple to black

--- a/src/games/Tetris/tetris.py
+++ b/src/games/Tetris/tetris.py
@@ -111,7 +111,7 @@ class TetrisGame:
         for (
             action_key,
             description,
-        ) in self.input_handler.controller_action_labels.items():
+        ) in self.input_handler.iter_action_labels():
             entries.append(
                 {
                     "label": description,
@@ -151,7 +151,7 @@ class TetrisGame:
                     current = getattr(self.logic, key)
                     setattr(self.logic, key, not current)
                     if key == "allow_rewind":
-                        self.logic.rewind_history.clear()
+                        self.logic.clear_rewind_history()
 
             elif (
                 entry["type"] == "mapping"
@@ -165,7 +165,7 @@ class TetrisGame:
         # Implementing draw_settings here as it was missing from
         # renderer and needs state access
         self.screen.fill(C.BLACK)
-        title = self.renderer.font_large.render("Settings", True, C.CYAN)
+        title = self.renderer.render_large_text("Settings", True, C.CYAN)
         title_rect = title.get_rect(center=(C.SCREEN_WIDTH // 2, 80))
         self.screen.blit(title, title_rect)
 
@@ -190,8 +190,8 @@ class TetrisGame:
             elif entry["type"] == "mapping":
                 value_text = self.input_handler.get_binding_label(entry["key"])
 
-            label_text = self.renderer.font.render(label, True, color)
-            value_render = self.renderer.small_font.render(
+            label_text = self.renderer.render_normal_text(label, True, color)
+            value_render = self.renderer.render_small_text(
                 value_text, True, C.LIGHT_GRAY
             )
 
@@ -200,7 +200,7 @@ class TetrisGame:
                 self.screen.blit(value_render, (520, y_offset + 6))
             y_offset += 40
 
-        hint = self.renderer.tiny_font.render(
+        hint = self.renderer.render_tiny_text(
             "Arrow keys to navigate, ENTER to toggle or remap, ESC to return",
             True,
             C.GRAY,
@@ -209,10 +209,10 @@ class TetrisGame:
         self.screen.blit(hint, hint_rect)
 
         if self.input_handler.awaiting_controller_action:
-            action_label = self.input_handler.controller_action_labels[
+            action_label = self.input_handler.get_action_label(
                 self.input_handler.awaiting_controller_action
-            ]
-            waiting = self.renderer.small_font.render(
+            )
+            waiting = self.renderer.render_small_text(
                 f"Waiting for input to bind {action_label}",
                 True,
                 C.YELLOW,
@@ -269,17 +269,16 @@ class TetrisGame:
                 if keys[pygame.K_LEFT] and self.logic.valid_move(
                     self.logic.current_piece, x_offset=-1
                 ):
-                    self.logic.current_piece.x -= 1
+                    self.logic.move_piece_left()
                     pygame.time.wait(100)
                 if keys[pygame.K_RIGHT] and self.logic.valid_move(
                     self.logic.current_piece, x_offset=1
                 ):
-                    self.logic.current_piece.x += 1
+                    self.logic.move_piece_right()
                     pygame.time.wait(100)
                 if keys[pygame.K_DOWN]:
                     if self.logic.valid_move(self.logic.current_piece, y_offset=1):
-                        self.logic.current_piece.y += 1
-                        self.logic.score += 1
+                        self.logic.move_piece_down()
                     pygame.time.wait(50)
 
                 self.input_handler.handle_controller_state(self.logic)
@@ -324,7 +323,7 @@ class TetrisGame:
                     overlay.fill(C.BLACK)
                     overlay.set_alpha(128)
                     self.screen.blit(overlay, (0, 0))
-                    pause_text = self.renderer.font_large.render(
+                    pause_text = self.renderer.render_large_text(
                         "PAUSED", True, C.YELLOW
                     )
                     center = (C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2)

--- a/src/games/Wizard_of_Wor/tests/test_game.py
+++ b/src/games/Wizard_of_Wor/tests/test_game.py
@@ -115,10 +115,8 @@ class TestWizardOfWorGame(unittest.TestCase):
 
     def test_check_collisions_player_hits_enemy(self) -> None:
         enemy = self.game.enemies[0]
-        self.game.player.x = enemy.x
-        self.game.player.y = enemy.y
-        self.game.player.rect.x = enemy.x - 11
-        self.game.player.rect.y = enemy.y - 11
+        # Use set_player_position so x/y and rect stay in sync (Law of Demeter).
+        self.game.set_player_position(enemy.x, enemy.y)
 
         self.game.player.invulnerable_timer = 0
 

--- a/src/games/Wizard_of_Wor/wizard_of_wor/game.py
+++ b/src/games/Wizard_of_Wor/wizard_of_wor/game.py
@@ -289,6 +289,21 @@ class WizardOfWorGame:
         # Keep only player bullets when player dies
         self.bullets = [b for b in self.bullets if b.is_player_bullet]
 
+    def set_player_position(self, x: float, y: float) -> None:
+        """Move the player to (*x*, *y*) and keep the collision rect in sync.
+
+        Prefer this over accessing ``player.rect`` directly from outside the
+        game class (Law of Demeter).
+        """
+        if self.player is None:
+            return
+        self.player.x = x
+        self.player.y = y
+        from constants import PLAYER_SIZE  # noqa: PLC0415
+
+        self.player.rect.x = int(x) - PLAYER_SIZE // 2
+        self.player.rect.y = int(y) - PLAYER_SIZE // 2
+
     def handle_events(self) -> None:
         """Handle input events."""
         for event in pygame.event.get():


### PR DESCRIPTION
## Summary

Fixes the worst 5–6 Law of Demeter violation clusters across game modules, closing #531.

- **Force_Field & Duum UIRenderer**: Added `release_intro_video()`, `update_start_button()`, and `is_start_button_clicked()` delegate methods so `game.py` no longer reaches two levels deep into `ui_renderer.intro_video` or `ui_renderer.start_button`.
- **Tetris `TetrisRenderer`**: Added `render_large_text()`, `render_normal_text()`, `render_small_text()`, `render_tiny_text()` so `tetris.py` stops accessing internal `renderer.font_*` objects directly.
- **Tetris `TetrisLogic`**: Added `move_piece_left()`, `move_piece_right()`, `move_piece_down()`, `clear_rewind_history()` to encapsulate `current_piece` and `rewind_history` mutation.
- **Tetris `InputHandler`**: Added `get_action_label()` and `iter_action_labels()` so callers don't index into `controller_action_labels` dict directly.
- **Wizard of Wor**: Added `set_player_position()` on `WizardOfWorGame`; test now uses it instead of setting `player.rect.x / player.rect.y` directly.

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `black --check` passes on all changed files
- [x] 111 tests pass across Tetris, Force_Field, and Duum modules
- [x] Pre-existing test failures in Wizard_of_Wor (pygame mock issue unrelated to this PR) confirmed pre-existing on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)