### PR TITLE
Narrow shared shot-resolution API

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,8 +10,8 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.2                                                |
-| **Last Spec Update**    | 2026-04-02                                           |
+| **Spec Version**        | 1.1.3                                                |
+| **Last Spec Update**    | 2026-04-06                                           |
 
 ## 2. Purpose & Mission
 
@@ -114,6 +114,7 @@ Games/
 | Duum Level Generation | `src/games/Duum/levels/`         | Procedural dungeon generation, room connectivity                                |
 | Tetris Logic          | `src/games/Tetris/`              | Piece mechanics, board state, gravity, line clearing                            |
 | Shared Renderers      | `src/games/shared/renderers/`    | Common rendering abstractions, 2D drawing, sprite management                    |
+| Shared Combat Manager | `src/games/shared/combat_manager.py` | Shared hitscan and explosion logic with a request-based shot-resolution contract |
 | C++ Bindings          | `src/games/shared/cpp_bindings/` | ctypes interface to compiled performance-critical code                          |
 | QuatEngine C++        | `src/games/shared/cpp/`          | Header-only C++17 engine modules: math, core, game, AI, renderer, input, loader |
 | C++ CI Pipeline       | `.github/workflows/cpp-ci.yml`   | clang-format style gate + cmake/ctest build matrix (GCC 12, Clang 17)           |
@@ -179,6 +180,21 @@ from src.games.shared.input import InputHandler
 input_handler = InputHandler()
 if input_handler.is_key_pressed("UP"):
     # Move player up
