### PR TITLE
fix: resolve asset load resolution in FPS games

### DIFF
--- a/src/games/Duum/src/sound.py
+++ b/src/games/Duum/src/sound.py
@@ -8,6 +8,10 @@ from games.shared.sound_manager_base import SoundManagerBase
 class SoundManager(SoundManagerBase):
     """Manages sound effects and music for Duum."""
 
+    def get_game_name(self) -> str:
+        """Return the game name for asset loading."""
+        return "Duum"
+
     # Map logical names to filenames
     SOUND_FILES = {
         "shoot": "shoot.wav",

--- a/src/games/Duum/src/ui_renderer.py
+++ b/src/games/Duum/src/ui_renderer.py
@@ -756,6 +756,10 @@ class UIRenderer(UIRendererBase):
             },
         ]
 
+    def _get_game_name(self) -> str:
+        """Return the game name for asset loading."""
+        return "Duum"
+
     def _get_game_title(self) -> str:
         """Return the Duum game title."""
         return "DUUM"

--- a/src/games/Force_Field/src/sound.py
+++ b/src/games/Force_Field/src/sound.py
@@ -8,6 +8,10 @@ from games.shared.sound_manager_base import SoundManagerBase
 class SoundManager(SoundManagerBase):
     """Manages sound effects and music for Force Field."""
 
+    def get_game_name(self) -> str:
+        """Return the game name for asset loading."""
+        return "Force_Field"
+
     # Map logical names to filenames
     SOUND_FILES = {
         "shoot": "shoot.wav",

--- a/src/games/Force_Field/src/ui_renderer.py
+++ b/src/games/Force_Field/src/ui_renderer.py
@@ -819,6 +819,10 @@ class UIRenderer(UIRendererBase):
             },
         ]
 
+    def _get_game_name(self) -> str:
+        """Return the game name for asset loading."""
+        return "Force_Field"
+
     def _get_game_title(self) -> str:
         """Return the Force Field game title."""
         return "FORCE FIELD"

--- a/src/games/Zombie_Survival/src/sound.py
+++ b/src/games/Zombie_Survival/src/sound.py
@@ -8,6 +8,10 @@ from games.shared.sound_manager_base import SoundManagerBase
 class SoundManager(SoundManagerBase):
     """Manages sound effects and music for Zombie Survival."""
 
+    def get_game_name(self) -> str:
+        """Return the game name for asset loading."""
+        return "Zombie_Survival"
+
     # Map logical names to filenames
     SOUND_FILES = {
         "shoot": "shoot.wav",

--- a/src/games/Zombie_Survival/src/ui_renderer.py
+++ b/src/games/Zombie_Survival/src/ui_renderer.py
@@ -676,6 +676,10 @@ class UIRenderer(UIRendererBase):
             },
         ]
 
+    def _get_game_name(self) -> str:
+        """Return the game name for asset loading."""
+        return "Zombie_Survival"
+
     def _get_game_title(self) -> str:
         """Return the Zombie Survival game title."""
         return "ZOMBIE SURVIVAL"

--- a/tests/shared/test_asset_path_resolution.py
+++ b/tests/shared/test_asset_path_resolution.py
@@ -1,0 +1,42 @@
+"""Test for ensuring asset path resolution correctly IDs each game."""
+
+import pygame
+
+from src.games.Duum.src.sound import SoundManager as DuumSoundManager
+from src.games.Duum.src.ui_renderer import UIRenderer as DuumUIRenderer
+from src.games.Force_Field.src.sound import SoundManager as FFSoundManager
+from src.games.Force_Field.src.ui_renderer import UIRenderer as FFUIRenderer
+from src.games.Zombie_Survival.src.sound import SoundManager as ZSSoundManager
+from src.games.Zombie_Survival.src.ui_renderer import UIRenderer as ZSUIRenderer
+
+
+def get_mock_screen() -> pygame.Surface:
+    """Return a mock pygame surface."""
+    return pygame.Surface((800, 600))
+
+
+def test_duum_asset_resolution() -> None:
+    """Test Duum correctly identifies its name regardless of sys.path."""
+    sound_mgr = DuumSoundManager()
+    assert sound_mgr.get_game_name() == "Duum"
+
+    ui_mgr = DuumUIRenderer.__new__(DuumUIRenderer)
+    assert ui_mgr._get_game_name() == "Duum"
+
+
+def test_force_field_asset_resolution() -> None:
+    """Test Force_Field correctly identifies its name regardless of sys.path."""
+    sound_mgr = FFSoundManager()
+    assert sound_mgr.get_game_name() == "Force_Field"
+
+    ui_mgr = FFUIRenderer.__new__(FFUIRenderer)
+    assert ui_mgr._get_game_name() == "Force_Field"
+
+
+def test_zombie_survival_asset_resolution() -> None:
+    """Test Zombie_Survival correctly identifies its name regardless of sys.path."""
+    sound_mgr = ZSSoundManager()
+    assert sound_mgr.get_game_name() == "Zombie_Survival"
+
+    ui_mgr = ZSUIRenderer.__new__(ZSUIRenderer)
+    assert ui_mgr._get_game_name() == "Zombie_Survival"


### PR DESCRIPTION
Subclasses of UIRenderer and SoundManager now return get_game_name strings explicitly bypassing __module__ path reflection. Resolves game_launcher.py launch failures.
