### PR TITLE
refactor: extract SRP helpers from monolithic run_assessment() (#680)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,8 +10,8 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License** | MIT |
 | **Current Version** | N/A |
-| **Spec Version** | 1.1.1 |
-| **Last Spec Update** | 2026-03-31 |
+| **Spec Version** | 1.1.2 |
+| **Last Spec Update** | 2026-04-02 |
 
 ## 2. Purpose & Mission
 
@@ -347,6 +347,10 @@ pytest tests/ -v
 
 Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (QuatGolf) in progress with quaternion physics implementation. Shared rendering infrastructure stable. Focus on test coverage expansion and performance optimization.
 
+### Completed (2026-04-02)
+
+- **run_assessment.py refactor** (issue #680): Extracted `file_discovery()`, `analyze_module()`, `calculate_scores()`, and `generate_report()` from the monolithic 394-line `run_assessment()` function. Each helper follows SRP; `run_assessment()` is now a thin orchestrator. 35 new unit tests cover every extracted function.
+
 ### Completed (2026-03-31)
 
 - **Collision detection optimization** (issue #681): Wizard of Wor collision detection replaced O(n²) brute-force with O(n) spatial-grid approach; significant FPS improvement at high entity counts.
@@ -374,6 +378,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2026-04-02 | 1.1.2 | Refactored `scripts/run_assessment.py` (issue #680): extracted `file_discovery`, `analyze_module`, `calculate_scores`, `generate_report` from monolithic function; added 35 unit tests; `run_assessment()` is now a thin orchestrator. |
 | 2026-03-31 | 1.1.1 | Added self-hosted runner fallback behavior to PR CI documentation and normalized C++ headers/tests to satisfy the blocking clang-format check |
 | 2026-03-28 | 1.0.0 | Initial specification document |
 | 2026-03-30 | 1.1.0 | A-N Assessment remediation: added DbC precondition validation to `game_launcher.py` (calculate_game_rects, handle_keyboard_navigation, draw_ui), `run_tests.py` (get_test_environment, run_game_tests), and scripts (analyze_completist_data, generate_assessment_summary, create_issues_from_assessment, mypy_autofix_agent). Added docstrings to MockRect methods in conftest.py. Added .env to .gitignore (infrastructure fix). Addresses issue #658. |

--- a/scripts/run_assessment.py
+++ b/scripts/run_assessment.py
@@ -43,24 +43,25 @@ ASSESSMENTS = {
     "O": {"name": "Maintainability", "description": "Code maintainability"},
 }
 
+# Directories excluded from Python file discovery
+_EXCLUDED_DIRS = {
+    ".git",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".tox",
+    "build",
+    "dist",
+}
+
 
 def find_python_files() -> list[Path]:
     """Find all Python files in the repository."""
     python_files: list[Path] = []
     for pattern in ["**/*.py"]:
         python_files.extend(Path(".").glob(pattern))
-    # Exclude common non-source directories
-    excluded = {
-        ".git",
-        "__pycache__",
-        ".venv",
-        "venv",
-        "node_modules",
-        ".tox",
-        "build",
-        "dist",
-    }
-    return [f for f in python_files if not any(p in f.parts for p in excluded)]
+    return [f for f in python_files if not any(p in f.parts for p in _EXCLUDED_DIRS)]
 
 
 def run_ruff_check_wrapper() -> dict:
@@ -122,32 +123,44 @@ def grep_in_files(pattern: str, files: list[Path]) -> int:
     return count
 
 
-def run_assessment(assessment_id: str, output_path: Path) -> int:
-    """
-    Run a specific assessment and generate report.
+# ---------------------------------------------------------------------------
+# Extracted single-responsibility helpers
+# ---------------------------------------------------------------------------
 
-    Args:
-        assessment_id: Assessment ID (A-O)
-        output_path: Path to save the assessment report
+
+def file_discovery() -> tuple[list[Path], int]:
+    """Discover Python source files and return them with a count.
 
     Returns:
-        Exit code (0 = success, 1 = failure)
+        A tuple of (python_files, file_count) where python_files is the list
+        of discovered Path objects and file_count is len(python_files).
     """
-    assessment = ASSESSMENTS.get(assessment_id)
-    if not assessment:
-        logger.error(f"Unknown assessment: {assessment_id}")
-        return 1
+    python_files = find_python_files()
+    return python_files, len(python_files)
 
-    logger.info(f"Running Assessment {assessment_id}: {assessment['name']}...")
 
-    # Gather metrics based on assessment type
-    findings = []
+def analyze_module(
+    assessment_id: str,
+    python_files: list[Path],
+    file_count: int,
+) -> tuple[list[str], int | None]:
+    """Analyse a repository for a single assessment category.
+
+    Each assessment category maps to a focused analysis routine.  The function
+    collects human-readable *findings* lines and an integer *score* (0-10,
+    or None when the score cannot be determined automatically).
+
+    Args:
+        assessment_id: Single uppercase letter identifying the assessment (A-O).
+        python_files:  List of Python source Path objects from file_discovery().
+        file_count:    Number of entries in python_files.
+
+    Returns:
+        A tuple of (findings, score) where findings is a list of markdown
+        bullet strings and score is an int 0-10 or None.
+    """
+    findings: list[str] = []
     score: int | None = 10  # Start with perfect score
-    if not (score is not None):
-        raise ValueError("DbC Blocked: Precondition failed.")
-
-    python_files: list[Path] = find_python_files()
-    file_count = len(python_files)
 
     if assessment_id == "A":  # Code Structure
         has_src = Path("src").exists()
@@ -162,9 +175,9 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
         )
         findings.append(f"- Tests directory/files: {'✓' if has_tests else '✗'}")
         if not has_src:
-            score -= 2
+            score -= 2  # type: ignore[operator]
         if not has_tests:
-            score -= 2
+            score -= 2  # type: ignore[operator]
 
     elif assessment_id == "B":  # Documentation
         docs = check_documentation()
@@ -185,21 +198,21 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
             docstring_percent = (docstring_count / checked_files) * 100
             findings.append(f"- Docstring presence (sample): {docstring_percent:.0f}%")
             if docstring_percent < 50:
-                score -= 2
+                score -= 2  # type: ignore[operator]
 
         if not docs["has_readme"]:
-            score -= 3
+            score -= 3  # type: ignore[operator]
         if not docs["has_docs_dir"]:
-            score -= 1
+            score -= 1  # type: ignore[operator]
 
     elif assessment_id == "C":  # Test Coverage
         test_count = count_test_files()
         findings.append(f"- Test files found: {test_count}")
         if test_count == 0:
-            score -= 5
+            score -= 5  # type: ignore[operator]
             findings.append("- Critical: No tests found")
         elif test_count < 5:
-            score -= 2
+            score -= 2  # type: ignore[operator]
             findings.append("- Warning: Low number of test files")
         else:
             findings.append("- Good number of test files")
@@ -225,16 +238,16 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
                     cov_percent = int(match.group(1))
                     findings.append(f"- Coverage: {cov_percent}%")
                     if cov_percent < 50:
-                        score -= 2
+                        score -= 2  # type: ignore[operator]
                         findings.append("- Warning: Low test coverage (< 50%)")
                     elif cov_percent < 80:
-                        score -= 1
+                        score -= 1  # type: ignore[operator]
                         findings.append("- Note: Moderate test coverage (< 80%)")
             else:
                 findings.append(
                     f"- Pytest execution: ✗ Failed (Exit code {result.returncode})"
                 )
-                score -= 2
+                score -= 2  # type: ignore[operator]
         except Exception as e:  # noqa: BLE001
             findings.append(f"- Pytest execution failed to start: {e}")
 
@@ -246,7 +259,7 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
         findings.append(f"- Files with try blocks: {try_count}")
         findings.append(f"- Files with except blocks: {except_count}")
         if try_count == 0:
-            score -= 2
+            score -= 2  # type: ignore[operator]
             findings.append("- Warning: No error handling detected in sample")
 
     elif assessment_id == "E":  # Performance
@@ -264,13 +277,13 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
             findings.append(
                 "- Note: No explicit performance profiling tools found in code"
             )
-            score -= 1
+            score -= 1  # type: ignore[operator]
 
         if time_sleep > 2:
             findings.append(
                 "- Warning: Multiple uses of time.sleep detected (potential bottleneck)"
             )
-            score -= 1
+            score -= 1  # type: ignore[operator]
 
     elif assessment_id == "F":  # Security
         # Basic check for subprocess without shell=True or hardcoded secrets
@@ -280,7 +293,7 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
                 f"- Critical: subprocess with shell=True found in "
                 f"{subprocess_shell} files"
             )
-            score -= 3
+            score -= 3  # type: ignore[operator]
         else:
             findings.append("- subprocess with shell=True: Not found (Good)")
 
@@ -291,7 +304,7 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
             findings.append(
                 f"- Warning: Potential secrets found in {secrets_found} files (vars)"
             )
-            score -= 1
+            score -= 1  # type: ignore[operator]
 
         # Check for eval/exec
         unsafe_eval = grep_in_files(r"eval\(|exec\(", python_files)
@@ -299,7 +312,7 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
             findings.append(
                 f"- Critical: Unsafe eval/exec detected in {unsafe_eval} files"
             )
-            score -= 3
+            score -= 3  # type: ignore[operator]
 
     elif assessment_id == "G":  # Dependencies
         has_req = Path("requirements.txt").exists()
@@ -318,18 +331,18 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
         )
 
         if not (has_req or has_pyproject):
-            score -= 5
+            score -= 5  # type: ignore[operator]
             findings.append("- Critical: No dependency definition found")
 
         if not has_lock:
             findings.append("- Note: No lock file found (reproducibility risk)")
-            score -= 1
+            score -= 1  # type: ignore[operator]
 
     elif assessment_id == "H":  # CI/CD
         has_github_workflows = Path(".github/workflows").exists()
         findings.append(f"- GitHub Workflows: {'✓' if has_github_workflows else '✗'}")
         if not has_github_workflows:
-            score -= 3
+            score -= 3  # type: ignore[operator]
             findings.append("- Warning: No GitHub Actions workflows found")
         else:
             workflow_count = len(list(Path(".github/workflows").glob("*.yml"))) + len(
@@ -347,18 +360,9 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
         )
         findings.append(f"- Black formatting: {black_status}")
         if ruff_result["exit_code"] != 0:
-            score -= 3
+            score -= 3  # type: ignore[operator]
         if black_result["exit_code"] != 0:
-            score -= 2
-
-    elif assessment_id == "L":  # Logging
-        logging_imports = grep_in_files(
-            r"import logging|from logging import", python_files
-        )
-        findings.append(f"- Files importing logging: {logging_imports}")
-        if logging_imports < 2 and file_count > 5:
-            score -= 2
-            findings.append("- Warning: Sparse logging detected")
+            score -= 2  # type: ignore[operator]
 
     elif assessment_id == "J":  # API Design
         # Check for type hints as a proxy for explicit API design
@@ -372,10 +376,10 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
             findings.append(f"- Type hint coverage: {ratio:.0%}")
 
             if ratio < 0.2:
-                score -= 3
+                score -= 3  # type: ignore[operator]
                 findings.append("- Warning: Low type hint usage (< 20%)")
             elif ratio < 0.5:
-                score -= 1
+                score -= 1  # type: ignore[operator]
                 findings.append("- Note: Moderate type hint usage")
             else:
                 findings.append("- Good type hint usage")
@@ -402,10 +406,19 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
         findings.append(f"- Files using @dataclass: {dataclass_usage}")
 
         if data_imports == 0 and dataclass_usage == 0 and file_count > 5:
-            score -= 2
+            score -= 2  # type: ignore[operator]
             findings.append(
                 "- Note: Limited explicit data handling structures detected"
             )
+
+    elif assessment_id == "L":  # Logging
+        logging_imports = grep_in_files(
+            r"import logging|from logging import", python_files
+        )
+        findings.append(f"- Files importing logging: {logging_imports}")
+        if logging_imports < 2 and file_count > 5:
+            score -= 2  # type: ignore[operator]
+            findings.append("- Warning: Sparse logging detected")
 
     elif assessment_id == "M":  # Configuration
         config_files = (
@@ -415,7 +428,7 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
         )
         findings.append(f"- Config files found: {[f.name for f in config_files]}")
         if not config_files:
-            score -= 1
+            score -= 1  # type: ignore[operator]
             findings.append("- Note: No standard config files found in root")
 
     elif assessment_id == "N":  # Scalability
@@ -457,32 +470,61 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
         findings.append(f"- Files > 1500 lines: {long_files}")
 
         if long_files > 0:
-            score -= min(3, long_files)
+            score -= min(3, long_files)  # type: ignore[operator]
             findings.append(
                 f"- Warning: {long_files} large files detected (> 1500 lines)"
             )
 
         if avg_lines > 500:
-            score -= 1
+            score -= 1  # type: ignore[operator]
             findings.append("- Warning: High average file size")
 
     else:
         # Fallback for unexpected assessment IDs
-        score = None  # type: ignore [assignment]
+        score = None
         findings.append(f"- Python files analyzed: {file_count}")
         findings.append(
             "- **REQUIRES REVIEW**: No automated checks available for this category"
         )
         findings.append("- Score must be assigned by Jules bot or manual code review")
 
-    # Format score display
-    if score is not None:
-        score = max(0, min(10, score))
-        score_display = f"{score}/10"
-    else:
-        score_display = "PENDING REVIEW"
+    return findings, score
 
-    # Generate report
+
+def calculate_scores(score: int | None) -> tuple[int | None, str]:
+    """Clamp and format a raw score value.
+
+    Args:
+        score: Raw integer score (may be negative after deductions) or None
+               when the score cannot be determined automatically.
+
+    Returns:
+        A tuple of (clamped_score, score_display) where clamped_score is
+        clamped to [0, 10] (or None) and score_display is the formatted
+        string (e.g. "7/10" or "PENDING REVIEW").
+    """
+    if score is not None:
+        clamped = max(0, min(10, score))
+        return clamped, f"{clamped}/10"
+    return None, "PENDING REVIEW"
+
+
+def generate_report(
+    assessment_id: str,
+    assessment: dict,
+    score_display: str,
+    findings: list[str],
+    output_path: Path,
+) -> None:
+    """Write the assessment markdown report to disk.
+
+    Args:
+        assessment_id:  Single uppercase letter identifying the assessment.
+        assessment:     Dict with 'name' and 'description' keys from ASSESSMENTS.
+        score_display:  Formatted score string (e.g. "7/10" or "PENDING REVIEW").
+        findings:       List of markdown bullet strings produced by analyze_module().
+        output_path:    Destination Path for the written report file.
+    """
     report_content = f"""# Assessment {assessment_id}: {assessment["name"]}
 
 **Date**: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
@@ -516,6 +558,45 @@ This assessment was generated automatically. For detailed analysis:
     # Write report
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(report_content)
+
+
+def run_assessment(assessment_id: str, output_path: Path) -> int:
+    """
+    Run a specific assessment and generate report.
+
+    Thin orchestrator: delegates file discovery, analysis, scoring, and report
+    generation to the dedicated helper functions (file_discovery,
+    analyze_module, calculate_scores, generate_report).
+
+    Args:
+        assessment_id: Assessment ID (A-O)
+        output_path: Path to save the assessment report
+
+    Returns:
+        Exit code (0 = success, 1 = failure)
+    """
+    assessment = ASSESSMENTS.get(assessment_id)
+    if not assessment:
+        logger.error(f"Unknown assessment: {assessment_id}")
+        return 1
+
+    logger.info(f"Running Assessment {assessment_id}: {assessment['name']}...")
+
+    # DbC precondition: assessment must be valid before proceeding
+    if not (assessment is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+
+    # 1. Discover files
+    python_files, file_count = file_discovery()
+
+    # 2. Analyse
+    findings, raw_score = analyze_module(assessment_id, python_files, file_count)
+
+    # 3. Score
+    _, score_display = calculate_scores(raw_score)
+
+    # 4. Report
+    generate_report(assessment_id, assessment, score_display, findings, output_path)
 
     logger.info(f"✓ Assessment {assessment_id} report saved to {output_path}")
     logger.info(f"  Score: {score_display}")

--- a/tests/test_run_assessment.py
+++ b/tests/test_run_assessment.py
@@ -1,0 +1,390 @@
+"""Tests for scripts/run_assessment.py extracted helper functions.
+
+Covers file_discovery, analyze_module, calculate_scores, and generate_report
+following the repository's TDD / SRP guidelines (issue #680).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make scripts importable without a full package install
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.run_assessment import (  # noqa: E402
+    ASSESSMENTS,
+    analyze_module,
+    calculate_scores,
+    file_discovery,
+    generate_report,
+    run_assessment,
+)
+
+# ---------------------------------------------------------------------------
+# Shared patch targets
+# ---------------------------------------------------------------------------
+_RUFF = "scripts.run_assessment.run_ruff_check_wrapper"
+_BLACK = "scripts.run_assessment.run_black_check_wrapper"
+_RUFF_PASS = {"exit_code": 0}
+_BLACK_PASS = {"exit_code": 0}
+_RUFF_FAIL = {"exit_code": 1}
+
+
+# ---------------------------------------------------------------------------
+# file_discovery
+# ---------------------------------------------------------------------------
+
+
+class TestFileDiscovery:
+    """Tests for file_discovery()."""
+
+    def test_returns_tuple_of_list_and_int(self) -> None:
+        """file_discovery() should return (list[Path], int)."""
+        with patch("scripts.run_assessment.find_python_files", return_value=[]):
+            files, count = file_discovery()
+        assert isinstance(files, list)
+        assert isinstance(count, int)
+
+    def test_count_matches_list_length(self) -> None:
+        """Count returned must equal len(files)."""
+        fake_files = [Path("a.py"), Path("b.py"), Path("c.py")]
+        with patch(
+            "scripts.run_assessment.find_python_files", return_value=fake_files
+        ):
+            files, count = file_discovery()
+        assert count == len(files)
+        assert count == 3
+
+    def test_empty_repository_returns_zero(self) -> None:
+        """An empty project produces an empty list and count 0."""
+        with patch("scripts.run_assessment.find_python_files", return_value=[]):
+            files, count = file_discovery()
+        assert files == []
+        assert count == 0
+
+    def test_returns_same_files_as_find_python_files(self) -> None:
+        """file_discovery() must pass through all files from find_python_files."""
+        expected = [Path("x.py"), Path("y.py")]
+        with patch(
+            "scripts.run_assessment.find_python_files", return_value=expected
+        ):
+            files, count = file_discovery()
+        assert files == expected
+
+
+# ---------------------------------------------------------------------------
+# analyze_module
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeModule:
+    """Tests for analyze_module()."""
+
+    # --- common contract tests ---
+
+    def test_returns_tuple_of_findings_and_score(self) -> None:
+        """analyze_module() must return (list, int|None)."""
+        with patch("scripts.run_assessment.count_test_files", return_value=10):
+            findings, score = analyze_module("A", [], 0)
+        assert isinstance(findings, list)
+        assert score is None or isinstance(score, int)
+
+    def test_findings_are_non_empty_for_valid_id(self) -> None:
+        """Every recognised assessment ID should produce at least one finding."""
+        mock_run = MagicMock(returncode=1, stdout="", stderr="")
+        for aid in ASSESSMENTS:
+            with (
+                patch("scripts.run_assessment.count_test_files", return_value=5),
+                patch(
+                    "scripts.run_assessment.check_documentation",
+                    return_value={
+                        "has_readme": True,
+                        "has_docs_dir": True,
+                        "has_changelog": True,
+                    },
+                ),
+                patch("scripts.run_assessment.grep_in_files", return_value=3),
+                patch(_RUFF, return_value=_RUFF_PASS),
+                patch(_BLACK, return_value=_BLACK_PASS),
+                patch("scripts.run_assessment.run_command", return_value=mock_run),
+            ):
+                findings, _ = analyze_module(aid, [], 0)
+            assert len(findings) > 0, f"No findings for assessment {aid}"
+
+    def test_unknown_id_returns_none_score(self) -> None:
+        """An unrecognised assessment ID (e.g. 'Z') returns score=None."""
+        findings, score = analyze_module("Z", [], 0)
+        assert score is None
+        assert any("REQUIRES REVIEW" in f for f in findings)
+
+    # --- Assessment A ---
+
+    def test_assessment_a_deducts_for_missing_src(self, tmp_path: Path) -> None:
+        """Assessment A deducts 2 points when src/ does not exist."""
+        original_cwd = Path.cwd()
+        os.chdir(tmp_path)
+        try:
+            with patch("scripts.run_assessment.count_test_files", return_value=5):
+                findings, score = analyze_module("A", [], 0)
+        finally:
+            os.chdir(original_cwd)
+        assert score is not None
+        assert score <= 8
+
+    def test_assessment_a_records_file_count(self) -> None:
+        """Assessment A finding must include the file count."""
+        with patch("scripts.run_assessment.count_test_files", return_value=0):
+            findings, _ = analyze_module("A", [], 42)
+        assert any("42" in f for f in findings)
+
+    # --- Assessment B ---
+
+    def test_assessment_b_deducts_for_missing_readme(self) -> None:
+        """Assessment B deducts 3 points when README.md does not exist."""
+        docs = {
+            "has_readme": False,
+            "has_docs_dir": True,
+            "has_changelog": False,
+        }
+        with patch("scripts.run_assessment.check_documentation", return_value=docs):
+            findings, score = analyze_module("B", [], 0)
+        assert score is not None
+        assert score <= 7
+
+    def test_assessment_b_full_score_with_all_docs(self) -> None:
+        """Assessment B keeps full score when all documentation is present."""
+        docs = {
+            "has_readme": True,
+            "has_docs_dir": True,
+            "has_changelog": True,
+        }
+        with patch("scripts.run_assessment.check_documentation", return_value=docs):
+            findings, score = analyze_module("B", [], 0)
+        assert score == 10
+
+    # --- Assessment C ---
+
+    def test_assessment_c_deducts_for_no_tests(self) -> None:
+        """Assessment C deducts 5 points when no test files exist."""
+        mock_run = MagicMock(returncode=1, stdout="", stderr="")
+        with (
+            patch("scripts.run_assessment.count_test_files", return_value=0),
+            patch("scripts.run_assessment.run_command", return_value=mock_run),
+        ):
+            findings, score = analyze_module("C", [], 0)
+        assert any("Critical" in f for f in findings)
+        assert score is not None
+        assert score <= 5
+
+    def test_assessment_c_notes_good_test_count(self) -> None:
+        """Assessment C notes a good test count when >= 5 test files exist."""
+        mock_run = MagicMock(returncode=1, stdout="", stderr="")
+        with (
+            patch("scripts.run_assessment.count_test_files", return_value=10),
+            patch("scripts.run_assessment.run_command", return_value=mock_run),
+        ):
+            findings, score = analyze_module("C", [], 0)
+        assert any("Good" in f for f in findings)
+
+    # --- Assessment I ---
+
+    def test_assessment_i_deducts_for_ruff_failure(self) -> None:
+        """Assessment I deducts 3 points on ruff failure."""
+        with (
+            patch(_RUFF, return_value=_RUFF_FAIL),
+            patch(_BLACK, return_value=_BLACK_PASS),
+        ):
+            findings, score = analyze_module("I", [], 0)
+        assert score is not None
+        assert score <= 7
+
+    def test_assessment_i_full_score_when_clean(self) -> None:
+        """Assessment I keeps full score when both ruff and black pass."""
+        with (
+            patch(_RUFF, return_value=_RUFF_PASS),
+            patch(_BLACK, return_value=_BLACK_PASS),
+        ):
+            findings, score = analyze_module("I", [], 0)
+        assert score == 10
+
+
+# ---------------------------------------------------------------------------
+# calculate_scores
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateScores:
+    """Tests for calculate_scores()."""
+
+    def test_returns_clamped_score_and_display_string(self) -> None:
+        """calculate_scores() returns a tuple of (int, str)."""
+        clamped, display = calculate_scores(7)
+        assert clamped == 7
+        assert display == "7/10"
+
+    def test_clamps_negative_to_zero(self) -> None:
+        """Scores below 0 are clamped to 0."""
+        clamped, display = calculate_scores(-5)
+        assert clamped == 0
+        assert display == "0/10"
+
+    def test_clamps_above_ten_to_ten(self) -> None:
+        """Scores above 10 are clamped to 10."""
+        clamped, display = calculate_scores(15)
+        assert clamped == 10
+        assert display == "10/10"
+
+    def test_none_score_returns_pending(self) -> None:
+        """A None score produces 'PENDING REVIEW' display string."""
+        clamped, display = calculate_scores(None)
+        assert clamped is None
+        assert display == "PENDING REVIEW"
+
+    def test_zero_score_formats_correctly(self) -> None:
+        """Score of exactly 0 should display as '0/10'."""
+        clamped, display = calculate_scores(0)
+        assert clamped == 0
+        assert display == "0/10"
+
+    def test_ten_score_formats_correctly(self) -> None:
+        """Score of exactly 10 should display as '10/10'."""
+        clamped, display = calculate_scores(10)
+        assert clamped == 10
+        assert display == "10/10"
+
+    @pytest.mark.parametrize("raw,expected", [(1, 1), (5, 5), (8, 8)])
+    def test_mid_range_scores_pass_through(self, raw: int, expected: int) -> None:
+        """Mid-range integer scores should pass through unchanged."""
+        clamped, display = calculate_scores(raw)
+        assert clamped == expected
+        assert display == f"{expected}/10"
+
+
+# ---------------------------------------------------------------------------
+# generate_report
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReport:
+    """Tests for generate_report()."""
+
+    def _minimal_assessment(self) -> dict:
+        return {"name": "Test Name", "description": "Test description"}
+
+    def test_creates_output_file(self, tmp_path: Path) -> None:
+        """generate_report() must create the output file."""
+        out = tmp_path / "report.md"
+        generate_report("A", self._minimal_assessment(), "9/10", ["- finding"], out)
+        assert out.exists()
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        """generate_report() must create missing parent directories."""
+        out = tmp_path / "nested" / "deep" / "report.md"
+        generate_report("B", self._minimal_assessment(), "8/10", [], out)
+        assert out.exists()
+
+    def test_report_contains_assessment_id(self, tmp_path: Path) -> None:
+        """Report markdown must include the assessment ID."""
+        out = tmp_path / "r.md"
+        generate_report("C", self._minimal_assessment(), "7/10", [], out)
+        content = out.read_text(encoding="utf-8")
+        assert "Assessment C" in content
+
+    def test_report_contains_score_display(self, tmp_path: Path) -> None:
+        """Report markdown must include the formatted score string."""
+        out = tmp_path / "r.md"
+        generate_report("D", self._minimal_assessment(), "PENDING REVIEW", [], out)
+        content = out.read_text(encoding="utf-8")
+        assert "PENDING REVIEW" in content
+
+    def test_report_contains_findings(self, tmp_path: Path) -> None:
+        """Report markdown must include all findings lines."""
+        out = tmp_path / "r.md"
+        findings = ["- finding one", "- finding two"]
+        generate_report("E", self._minimal_assessment(), "6/10", findings, out)
+        content = out.read_text(encoding="utf-8")
+        assert "finding one" in content
+        assert "finding two" in content
+
+    def test_report_contains_assessment_name(self, tmp_path: Path) -> None:
+        """Report must mention the assessment name from the assessment dict."""
+        out = tmp_path / "r.md"
+        assessment = {"name": "Code Quality", "description": "desc"}
+        generate_report("F", assessment, "5/10", [], out)
+        content = out.read_text(encoding="utf-8")
+        assert "Code Quality" in content
+
+    def test_report_overrides_existing_file(self, tmp_path: Path) -> None:
+        """Calling generate_report() twice must overwrite the previous content."""
+        out = tmp_path / "r.md"
+        generate_report("G", self._minimal_assessment(), "10/10", ["- old"], out)
+        generate_report("G", self._minimal_assessment(), "1/10", ["- new"], out)
+        content = out.read_text(encoding="utf-8")
+        assert "1/10" in content
+        assert "- new" in content
+
+
+# ---------------------------------------------------------------------------
+# run_assessment (orchestrator integration)
+# ---------------------------------------------------------------------------
+
+
+class TestRunAssessment:
+    """Integration-style tests for the run_assessment() orchestrator."""
+
+    def test_returns_zero_for_valid_assessment(self, tmp_path: Path) -> None:
+        """run_assessment() must return 0 on success."""
+        out = tmp_path / "report.md"
+        with (
+            patch("scripts.run_assessment.find_python_files", return_value=[]),
+            patch("scripts.run_assessment.count_test_files", return_value=5),
+        ):
+            result = run_assessment("A", out)
+        assert result == 0
+
+    def test_returns_one_for_unknown_assessment(self, tmp_path: Path) -> None:
+        """run_assessment() must return 1 when the assessment ID is unrecognised."""
+        out = tmp_path / "report.md"
+        result = run_assessment("Z", out)
+        assert result == 1
+
+    def test_creates_report_file(self, tmp_path: Path) -> None:
+        """run_assessment() must leave a report file at output_path."""
+        out = tmp_path / "report.md"
+        with (
+            patch("scripts.run_assessment.find_python_files", return_value=[]),
+            patch("scripts.run_assessment.count_test_files", return_value=5),
+        ):
+            run_assessment("A", out)
+        assert out.exists()
+
+    def test_all_valid_ids_succeed(self, tmp_path: Path) -> None:
+        """run_assessment() must succeed (return 0) for every defined assessment."""
+        mock_run = MagicMock(returncode=1, stdout="", stderr="")
+        for aid in ASSESSMENTS:
+            out = tmp_path / f"report_{aid}.md"
+            with (
+                patch("scripts.run_assessment.find_python_files", return_value=[]),
+                patch("scripts.run_assessment.count_test_files", return_value=5),
+                patch(
+                    "scripts.run_assessment.check_documentation",
+                    return_value={
+                        "has_readme": True,
+                        "has_docs_dir": True,
+                        "has_changelog": True,
+                    },
+                ),
+                patch("scripts.run_assessment.grep_in_files", return_value=3),
+                patch(_RUFF, return_value=_RUFF_PASS),
+                patch(_BLACK, return_value=_BLACK_PASS),
+                patch("scripts.run_assessment.run_command", return_value=mock_run),
+            ):
+                result = run_assessment(aid, out)
+            assert result == 0, (
+                f"run_assessment returned non-zero for assessment {aid}"
+            )

--- a/tests/test_run_assessment.py
+++ b/tests/test_run_assessment.py
@@ -53,9 +53,7 @@ class TestFileDiscovery:
     def test_count_matches_list_length(self) -> None:
         """Count returned must equal len(files)."""
         fake_files = [Path("a.py"), Path("b.py"), Path("c.py")]
-        with patch(
-            "scripts.run_assessment.find_python_files", return_value=fake_files
-        ):
+        with patch("scripts.run_assessment.find_python_files", return_value=fake_files):
             files, count = file_discovery()
         assert count == len(files)
         assert count == 3
@@ -70,9 +68,7 @@ class TestFileDiscovery:
     def test_returns_same_files_as_find_python_files(self) -> None:
         """file_discovery() must pass through all files from find_python_files."""
         expected = [Path("x.py"), Path("y.py")]
-        with patch(
-            "scripts.run_assessment.find_python_files", return_value=expected
-        ):
+        with patch("scripts.run_assessment.find_python_files", return_value=expected):
             files, count = file_discovery()
         assert files == expected
 
@@ -385,6 +381,4 @@ class TestRunAssessment:
                 patch("scripts.run_assessment.run_command", return_value=mock_run),
             ):
                 result = run_assessment(aid, out)
-            assert result == 0, (
-                f"run_assessment returned non-zero for assessment {aid}"
-            )
+            assert result == 0, f"run_assessment returned non-zero for assessment {aid}"


### PR DESCRIPTION
## Summary

- Extracted `file_discovery()`, `analyze_module()`, `calculate_scores()`, and `generate_report()` from the 394-line `run_assessment()` function in `scripts/run_assessment.py`
- `run_assessment()` is now a thin orchestrator that calls the four helpers in sequence, preserving the existing public API and CLI interface unchanged
- Added 35 new unit tests in `tests/test_run_assessment.py` covering each extracted function (contract tests, boundary tests, parametrised cases)
- Updated `SPEC.md` to version 1.1.2 documenting the refactor

Closes #680

## Test plan

- [x] `pytest tests/test_run_assessment.py -v` — 35 tests, all passing
- [x] `ruff check scripts/run_assessment.py tests/test_run_assessment.py` — no issues
- [x] Existing CLI interface (`--assessment`, `--output`) unchanged
- [x] `run_assessment()` still returns 0 on success and 1 on unknown ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)