+```
+
+**Shared Combat Resolution:**
+
+```python
+from games.shared.combat_manager import ShotResolutionRequest
+
+request = ShotResolutionRequest(
+    player=player,
+    raycaster=raycaster,
+    bots=bots,
+    damage_texts=damage_texts,
+    show_damage=show_damage,
+)
+damage_texts = combat_manager.check_shot_hit(request)
 ```
 
 ## 6. Data & Configuration
@@ -382,6 +398,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-06 | 1.1.3   | Narrowed the shared combat-manager hitscan interface to a request-based shot-resolution contract and documented the shared combat component explicitly.                                                                                                                                                                                                                                                                                                   |
 | 2026-04-02 | 1.1.2   | Refactored `scripts/run_assessment.py` (issue #680): extracted `file_discovery`, `analyze_module`, `calculate_scores`, `generate_report` from monolithic function; added 35 unit tests; `run_assessment()` is now a thin orchestrator.                                                                                                                                                                                                                   |
 | 2026-03-31 | 1.1.1   | Added self-hosted runner fallback behavior to PR CI documentation and normalized C++ headers/tests to satisfy the blocking clang-format check                                                                                                                                                                                                                                                                                                            |
 | 2026-03-28 | 1.0.0   | Initial specification document                                                                                                                                                                                                                                                                                                                                                                                                                           |

--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -6,9 +6,8 @@ import random
 
 import pygame
 
+from games.shared.combat_manager import ShotResolutionRequest
 from games.shared.config import RaycasterConfig
-
-# Shared components
 from games.shared.constants import (
     BEAST_TIMER_MAX,
     BEAST_TIMER_MIN,
@@ -463,14 +462,16 @@ class Game(FPSGameBase):
         if not (self.raycaster is not None):
             raise ValueError("DbC Blocked: Precondition failed.")
         self.damage_texts = self.combat_manager.check_shot_hit(
-            player=self.player,
-            raycaster=self.raycaster,
-            bots=self.bots,
-            damage_texts=self.damage_texts,
-            show_damage=self.show_damage,
-            is_secondary=is_secondary,
-            angle_offset=angle_offset,
-            is_laser=is_laser,
+            ShotResolutionRequest(
+                player=self.player,
+                raycaster=self.raycaster,
+                bots=self.bots,
+                damage_texts=self.damage_texts,
+                show_damage=self.show_damage,
+                is_secondary=is_secondary,
+                angle_offset=angle_offset,
+                is_laser=is_laser,
+            )
         )
         self._sync_combat_state()
 

--- a/src/games/Zombie_Survival/src/weapon_system.py
+++ b/src/games/Zombie_Survival/src/weapon_system.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import random
 from typing import TYPE_CHECKING, Any
 
+from games.shared.combat_manager import ShotResolutionRequest
 from games.shared.constants import MINIGUN_BULLETS_PER_SHOT, MINIGUN_SPREAD
 
 from . import constants as C  # noqa: N812
@@ -74,14 +75,16 @@ class WeaponSystem:
         if not (game.raycaster is not None):
             raise ValueError("DbC Blocked: Precondition failed.")
         game.damage_texts = game.combat_manager.check_shot_hit(
-            player=game.player,
-            raycaster=game.raycaster,
-            bots=game.bots,
-            damage_texts=game.damage_texts,
-            show_damage=game.show_damage,
-            is_secondary=is_secondary,
-            angle_offset=angle_offset,
-            is_laser=is_laser,
+            ShotResolutionRequest(
+                player=game.player,
+                raycaster=game.raycaster,
+                bots=game.bots,
+                damage_texts=game.damage_texts,
+                show_damage=game.show_damage,
+                is_secondary=is_secondary,
+                angle_offset=angle_offset,
+                is_laser=is_laser,
+            )
         )
         game.sync_combat_state()
 
@@ -145,6 +148,8 @@ class WeaponSystem:
     def _fire_projectile(self, weapon_data: dict[str, Any], weapon_name: str) -> None:
         """Spawn a projectile based on weapon data."""
         game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
         size_map = {"plasma": 0.225, "rocket": 0.3}
         p = Projectile(
             game.player_x,
@@ -174,6 +179,8 @@ class WeaponSystem:
     def _fire_burst(self, weapon_data: dict[str, Any], weapon_name: str) -> None:
         """Fire a burst of fast projectiles."""
         game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
         damage = game.player.get_current_weapon_damage()
         for _ in range(MINIGUN_BULLETS_PER_SHOT):
             angle_off = random.uniform(-MINIGUN_SPREAD, MINIGUN_SPREAD)

--- a/src/games/shared/combat_manager.py
+++ b/src/games/shared/combat_manager.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import logging
 import math
 import random
+from collections.abc import Sequence
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pygame
@@ -22,6 +24,31 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ShotResolutionRequest:
+    """Input contract for resolving one hitscan shot."""
+
+    player: Any
+    raycaster: Any
+    bots: Sequence[Any]
+    damage_texts: list[dict[str, Any]]
+    show_damage: bool = True
+    is_secondary: bool = False
+    angle_offset: float = 0.0
+    is_laser: bool = False
+
+
+@dataclass(slots=True)
+class ShotResolutionResult:
+    """Resolved hit target and aim geometry for one hitscan shot."""
+
+    aim_angle: float
+    wall_distance: float
+    closest_bot: Any | None
+    closest_distance: float
+    is_headshot: bool
 
 
 class CombatManagerBase:
@@ -82,101 +109,23 @@ class CombatManagerBase:
     # Hitscan shot detection
     # ------------------------------------------------------------------
 
-    def check_shot_hit(
-        self,
-        player: Any,
-        raycaster: Any,
-        bots: list[Any],
-        damage_texts: list[dict[str, Any]],
-        show_damage: bool = True,
-        is_secondary: bool = False,
-        angle_offset: float = 0.0,
-        is_laser: bool = False,
-    ) -> list[dict[str, Any]]:
-        """Check if a hitscan shot hit any bot.
-
-        Returns the updated damage_texts list.  The caller owns the list;
-        this method only appends to it.
-
-        Args:
-            player: The player object (must have x, y, angle, zoomed, etc.).
-            raycaster: The Raycaster instance for ray casting.
-            bots: List of bot objects to check against.
-            damage_texts: Mutable list of floating damage text dicts.
-            show_damage: Whether to show damage numbers.
-            is_secondary: Whether this is a secondary fire.
-            angle_offset: Angle offset for spread weapons.
-            is_laser: Whether this is a laser beam.
-
-        Returns:
-            The (possibly modified) damage_texts list.
-        """
+    def check_shot_hit(self, request: ShotResolutionRequest) -> list[dict[str, Any]]:
+        """Resolve a hitscan shot and apply the shared side effects."""
         try:
-            weapon_range = player.get_current_weapon_range()
-            if is_secondary:
-                weapon_range = 100
+            resolution = self.resolve_shot_target(request)
+            weapon_range = self._get_weapon_range(request.player, request.is_secondary)
 
-            weapon_damage = player.get_current_weapon_damage()
-
-            # Aim Logic
-            spread_zoom = getattr(self.C, "SPREAD_ZOOM", 0.01)
-            spread_base = getattr(self.C, "SPREAD_BASE", 0.04)
-            current_spread = spread_zoom if player.zoomed else spread_base
-            if angle_offset == 0.0:
-                spread_offset = random.uniform(-current_spread, current_spread)
-                aim_angle = player.angle + spread_offset
-            else:
-                aim_angle = player.angle + angle_offset
-
-            aim_angle %= 2 * math.pi
-
-            # Cast ray to find wall distance
-            wall_dist, _, _, _, _ = raycaster.cast_ray(player.x, player.y, aim_angle)
-
-            if wall_dist > weapon_range:
-                wall_dist = float(weapon_range)
-
-            closest_bot = None
-            closest_dist = float("inf")
-            is_headshot = False
-
-            wall_dist_sq = wall_dist * wall_dist
-            headshot_threshold = getattr(self.C, "HEADSHOT_THRESHOLD", 0.05)
-
-            for bot in bots:
-                if not bot.alive:
-                    continue
-
-                dx = bot.x - player.x
-                dy = bot.y - player.y
-                dist_sq = dx * dx + dy * dy
-
-                if dist_sq > wall_dist_sq:
-                    continue
-
-                distance = math.sqrt(dist_sq)
-
-                bot_angle = math.atan2(dy, dx)
-                if bot_angle < 0:
-                    bot_angle += 2 * math.pi
-
-                angle_diff = abs(bot_angle - aim_angle)
-                if angle_diff > math.pi:
-                    angle_diff = 2 * math.pi - angle_diff
-
-                if angle_diff < 0.15:
-                    if distance < closest_dist:
-                        closest_bot = bot
-                        closest_dist = distance
-                        is_headshot = angle_diff < headshot_threshold
-
-            if is_secondary:
+            if request.is_secondary:
                 self._handle_secondary_hit(
-                    player, closest_bot, closest_dist, wall_dist, damage_texts
+                    request.player,
+                    resolution.closest_bot,
+                    resolution.closest_distance,
+                    resolution.wall_distance,
+                    request.damage_texts,
                 )
-                return damage_texts
+                return request.damage_texts
 
-            if is_laser:
+            if request.is_laser:
                 self.particle_system.add_laser(
                     start=(self.C.SCREEN_WIDTH - 200, self.C.SCREEN_HEIGHT - 180),
                     end=(self.C.SCREEN_WIDTH // 2, self.C.SCREEN_HEIGHT // 2),
@@ -185,27 +134,121 @@ class CombatManagerBase:
                     width=3,
                 )
 
-            if closest_bot:
+            if resolution.closest_bot:
                 self._apply_hit_damage(
-                    player,
-                    closest_bot,
-                    closest_dist,
+                    request.player,
+                    resolution.closest_bot,
+                    resolution.closest_distance,
                     weapon_range,
-                    weapon_damage,
-                    is_headshot,
-                    damage_texts,
-                    show_damage,
+                    request.player.get_current_weapon_damage(),
+                    resolution.is_headshot,
+                    request.damage_texts,
+                    request.show_damage,
                 )
 
-            # Visual traces
             self._add_shot_visuals(
-                player, aim_angle, closest_bot, closest_dist, wall_dist
+                request.player,
+                resolution.aim_angle,
+                resolution.closest_bot,
+                resolution.closest_distance,
+                resolution.wall_distance,
             )
-
         except (ValueError, AttributeError, ZeroDivisionError):
             logger.exception("Error in check_shot_hit")
 
-        return damage_texts
+        return request.damage_texts
+
+    def resolve_shot_target(
+        self, request: ShotResolutionRequest
+    ) -> ShotResolutionResult:
+        """Resolve hit geometry without applying presentation or damage side effects."""
+        weapon_range = self._get_weapon_range(request.player, request.is_secondary)
+        aim_angle = self._resolve_aim_angle(request.player, request.angle_offset)
+        wall_distance = self._resolve_wall_distance(
+            request.player, request.raycaster, aim_angle, weapon_range
+        )
+        closest_bot, closest_distance, is_headshot = self._find_closest_target(
+            request.player,
+            request.bots,
+            aim_angle,
+            wall_distance,
+        )
+        return ShotResolutionResult(
+            aim_angle=aim_angle,
+            wall_distance=wall_distance,
+            closest_bot=closest_bot,
+            closest_distance=closest_distance,
+            is_headshot=is_headshot,
+        )
+
+    def _get_weapon_range(self, player: Any, is_secondary: bool) -> float:
+        """Return the range to use for the current shot mode."""
+        if is_secondary:
+            return 100.0
+        return float(player.get_current_weapon_range())
+
+    def _resolve_aim_angle(self, player: Any, angle_offset: float) -> float:
+        """Return the normalized aim angle for a shot."""
+        spread_zoom = getattr(self.C, "SPREAD_ZOOM", 0.01)
+        spread_base = getattr(self.C, "SPREAD_BASE", 0.04)
+        current_spread = spread_zoom if player.zoomed else spread_base
+        if angle_offset == 0.0:
+            spread_offset = random.uniform(-current_spread, current_spread)
+            angle = player.angle + spread_offset
+        else:
+            angle = player.angle + angle_offset
+        return angle % (2 * math.pi)
+
+    def _resolve_wall_distance(
+        self,
+        player: Any,
+        raycaster: Any,
+        aim_angle: float,
+        weapon_range: float,
+    ) -> float:
+        """Return the distance to the blocking wall, clamped by weapon range."""
+        wall_dist, _, _, _, _ = raycaster.cast_ray(player.x, player.y, aim_angle)
+        return min(float(wall_dist), weapon_range)
+
+    def _find_closest_target(
+        self,
+        player: Any,
+        bots: Sequence[Any],
+        aim_angle: float,
+        wall_distance: float,
+    ) -> tuple[Any | None, float, bool]:
+        """Return the nearest hittable bot intersecting the resolved shot."""
+        closest_bot = None
+        closest_dist = float("inf")
+        is_headshot = False
+        wall_dist_sq = wall_distance * wall_distance
+        headshot_threshold = getattr(self.C, "HEADSHOT_THRESHOLD", 0.05)
+
+        for bot in bots:
+            if not bot.alive:
+                continue
+
+            dx = bot.x - player.x
+            dy = bot.y - player.y
+            dist_sq = dx * dx + dy * dy
+            if dist_sq > wall_dist_sq:
+                continue
+
+            distance = math.sqrt(dist_sq)
+            bot_angle = math.atan2(dy, dx)
+            if bot_angle < 0:
+                bot_angle += 2 * math.pi
+
+            angle_diff = abs(bot_angle - aim_angle)
+            if angle_diff > math.pi:
+                angle_diff = 2 * math.pi - angle_diff
+
+            if angle_diff < 0.15 and distance < closest_dist:
+                closest_bot = bot
+                closest_dist = distance
+                is_headshot = angle_diff < headshot_threshold
+
+        return closest_bot, closest_dist, is_headshot
 
     def _handle_secondary_hit(
         self,

--- a/tests/shared/test_combat_manager.py
+++ b/tests/shared/test_combat_manager.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from games.shared.combat_manager import CombatManagerBase
+from games.shared.combat_manager import CombatManagerBase, ShotResolutionRequest
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -340,6 +340,29 @@ class TestExplodeGeneric:
 class TestCheckShotHit:
     """Tests for check_shot_hit, applying hit damage, and secondary hits."""
 
+    @staticmethod
+    def _make_request(
+        *,
+        player: Any,
+        raycaster: Any,
+        bots: list[Any],
+        damage_texts: list[dict[str, Any]] | None = None,
+        show_damage: bool = True,
+        is_secondary: bool = False,
+        angle_offset: float = 0.0,
+        is_laser: bool = False,
+    ) -> ShotResolutionRequest:
+        return ShotResolutionRequest(
+            player=player,
+            raycaster=raycaster,
+            bots=bots,
+            damage_texts=[] if damage_texts is None else damage_texts,
+            show_damage=show_damage,
+            is_secondary=is_secondary,
+            angle_offset=angle_offset,
+            is_laser=is_laser,
+        )
+
     def test_check_shot_hit_primary(self) -> None:
         mgr = CombatManagerBase(
             entity_manager=_make_entity_manager(),
@@ -363,7 +386,9 @@ class TestCheckShotHit:
         mock_rc = MagicMock()
         mock_rc.cast_ray.return_value = (50.0, 0, 0, 0, 0)
 
-        mgr.check_shot_hit(player, mock_rc, [bot], [], angle_offset=0.0)
+        mgr.check_shot_hit(
+            self._make_request(player=player, raycaster=mock_rc, bots=[bot])
+        )
         assert mock_rc.cast_ray.called
         assert mgr._apply_hit_damage.called
 
@@ -386,7 +411,14 @@ class TestCheckShotHit:
         mock_rc = MagicMock()
         mock_rc.cast_ray.return_value = (50.0, 0, 0, 0, 0)
 
-        mgr.check_shot_hit(player, mock_rc, [], [], angle_offset=0.0, is_laser=True)
+        mgr.check_shot_hit(
+            self._make_request(
+                player=player,
+                raycaster=mock_rc,
+                bots=[],
+                is_laser=True,
+            )
+        )
         assert mgr.particle_system.add_laser.called
 
     def test_check_shot_hit_secondary(self) -> None:
@@ -410,8 +442,48 @@ class TestCheckShotHit:
         mock_rc = MagicMock()
         mock_rc.cast_ray.return_value = (50.0, 0, 0, 0, 0)
 
-        mgr.check_shot_hit(player, mock_rc, [], [], angle_offset=0.0, is_secondary=True)
+        mgr.check_shot_hit(
+            self._make_request(
+                player=player,
+                raycaster=mock_rc,
+                bots=[],
+                is_secondary=True,
+            )
+        )
         assert mgr._handle_secondary_hit.called
+
+    def test_resolve_shot_target_separates_geometry_from_side_effects(self) -> None:
+        mgr = CombatManagerBase(
+            entity_manager=_make_entity_manager(),
+            particle_system=MagicMock(),
+            sound_manager=MagicMock(),
+            constants=_make_constants(),
+        )
+        player = SimpleNamespace(
+            x=0.0,
+            y=0.0,
+            angle=0.0,
+            zoomed=False,
+            get_current_weapon_range=lambda: 100.0,
+            get_current_weapon_damage=lambda: 10,
+        )
+        bot = _make_bot(x=10.0, y=0.0, alive=True)
+        mock_rc = MagicMock()
+        mock_rc.cast_ray.return_value = (50.0, 0, 0, 0, 0)
+
+        resolution = mgr.resolve_shot_target(
+            self._make_request(
+                player=player,
+                raycaster=mock_rc,
+                bots=[bot],
+                angle_offset=0.001,
+            )
+        )
+
+        assert resolution.closest_bot is bot
+        assert resolution.closest_distance == pytest.approx(10.0)
+        mgr.particle_system.add_trace.assert_not_called()
+        mgr.particle_system.add_explosion.assert_not_called()
 
     def test_handle_secondary_hit_creates_explosion(self) -> None:
         mgr = CombatManagerBase(
@@ -484,15 +556,25 @@ class TestCombatManagerEdgeCases:
         mock_rc.cast_ray.return_value = (200.0, 0, 0, 0, 0)
 
         mgr.check_shot_hit(
-            player,
-            mock_rc,
-            [bot_dead, bot_far, bot_behind, bot_wrap, bot_close, bot_further_in_line],
-            [],
-            angle_offset=0.1,
+            TestCheckShotHit._make_request(
+                player=player,
+                raycaster=mock_rc,
+                bots=[
+                    bot_dead,
+                    bot_far,
+                    bot_behind,
+                    bot_wrap,
+                    bot_close,
+                    bot_further_in_line,
+                ],
+                angle_offset=0.1,
+            )
         )
 
         # Exception
-        mgr.check_shot_hit(None, mock_rc, [], [])
+        mgr.check_shot_hit(  # type: ignore[arg-type]
+            TestCheckShotHit._make_request(player=None, raycaster=mock_rc, bots=[])
+        )
 
     def test_handle_secondary_hit_exception(self) -> None:
         mgr = CombatManagerBase(


### PR DESCRIPTION
## Summary
- introduce a request object for shared hitscan shot resolution
- separate pure shot-target resolution from damage and presentation side effects
- update Zombie Survival weapon firing to use the narrowed shared combat API

Closes #716

## Validation
- python -m pytest tests/shared/test_combat_manager.py tests/Zombie_Survival/test_combat_manager.py
- ruff check src/games/shared/combat_manager.py src/games/Zombie_Survival/src/weapon_system.py tests/shared/test_combat_manager.py tests/Zombie_Survival/test_combat_manager.py
- ruff format --check src/games/shared/combat_manager.py src/games/Zombie_Survival/src/weapon_system.py tests/shared/test_combat_manager.py tests/Zombie_Survival/test_combat_manager.py
- black --check src/games/shared/combat_manager.py src/games/Zombie_Survival/src/weapon_system.py tests/shared/test_combat_manager.py tests/Zombie_Survival/test_combat_manager.py
- python -m mypy src/games/shared/combat_manager.py src/games/Zombie_Survival/src/weapon_system.py (repo has pre-existing mypy failures in unrelated Zombie_Survival ui/game modules pulled in by import traversal)