### PR TITLE
Split Force Field gameplay orchestration into focused modules

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.3                                                |
+| **Spec Version**        | 1.1.4                                                |
 | **Last Spec Update**    | 2026-04-06                                           |
 
 ## 2. Purpose & Mission
@@ -367,6 +367,10 @@ pytest tests/ -v
 
 Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (QuatGolf) in progress with quaternion physics implementation. Shared rendering infrastructure stable. Focus on test coverage expansion and performance optimization.
 
+### Completed (2026-04-06)
+
+- **Force Field orchestrator split** (issue #715): Reduced `src/games/Force_Field/src/game.py` to a thin orchestrator by extracting session lifecycle, combat actions, gameplay runtime, and screen-flow responsibilities into focused modules. Added screen-flow tests covering intro transitions, map-select launch flow, and key-binding selection.
+
 ### Completed (2026-04-02)
 
 - **run_assessment.py refactor** (issue #680): Extracted `file_discovery()`, `analyze_module()`, `calculate_scores()`, and `generate_report()` from the monolithic 394-line `run_assessment()` function. Each helper follows SRP; `run_assessment()` is now a thin orchestrator. 35 new unit tests cover every extracted function.
@@ -398,6 +402,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-06 | 1.1.4   | Split the Force Field orchestrator into focused `game_session`, `combat_actions`, `gameplay_runtime`, and `screen_flow` modules, reducing `game.py` to a thin coordinator and adding screen-flow coverage for intro, setup, and key-config transitions.                                                                                                                                                                                               |
 | 2026-04-06 | 1.1.3   | Narrowed the shared combat-manager hitscan interface to a request-based shot-resolution contract and documented the shared combat component explicitly.                                                                                                                                                                                                                                                                                                   |
 | 2026-04-02 | 1.1.2   | Refactored `scripts/run_assessment.py` (issue #680): extracted `file_discovery`, `analyze_module`, `calculate_scores`, `generate_report` from monolithic function; added 35 unit tests; `run_assessment()` is now a thin orchestrator.                                                                                                                                                                                                                   |
 | 2026-03-31 | 1.1.1   | Added self-hosted runner fallback behavior to PR CI documentation and normalized C++ headers/tests to satisfy the blocking clang-format check                                                                                                                                                                                                                                                                                                            |

--- a/src/games/Force_Field/src/combat_actions.py
+++ b/src/games/Force_Field/src/combat_actions.py
@@ -1,0 +1,160 @@
+"""Combat-side gameplay actions extracted from the Force Field orchestrator."""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import TYPE_CHECKING
+
+import pygame
+
+from games.shared.constants import COMBO_TIMER_FRAMES
+
+from . import constants as C  # noqa: N812
+
+if TYPE_CHECKING:
+    from .bot import Bot
+    from .game import Game
+    from .player import Player
+
+
+MELEE_RANGE = 3.0
+MELEE_DAMAGE = 75
+MELEE_ARC = math.pi / 3
+SWEEP_ARC_HALF_WIDTH = math.pi / 4
+SWEEP_LAYERS = 3
+SWEEP_SEGMENTS = 30
+SWEEP_SPARK_COUNT = 15
+BOT_PARTICLE_COUNT = 5
+
+
+def execute_melee_attack(game: Game) -> None:
+    """Apply the player's melee attack to nearby bots and trigger FX."""
+    player = _require_player(game)
+
+    create_melee_sweep_effect(game)
+    _play_melee_sound(game)
+
+    hits = 0
+    for bot in game.bots:
+        if not bot.alive or not _bot_in_melee_arc(player, bot):
+            continue
+        if bot.take_damage(MELEE_DAMAGE):
+            _record_melee_kill(game, bot)
+        hits += 1
+        _spawn_bot_hit_particles(game, bot)
+
+    if hits == 1:
+        game.add_message("CRITICAL HIT!", C.RED)
+    elif hits > 1:
+        game.add_message(f"COMBO x{hits}!", C.RED)
+
+
+def create_melee_sweep_effect(game: Game) -> None:
+    """Create the sweeping slash particles for the melee attack."""
+    player = _require_player(game)
+    _add_sweep_layers(game, player.angle)
+    _add_center_burst(game)
+
+
+def _play_melee_sound(game: Game) -> None:
+    """Fire and forget the melee shotgun audio cue."""
+    try:
+        game.sound_manager.play_sound("shoot_shotgun")
+    except (pygame.error, OSError):
+        return
+
+
+def _bot_in_melee_arc(player: Player, bot: Bot) -> bool:
+    """Return whether a bot falls inside the melee cone."""
+    dx = bot.x - player.x
+    dy = bot.y - player.y
+    if math.hypot(dx, dy) > MELEE_RANGE:
+        return False
+    bot_angle = math.atan2(dy, dx)
+    angle_diff = abs(bot_angle - player.angle)
+    while angle_diff > math.pi:
+        angle_diff -= 2 * math.pi
+    return abs(angle_diff) <= MELEE_ARC / 2
+
+
+def _record_melee_kill(game: Game, bot: Bot) -> None:
+    """Synchronize kill/combo state and emit the kill event."""
+    game.sound_manager.play_sound("scream")
+    game.kills += 1
+    game.kill_combo_count += 1
+    game.kill_combo_timer = COMBO_TIMER_FRAMES
+    game.last_death_pos = (bot.x, bot.y)
+    game.event_bus.emit("bot_killed", x=bot.x, y=bot.y)
+
+
+def _spawn_bot_hit_particles(game: Game, bot: Bot) -> None:
+    """Spawn blood particles at the impacted bot location."""
+    for _ in range(BOT_PARTICLE_COUNT):
+        game.particle_system.add_particle(
+            x=bot.x * 64 + 32,
+            y=bot.y * 64 + 32,
+            dx=random.uniform(-3, 3),
+            dy=random.uniform(-3, 3),
+            color=(200, 0, 0),
+            timer=30,
+            size=random.randint(2, 4),
+        )
+
+
+def _add_sweep_layers(game: Game, player_angle: float) -> None:
+    """Render the layered melee arc across the center of the screen."""
+    arc_start = player_angle - SWEEP_ARC_HALF_WIDTH
+    arc_end = player_angle + SWEEP_ARC_HALF_WIDTH
+    for layer in range(SWEEP_LAYERS):
+        layer_distance = 80 + layer * 40
+        for index in range(SWEEP_SEGMENTS):
+            angle = arc_start + (index / (SWEEP_SEGMENTS - 1)) * (arc_end - arc_start)
+            distance = layer_distance + random.randint(-20, 20)
+            x = C.SCREEN_WIDTH // 2 + math.cos(angle) * distance
+            y = C.SCREEN_HEIGHT // 2 + math.sin(angle) * distance
+            game.particle_system.add_particle(
+                x=x,
+                y=y,
+                dx=math.cos(angle) * 8,
+                dy=math.sin(angle) * 8,
+                color=_layer_color(layer),
+                timer=20 - layer * 5,
+                size=4 + layer,
+                gravity=0.05,
+                fade_color=(100, 0, 0),
+            )
+
+
+def _add_center_burst(game: Game) -> None:
+    """Add the central slash burst so melee impacts read clearly."""
+    for _ in range(SWEEP_SPARK_COUNT):
+        angle = random.uniform(0, 2 * math.pi)
+        speed = random.uniform(3, 12)
+        game.particle_system.add_particle(
+            x=C.SCREEN_WIDTH // 2,
+            y=C.SCREEN_HEIGHT // 2,
+            dx=math.cos(angle) * speed,
+            dy=math.sin(angle) * speed,
+            color=(255, 255, 255),
+            timer=25,
+            size=random.randint(2, 6),
+            gravity=0.1,
+            fade_color=(255, 100, 0),
+        )
+
+
+def _layer_color(layer: int) -> tuple[int, int, int]:
+    """Return the color used for the given sweep layer."""
+    if layer == 0:
+        return (255, 255, 200)
+    if layer == 1:
+        return (255, 150, 0)
+    return (255, 50, 0)
+
+
+def _require_player(game: Game) -> Player:
+    """Return the current player or raise when combat state is incomplete."""
+    if game.player is None:
+        raise ValueError("DbC Blocked: Precondition failed.")
+    return game.player

--- a/src/games/Force_Field/src/game.py
+++ b/src/games/Force_Field/src/game.py
@@ -1,21 +1,12 @@
 from __future__ import annotations
 
 import logging
-import math
-import random
 from typing import Any
 
 import pygame
 
 from games.shared.config import RaycasterConfig
 from games.shared.constants import (
-    BEAST_TIMER_MAX,
-    BEAST_TIMER_MIN,
-    COMBO_TIMER_FRAMES,
-    FOG_REVEAL_RADIUS,
-    GROAN_TIMER_DELAY,
-    PICKUP_RADIUS_SQ,
-    PORTAL_RADIUS_SQ,
     GameState,
 )
 from games.shared.event_bus import EventBus
@@ -26,6 +17,7 @@ from games.shared.interfaces import Portal
 from games.shared.raycaster import Raycaster
 from games.shared.sound_manager_base import SoundManagerBase
 
+from . import combat_actions, game_session, gameplay_runtime, screen_flow
 from . import constants as C  # noqa: N812
 from .combat_system import CombatSystem
 from .entity_manager import EntityManager
@@ -193,121 +185,12 @@ class Game(FPSGameBase):
         )
 
     def start_game(self) -> None:
-        """Start new game"""
-        self.level = self.selected_start_level
-        self.lives = self.selected_lives
-        self.kills = 0
-        self.level_times = []
-        self.paused = False
-        self.particle_system.particles = []
-        self.damage_texts = []
-        self.entity_manager.reset()
-
-        # Roguelike Weapon Start
-        # Always have pistol, plus one random higher-tier weapon
-        possible_starters = [
-            "rifle",
-            "shotgun",
-            "minigun",
-            "plasma",
-            "laser",
-            "rocket",
-            "flamethrower",
-            "pulse",
-            "freezer",
-        ]
-        starter = random.choice(possible_starters)
-        self.unlocked_weapons = {"pistol", starter}
-        self.god_mode = False
-        self.cheat_mode_active = False
-
-        # Reset Combo & Atmosphere
-        self.kill_combo_count = 0
-        self.kill_combo_timer = 0
-        self.heartbeat_timer = 0
-        self.breath_timer = 0
-        self.groan_timer = 0
-        self.beast_timer = 0
-
-        # Create map with selected size
-        self.game_map = Map(self.selected_map_size)
-        self.raycaster = Raycaster(self.game_map, self.raycaster_config)
-        self.raycaster.set_render_scale(self.render_scale)
-        self.last_death_pos = None
-
-        # Grab mouse
-        pygame.mouse.set_visible(False)
-        pygame.event.set_grab(True)
-
-        self.start_level()
+        """Start a new run using the configured campaign options."""
+        game_session.start_game(self)
 
     def start_level(self) -> None:
-        """Start a new level"""
-        if not (self.game_map is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        self.level_start_time = pygame.time.get_ticks()
-        self.total_paused_time = 0
-        self.pause_start_time = 0
-        self.particle_system.particles = []
-        self.damage_texts = []
-        self.damage_flash_timer = 0
-        self.screen_shake = 0.0
-        self.visited_cells = set()  # Reset fog of war
-        self.portal = None
-
-        # Grab mouse for FPS gameplay
-        pygame.mouse.set_visible(False)
-        pygame.event.set_grab(True)
-
-        # Player Spawn Logic
-        player_pos = self._get_best_spawn_point()
-
-        # Preserve ammo and weapon selection from previous level if player exists
-        previous_ammo = None
-        previous_weapon = "pistol"
-        old_player = self.player
-        if old_player:
-            previous_ammo = old_player.ammo
-            previous_weapon = old_player.current_weapon
-
-        self.player = Player(player_pos[0], player_pos[1], player_pos[2])
-        if previous_ammo:
-            self.player.ammo = previous_ammo
-            if previous_weapon in self.unlocked_weapons:
-                self.player.current_weapon = previous_weapon
-            else:
-                self.player.current_weapon = "pistol"
-
-        # If Level 1 (New Game), equip the non-pistol starter
-        if self.level == 1:
-            for w in self.unlocked_weapons:
-                if w != "pistol":
-                    self.player.current_weapon = w
-                    break
-        # Validate current weapon is unlocked
-        if self.player.current_weapon not in self.unlocked_weapons:
-            self.player.current_weapon = "pistol"
-
-        # Propagate God Mode state
-        self.player.god_mode = self.god_mode
-
-        # Delegate spawning to SpawnManager
-        self.entity_manager.reset()
-        self.spawn_manager.spawn_all(
-            player_pos, self.game_map, self.level, self.selected_difficulty
-        )
-
-        # Start Music
-        music_tracks = [
-            "music_loop",
-            "music_drums",
-            "music_wind",
-            "music_horror",
-            "music_piano",
-            "music_action",
-        ]
-        if hasattr(self, "sound_manager"):
-            self.sound_manager.start_music(random.choice(music_tracks))
+        """Start the current level with a fresh spawn and preserved loadout."""
+        game_session.start_level(self)
 
     # save_game is inherited from FPSGameBase.
 
@@ -336,668 +219,92 @@ class Game(FPSGameBase):
         self.combat_system.explode_freezer(projectile)
 
     def execute_melee_attack(self) -> None:
-        """Execute melee attack - wide sweeping damage in front of player"""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-
-        melee_range = 3.0
-        melee_damage = 75
-        melee_arc = math.pi / 3
-
-        self.create_melee_sweep_effect()
-
-        try:
-            self.sound_manager.play_sound("shoot_shotgun")
-        except (pygame.error, OSError):
-            pass
-
-        player_x, player_y = self.player.x, self.player.y
-        player_angle = self.player.angle
-
-        hits = 0
-        for bot in self.bots:
-            if not bot.alive:
-                continue
-
-            dx = bot.x - player_x
-            dy = bot.y - player_y
-            distance = math.sqrt(dx * dx + dy * dy)
-
-            if distance <= melee_range:
-                bot_angle = math.atan2(dy, dx)
-                angle_diff = abs(bot_angle - player_angle)
-
-                while angle_diff > math.pi:
-                    angle_diff -= 2 * math.pi
-                angle_diff = abs(angle_diff)
-
-                if angle_diff <= melee_arc / 2:
-                    if bot.take_damage(melee_damage):
-                        self.sound_manager.play_sound("scream")
-                        self.kills += 1
-                        self.kill_combo_count += 1
-                        self.kill_combo_timer = COMBO_TIMER_FRAMES
-                        self.last_death_pos = (bot.x, bot.y)
-                        self.event_bus.emit("bot_killed", x=bot.x, y=bot.y)
-
-                    hits += 1
-
-                    for _ in range(5):
-                        self.particle_system.add_particle(
-                            x=bot.x * 64 + 32,
-                            y=bot.y * 64 + 32,
-                            dx=random.uniform(-3, 3),
-                            dy=random.uniform(-3, 3),
-                            color=(200, 0, 0),
-                            timer=30,
-                            size=random.randint(2, 4),
-                        )
-
-        if hits > 0:
-            if hits == 1:
-                self.add_message("CRITICAL HIT!", C.RED)
-            else:
-                self.add_message(f"COMBO x{hits}!", C.RED)
+        """Execute the melee attack owned by the combat-actions subsystem."""
+        combat_actions.execute_melee_attack(self)
 
     def create_melee_sweep_effect(self) -> None:
-        """Create enhanced visual sweep effect for melee attack"""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-
-        player_angle = self.player.angle
-        arc_start = player_angle - math.pi / 4
-        arc_end = player_angle + math.pi / 4
-
-        for layer in range(3):
-            layer_distance = 80 + layer * 40
-
-            for i in range(30):
-                t = i / 29.0
-                angle = arc_start + t * (arc_end - arc_start)
-
-                distance = layer_distance + random.randint(-20, 20)
-
-                x = C.SCREEN_WIDTH // 2 + math.cos(angle) * distance
-                y = C.SCREEN_HEIGHT // 2 + math.sin(angle) * distance
-
-                if layer == 0:
-                    color = (255, 255, 200)
-                elif layer == 1:
-                    color = (255, 150, 0)
-                else:
-                    color = (255, 50, 0)
-
-                self.particle_system.add_particle(
-                    x=x,
-                    y=y,
-                    dx=math.cos(angle) * 8,
-                    dy=math.sin(angle) * 8,
-                    color=color,
-                    timer=20 - layer * 5,
-                    size=4 + layer,
-                    gravity=0.05,
-                    fade_color=(100, 0, 0),
-                )
-
-        for _ in range(15):
-            angle = random.uniform(0, 2 * math.pi)
-            speed = random.uniform(3, 12)
-            self.particle_system.add_particle(
-                x=C.SCREEN_WIDTH // 2,
-                y=C.SCREEN_HEIGHT // 2,
-                dx=math.cos(angle) * speed,
-                dy=math.sin(angle) * speed,
-                color=(255, 255, 255),
-                timer=25,
-                size=random.randint(2, 6),
-                gravity=0.1,
-                fade_color=(255, 100, 0),
-            )
+        """Create the melee slash particles via the combat-actions module."""
+        combat_actions.create_melee_sweep_effect(self)
 
     def _check_game_over(self) -> bool:
-        if not self.player.alive:
-            if self.lives > 1:
-                self.lives -= 1
-                self.respawn_player()
-                return True
-            level_time = (
-                pygame.time.get_ticks() - self.level_start_time - self.total_paused_time
-            ) / 1000.0
-            self.level_times.append(level_time)
-            self.lives = 0
-
-            self.state = GameState.GAME_OVER
-            self.game_over_timer = 0
-            self.sound_manager.play_sound("game_over1")
-            pygame.mouse.set_visible(True)
-            pygame.event.set_grab(False)
-            return True
-        return False
+        """Delegate death handling to the gameplay runtime subsystem."""
+        return gameplay_runtime.check_game_over(self)
 
     def _update_screen_shake(self) -> None:
-        if self.screen_shake > 0:
-            self.screen_shake *= 0.9
-            if self.screen_shake < 0.5:
-                self.screen_shake = 0.0
+        """Delegate screen-shake decay to the gameplay runtime subsystem."""
+        gameplay_runtime.update_screen_shake(self)
 
     def _check_portal_completion(self) -> bool:
-        enemies_alive = self.entity_manager.get_active_enemies()
-        if not enemies_alive:
-            if self.portal is None:
-                self.spawn_portal()
-                self.damage_texts.append(
-                    {
-                        "x": C.SCREEN_WIDTH // 2,
-                        "y": C.SCREEN_HEIGHT // 2,
-                        "text": "PORTAL OPENED!",
-                        "color": C.CYAN,
-                        "timer": 180,
-                        "vy": 0,
-                    }
-                )
-
-        if self.portal:
-            dx = self.portal["x"] - self.player.x
-            dy = self.portal["y"] - self.player.y
-            dist_sq = dx * dx + dy * dy
-            if dist_sq < PORTAL_RADIUS_SQ:
-                paused = self.total_paused_time
-                now = pygame.time.get_ticks()
-                level_time = (now - self.level_start_time - paused) / 1000.0
-                self.level_times.append(level_time)
-                self.state = GameState.LEVEL_COMPLETE
-                pygame.mouse.set_visible(True)
-                pygame.event.set_grab(False)
-                return True
-        return False
+        """Delegate portal logic to the gameplay runtime subsystem."""
+        return gameplay_runtime.check_portal_completion(self)
 
     def _handle_combat_input(self) -> None:
-        is_firing = (
-            self.input_manager.is_action_pressed("shoot")
-            or pygame.mouse.get_pressed()[0]
-        )
-
-        if is_firing:
-            w_data = C.WEAPONS.get(self.player.current_weapon, {})
-            if w_data.get("automatic", False):
-                if self.player.shoot():
-                    self.combat_system.fire_weapon()
+        """Delegate held-fire handling to the gameplay runtime subsystem."""
+        gameplay_runtime.handle_combat_input(self)
 
     def _handle_joystick_input(self, shield_active: bool) -> bool:
-        axis_x = self.joystick.get_axis(0)
-        axis_y = self.joystick.get_axis(1)
-
-        if abs(axis_x) > C.JOYSTICK_DEADZONE:
-            self.player.strafe(
-                self.game_map,
-                self.bots,
-                right=(axis_x > 0),
-                speed=abs(axis_x) * C.PLAYER_SPEED * self.movement_speed_multiplier,
-            )
-            self.player.is_moving = True
-        if abs(axis_y) > C.JOYSTICK_DEADZONE:
-            self.player.move(
-                self.game_map,
-                self.bots,
-                forward=(axis_y < 0),
-                speed=abs(axis_y) * C.PLAYER_SPEED * self.movement_speed_multiplier,
-            )
-            self.player.is_moving = True
-
-        look_x = 0.0
-        look_y = 0.0
-        if self.joystick.get_numaxes() >= 4:
-            look_x = self.joystick.get_axis(2)
-            look_y = self.joystick.get_axis(3)
-
-        if abs(look_x) > C.JOYSTICK_DEADZONE:
-            self.player.rotate(look_x * C.PLAYER_ROT_SPEED * 15 * C.SENSITIVITY_X)
-        if abs(look_y) > C.JOYSTICK_DEADZONE:
-            self.player.pitch_view(-look_y * 10 * C.SENSITIVITY_Y)
-
-        if self.joystick.get_numbuttons() > 0 and self.joystick.get_button(0):
-            shield_active = True
-
-        if self.joystick.get_numbuttons() > 2 and self.joystick.get_button(2):
-            self.player.reload()
-
-        if self.joystick.get_numbuttons() > 5 and self.joystick.get_button(5):
-            if self.player.shoot():
-                self.combat_system.fire_weapon()
-
-        if self.joystick.get_numbuttons() > 4 and self.joystick.get_button(4):
-            if self.player.fire_secondary():
-                self.combat_system.fire_weapon(is_secondary=True)
-
-        if self.joystick.get_numhats() > 0:
-            hat = self.joystick.get_hat(0)
-            if hat[0] == -1:
-                self.switch_weapon_with_message("pistol")
-            if hat[0] == 1:
-                self.switch_weapon_with_message("rifle")
-            if hat[1] == 1:
-                self.switch_weapon_with_message("shotgun")
-            if hat[1] == -1:
-                self.switch_weapon_with_message("plasma")
-
-        return shield_active
+        """Delegate controller input handling to the gameplay runtime."""
+        return gameplay_runtime.handle_joystick_input(self, shield_active)
 
     def _update_damage_texts(self) -> None:
-        for t in self.damage_texts:
-            t["y"] += t["vy"]
-            t["timer"] -= 1
-        self.damage_texts = [t for t in self.damage_texts if t["timer"] > 0]
+        """Delegate damage-text animation to the gameplay runtime."""
+        gameplay_runtime.update_damage_texts(self)
 
     def _handle_keyboard_movement(self, keys) -> None:
-        sprint_key = keys[pygame.K_RSHIFT]
-        is_sprinting = self.input_manager.is_action_pressed("sprint") or sprint_key
-
-        if is_sprinting and self.player.stamina > 0:
-            current_speed = C.PLAYER_SPRINT_SPEED * self.movement_speed_multiplier
-            self.player.stamina -= 1
-            self.player.stamina_recharge_delay = 60
-        else:
-            current_speed = C.PLAYER_SPEED * self.movement_speed_multiplier
-
-        moving = False
-
-        if self.input_manager.is_action_pressed("move_forward"):
-            self.player.move(
-                self.game_map, self.bots, forward=True, speed=current_speed
-            )
-            moving = True
-        if self.input_manager.is_action_pressed("move_backward"):
-            self.player.move(
-                self.game_map, self.bots, forward=False, speed=current_speed
-            )
-            moving = True
-        if self.input_manager.is_action_pressed("strafe_left"):
-            self.player.strafe(
-                self.game_map, self.bots, right=False, speed=current_speed
-            )
-            moving = True
-        if self.input_manager.is_action_pressed("strafe_right"):
-            self.player.strafe(
-                self.game_map, self.bots, right=True, speed=current_speed
-            )
-            moving = True
-
-        self.player.is_moving = moving
-
-        if self.input_manager.is_action_pressed("turn_left"):
-            self.player.rotate(-0.05)
-        if self.input_manager.is_action_pressed("turn_right"):
-            self.player.rotate(0.05)
-        if self.input_manager.is_action_pressed("look_up"):
-            self.player.pitch_view(5)
-        if self.input_manager.is_action_pressed("look_down"):
-            self.player.pitch_view(-5)
+        """Delegate keyboard movement to the gameplay runtime subsystem."""
+        gameplay_runtime.handle_keyboard_movement(self, keys)
 
     def _update_fog_of_war(self) -> None:
-        px, py = int(self.player.x), int(self.player.y)
-        for dy in range(-4, 5):
-            for dx in range(-4, 5):
-                if dx * dx + dy * dy <= 16:
-                    cx, cy = px + dx, py + dy
-                    if (
-                        self.game_map
-                        and 0 <= cx < self.game_map.width
-                        and 0 <= cy < self.game_map.height
-                    ):
-                        self.visited_cells.add((cx, cy))
+        """Delegate near-field fog reveal to the gameplay runtime."""
+        gameplay_runtime.update_fog_of_war(self)
 
     def _check_item_pickups(self) -> None:
-        for bot in self.bots:
-            is_item = bot.enemy_type.startswith(("health", "ammo", "bomb", "pickup"))
-            if bot.alive and is_item:
-                dx = bot.x - self.player.x
-                dy = bot.y - self.player.y
-                dist_sq = dx * dx + dy * dy
-                if dist_sq < PICKUP_RADIUS_SQ:
-                    pickup_msg = ""
-                    color = C.GREEN
-
-                    if bot.enemy_type == "health_pack":
-                        if self.player.health < C.PLAYER_HEALTH:
-                            self.player.health = min(
-                                C.PLAYER_HEALTH, self.player.health + 50
-                            )
-                            pickup_msg = "HEALTH +50"
-                    elif bot.enemy_type == "ammo_box":
-                        for w in self.player.ammo:
-                            self.player.ammo[w] += 20
-                        pickup_msg = "AMMO FOUND"
-                        color = C.YELLOW
-                    elif bot.enemy_type == "bomb_item":
-                        self.player.bombs += 1
-                        pickup_msg = "BOMB +1"
-                        color = C.ORANGE
-                    elif bot.enemy_type.startswith("pickup_"):
-                        w_name = bot.enemy_type.replace("pickup_", "")
-                        if w_name not in self.unlocked_weapons:
-                            self.unlocked_weapons.add(w_name)
-                            self.player.switch_weapon(w_name)
-                            pickup_msg = f"{w_name.upper()} ACQUIRED!"
-                            color = C.CYAN
-                        else:
-                            if w_name in self.player.ammo:
-                                clip_size = int(C.WEAPONS[w_name]["clip_size"])
-                                self.player.ammo[w_name] += clip_size * 2
-                                pickup_msg = f"{w_name.upper()} AMMO"
-                                color = C.YELLOW
-
-                    if pickup_msg:
-                        bot.alive = False
-                        bot.removed = True
-                        self.damage_texts.append(
-                            {
-                                "x": C.SCREEN_WIDTH // 2,
-                                "y": C.SCREEN_HEIGHT // 2 - 50,
-                                "text": pickup_msg,
-                                "color": color,
-                                "timer": 60,
-                                "vy": -1,
-                            }
-                        )
+        """Delegate pickup handling to the gameplay runtime subsystem."""
+        gameplay_runtime.check_item_pickups(self)
 
     def _update_large_fog_reveal(self) -> None:
-        cx, cy = int(self.player.x), int(self.player.y)
-        reveal_radius = FOG_REVEAL_RADIUS
-        for r_i in range(-reveal_radius, reveal_radius + 1):
-            for r_j in range(-reveal_radius, reveal_radius + 1):
-                if r_i * r_i + r_j * r_j <= reveal_radius * reveal_radius:
-                    self.visited_cells.add((cx + r_j, cy + r_i))
+        """Delegate wide minimap reveal to the gameplay runtime."""
+        gameplay_runtime.update_large_fog_reveal(self)
 
     def _update_atmosphere(self) -> None:
-        min_dist = self.entity_manager.get_nearest_enemy_distance(
-            self.player.x, self.player.y
-        )
-
-        if min_dist < 15:
-            self.beast_timer -= 1
-            if self.beast_timer <= 0:
-                self.sound_manager.play_sound("beast")
-                self.beast_timer = random.randint(BEAST_TIMER_MIN, BEAST_TIMER_MAX)
-
-        if min_dist < 20:
-            beat_delay = int(min(1.5, max(0.4, min_dist / 10.0)) * C.FPS)
-            self.heartbeat_timer -= 1
-            if self.heartbeat_timer <= 0:
-                self.sound_manager.play_sound("heartbeat")
-                self.sound_manager.play_sound("breath")
-                self.heartbeat_timer = beat_delay
-
-        if self.player.health < 50:
-            self.groan_timer -= 1
-            if self.groan_timer <= 0:
-                self.sound_manager.play_sound("groan")
-                self.groan_timer = GROAN_TIMER_DELAY
+        """Delegate ambient audio updates to the gameplay runtime."""
+        gameplay_runtime.update_atmosphere(self)
 
     def _check_kill_combo(self) -> None:
-        if self.kill_combo_timer > 0:
-            self.kill_combo_timer -= 1
-            if self.kill_combo_timer <= 0:
-                if self.kill_combo_count >= 3:
-                    phrases = [
-                        "DAMN, I'M GOOD!",
-                        "COME GET SOME!",
-                        "HAIL TO THE KING!",
-                        "GROOVY!",
-                        "PIECE OF CAKE!",
-                        "WHO WANTS SOME?",
-                        "EAT THIS!",
-                        "SHAKE IT BABY!",
-                        "NOBODY STEALS OUR CHICKS!",
-                        "IT'S TIME TO KICK ASS!",
-                        "DAMN, THOSE ALIEN BASTARDS!",
-                        "YOUR FACE, YOUR ASS!",
-                        "WHAT'S THE DIFFERENCE?",
-                        "HOLY COW!",
-                        "TERMINATED!",
-                        "WASTED!",
-                        "OWNED!",
-                        "DOMINATING!",
-                        "UNSTOPPABLE!",
-                        "RAMPAGE!",
-                        "GODLIKE!",
-                        "BOOM BABY!",
-                    ]
-
-                    phrase = random.choice(phrases)
-                    self.sound_manager.play_sound("phrase_cool")
-
-                    self.damage_texts.append(
-                        {
-                            "x": C.SCREEN_WIDTH // 2,
-                            "y": C.SCREEN_HEIGHT // 2 - 150,
-                            "text": phrase,
-                            "color": C.YELLOW,
-                            "timer": 180,
-                            "vy": -0.2,
-                            "size": "large",
-                            "effect": "glow",
-                        }
-                    )
-                self.kill_combo_count = 0
+        """Delegate combo expiry logic to the gameplay runtime."""
+        gameplay_runtime.check_kill_combo(self)
 
     def update_game(self) -> None:
-        """Update game state"""
-        if self.paused:
-            return
-
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-
-        if self._check_game_over():
-            return
-
-        self._update_screen_shake()
-
-        if self._check_portal_completion():
-            return
-
-        keys = pygame.key.get_pressed()
-        shield_active = self.input_manager.is_action_pressed("shield")
-
-        if not self.paused and self.player and self.player.alive:
-            self._handle_combat_input()
-
-        if self.joystick and not self.paused and self.player and self.player.alive:
-            shield_active = self._handle_joystick_input(shield_active)
-
-        self.player.set_shield(shield_active)
-        self.particle_system.update()
-        self._update_damage_texts()
-
-        self._handle_keyboard_movement(keys)
-        self.player.update()
-
-        self._update_fog_of_war()
-        self.entity_manager.update_bots(self.game_map, self.player, self)
-        self._check_item_pickups()
-        self.entity_manager.update_projectiles(self.game_map, self.player, self)
-        self._update_large_fog_reveal()
-
-        self._update_atmosphere()
-        self._check_kill_combo()
+        """Update one active gameplay frame through the runtime subsystem."""
+        gameplay_runtime.update_game(self)
 
     def handle_intro_events(self) -> None:
-        """Handle intro screen events"""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.ui_renderer.release_intro_video()
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_SPACE or event.key == pygame.K_ESCAPE:
-                    self.ui_renderer.release_intro_video()
-                    self.state = GameState.MENU
-            elif event.type == pygame.MOUSEBUTTONDOWN:
-                self.ui_renderer.release_intro_video()
-                self.state = GameState.MENU
+        """Delegate intro events to the screen-flow subsystem."""
+        screen_flow.handle_intro_events(self)
 
     def handle_menu_events(self) -> None:
-        """Handle main menu events"""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_RETURN or event.key == pygame.K_SPACE:
-                    self.state = GameState.MAP_SELECT
-                elif event.key == pygame.K_ESCAPE:
-                    self.running = False
-            elif event.type == pygame.MOUSEBUTTONDOWN:
-                self.state = GameState.MAP_SELECT
+        """Delegate main-menu events to the screen-flow subsystem."""
+        screen_flow.handle_menu_events(self)
 
     def handle_map_select_events(self) -> None:
-        """Handle map selection events"""
-        self.ui_renderer.update_start_button(pygame.mouse.get_pos())
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_ESCAPE:
-                    self.state = GameState.MENU
-                elif event.key == pygame.K_RETURN:
-                    self.start_game()
-                    self.state = GameState.PLAYING
-                    pygame.mouse.set_visible(False)
-                    pygame.event.set_grab(True)
-            elif event.type == pygame.MOUSEBUTTONDOWN:
-                if self.ui_renderer.is_start_button_clicked(event.pos):
-                    self.start_game()
-                    self.state = GameState.PLAYING
-                    pygame.mouse.set_visible(False)
-                    pygame.event.set_grab(True)
-
-                my = event.pos[1]
-                if 200 <= my < 200 + 4 * 80:
-                    row = (my - 200) // 80
-                    if row == 0:
-                        sizes = C.MAP_SIZES
-                        try:
-                            idx = sizes.index(self.selected_map_size)
-                            self.selected_map_size = sizes[(idx + 1) % len(sizes)]
-                        except ValueError:
-                            self.selected_map_size = 40
-                    elif row == 1:
-                        diffs = list(C.DIFFICULTIES.keys())
-                        try:
-                            idx = diffs.index(self.selected_difficulty)
-                            self.selected_difficulty = diffs[(idx + 1) % len(diffs)]
-                        except ValueError:
-                            self.selected_difficulty = "NORMAL"
-                    elif row == 2:
-                        self.selected_start_level = (self.selected_start_level % 5) + 1
-                    elif row == 3:
-                        self.selected_lives = (self.selected_lives % 5) + 1
+        """Delegate setup-screen events to the screen-flow subsystem."""
+        screen_flow.handle_map_select_events(self)
 
     def handle_level_complete_events(self) -> None:
-        """Handle input events during the level complete screen."""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_SPACE:
-                    self.level += 1
-                    self.start_level()
-                    self.state = GameState.PLAYING
-                elif event.key == pygame.K_ESCAPE:
-                    self.state = GameState.MENU
+        """Delegate level-complete events to the screen-flow subsystem."""
+        screen_flow.handle_level_complete_events(self)
 
     def handle_game_over_events(self) -> None:
-        """Handle input events during the game over screen."""
-        self.game_over_timer += 1
-        if self.game_over_timer == 120:
-            self.sound_manager.play_sound("game_over2")
-
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_SPACE:
-                    self.start_game()
-                    self.state = GameState.PLAYING
-                elif event.key == pygame.K_ESCAPE:
-                    self.state = GameState.MENU
+        """Delegate game-over events to the screen-flow subsystem."""
+        screen_flow.handle_game_over_events(self)
 
     def handle_key_config_events(self) -> None:
-        """Handle input events in Key Config menu."""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-
-            elif event.type == pygame.KEYDOWN:
-                if self.binding_action:
-                    if event.key != pygame.K_ESCAPE:
-                        self.input_manager.bind_key(self.binding_action, event.key)
-                    self.binding_action = None
-                elif event.key == pygame.K_ESCAPE:
-                    self.state = GameState.PLAYING if self.paused else GameState.MENU
-
-            elif event.type == pygame.MOUSEBUTTONDOWN and not self.binding_action:
-                mx, my = event.pos
-
-                bindings = self.input_manager.bindings
-                actions = sorted(bindings.keys())
-                start_y = 120
-                col_1_x = C.SCREEN_WIDTH // 4
-                col_2_x = C.SCREEN_WIDTH * 3 // 4
-                limit = 12
-
-                for i, action in enumerate(actions):
-                    col = 0 if i < limit else 1
-                    idx = i if i < limit else i - limit
-                    x = col_1_x if col == 0 else col_2_x
-                    y = start_y + idx * 40
-
-                    rect = pygame.Rect(x - 150, y, 300, 30)
-                    if rect.collidepoint(mx, my):
-                        self.binding_action = action
-                        return
-
-                center_x = C.SCREEN_WIDTH // 2 - 50
-                top_y = C.SCREEN_HEIGHT - 80
-                back_rect = pygame.Rect(center_x, top_y, 100, 40)
-                if back_rect.collidepoint(mx, my):
-                    self.state = GameState.PLAYING if self.paused else GameState.MENU
+        """Delegate key-config events to the screen-flow subsystem."""
+        screen_flow.handle_key_config_events(self)
 
     def _update_intro_logic(self, elapsed: int) -> None:
-        """Update intro sequence logic and transitions."""
-        duration = 0
-        if self.intro_phase == 0:
-            duration = 3000
-        elif self.intro_phase == 1:
-            duration = 3000
-        elif self.intro_phase == 2:
-            slides_durations = [8000, 10000, 4000, 4000]
-            if self.intro_step < len(slides_durations):
-                duration = slides_durations[self.intro_step]
-
-                if self.intro_step == 0 and elapsed < 50:
-                    if not getattr(self, "laugh_played", False):
-                        self.sound_manager.play_sound("laugh")
-                        self.laugh_played = True
-
-                if elapsed > duration:
-                    self.intro_step += 1
-                    self.intro_start_time = 0
-                    if hasattr(self, "laugh_played"):
-                        del self.laugh_played
-            else:
-                self.state = GameState.MENU
-                return
-
-        if self.intro_phase < 2:
-            if self.intro_phase == 1 and elapsed < 50:
-                if not getattr(self, "water_played", False):
-                    self.sound_manager.play_sound("water")
-                    self.water_played = True
-
-            if elapsed > duration:
-                self.intro_phase += 1
-                self.intro_start_time = 0
-                if self.intro_phase == 2:
-                    self.ui_renderer.release_intro_video()
+        """Delegate intro timing to the screen-flow subsystem."""
+        screen_flow.update_intro_logic(self, elapsed)
 
     def run(self) -> None:
         """Main game loop"""

--- a/src/games/Force_Field/src/game_session.py
+++ b/src/games/Force_Field/src/game_session.py
@@ -1,0 +1,150 @@
+"""Session lifecycle helpers for Force Field."""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+import pygame
+
+from games.shared.raycaster import Raycaster
+
+from .map import Map
+from .player import Player
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+STARTER_WEAPONS = (
+    "rifle",
+    "shotgun",
+    "minigun",
+    "plasma",
+    "laser",
+    "rocket",
+    "flamethrower",
+    "pulse",
+    "freezer",
+)
+LEVEL_MUSIC_TRACKS = (
+    "music_loop",
+    "music_drums",
+    "music_wind",
+    "music_horror",
+    "music_piano",
+    "music_action",
+)
+
+
+def start_game(game: Game) -> None:
+    """Reset top-level run state and begin the selected starting level."""
+    game.level = game.selected_start_level
+    game.lives = game.selected_lives
+    game.kills = 0
+    game.level_times = []
+    game.paused = False
+    game.particle_system.particles = []
+    game.damage_texts = []
+    game.entity_manager.reset()
+    game.unlocked_weapons = {"pistol", random.choice(STARTER_WEAPONS)}
+    game.god_mode = False
+    game.cheat_mode_active = False
+    _reset_atmosphere(game)
+    game.game_map = Map(game.selected_map_size)
+    game.raycaster = Raycaster(game.game_map, game.raycaster_config)
+    game.raycaster.set_render_scale(game.render_scale)
+    game.last_death_pos = None
+    pygame.mouse.set_visible(False)
+    pygame.event.set_grab(True)
+    start_level(game)
+
+
+def start_level(game: Game) -> None:
+    """Start the current level while preserving the existing loadout."""
+    if game.game_map is None:
+        raise ValueError("DbC Blocked: Precondition failed.")
+    _reset_level_state(game)
+    player_pos = game._get_best_spawn_point()
+    previous_ammo, previous_weapon = _previous_loadout(game)
+    game.player = Player(player_pos[0], player_pos[1], player_pos[2])
+    player = _require_player(game)
+    _restore_player_loadout(game, previous_ammo, previous_weapon)
+    _equip_starter_weapon(game)
+    player.god_mode = game.god_mode
+    game.entity_manager.reset()
+    game.spawn_manager.spawn_all(
+        player_pos,
+        game.game_map,
+        game.level,
+        game.selected_difficulty,
+    )
+    if hasattr(game, "sound_manager"):
+        game.sound_manager.start_music(random.choice(LEVEL_MUSIC_TRACKS))
+
+
+def _reset_atmosphere(game: Game) -> None:
+    """Reset combo and atmosphere timers for a new run."""
+    game.kill_combo_count = 0
+    game.kill_combo_timer = 0
+    game.heartbeat_timer = 0
+    game.breath_timer = 0
+    game.groan_timer = 0
+    game.beast_timer = 0
+
+
+def _reset_level_state(game: Game) -> None:
+    """Reset per-level transient state before spawning entities."""
+    game.level_start_time = pygame.time.get_ticks()
+    game.total_paused_time = 0
+    game.pause_start_time = 0
+    game.particle_system.particles = []
+    game.damage_texts = []
+    game.damage_flash_timer = 0
+    game.screen_shake = 0.0
+    game.visited_cells = set()
+    game.portal = None
+    pygame.mouse.set_visible(False)
+    pygame.event.set_grab(True)
+
+
+def _previous_loadout(game: Game) -> tuple[dict[str, int] | None, str]:
+    """Capture ammo and weapon selection from the current player, if any."""
+    if game.player is None:
+        return None, "pistol"
+    return game.player.ammo, game.player.current_weapon
+
+
+def _restore_player_loadout(
+    game: Game,
+    previous_ammo: dict[str, int] | None,
+    previous_weapon: str,
+) -> None:
+    """Restore the previous ammo state and valid weapon selection."""
+    player = _require_player(game)
+    if previous_ammo is not None:
+        player.ammo = previous_ammo
+        if previous_weapon in game.unlocked_weapons:
+            player.current_weapon = previous_weapon
+        else:
+            player.current_weapon = "pistol"
+    if player.current_weapon not in game.unlocked_weapons:
+        player.current_weapon = "pistol"
+
+
+def _equip_starter_weapon(game: Game) -> None:
+    """Equip the random starter weapon on the first level of a new run."""
+    if game.level != 1:
+        return
+    player = _require_player(game)
+    for weapon_name in game.unlocked_weapons:
+        if weapon_name != "pistol":
+            player.current_weapon = weapon_name
+            return
+
+
+def _require_player(game: Game) -> Player:
+    """Return the current player or raise when level state is incomplete."""
+    if game.player is None:
+        raise ValueError("DbC Blocked: Precondition failed.")
+    return game.player

--- a/src/games/Force_Field/src/gameplay_runtime.py
+++ b/src/games/Force_Field/src/gameplay_runtime.py
@@ -1,0 +1,500 @@
+"""Per-frame gameplay runtime for Force Field."""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING, Protocol
+
+import pygame
+
+from games.shared.constants import (
+    BEAST_TIMER_MAX,
+    BEAST_TIMER_MIN,
+    FOG_REVEAL_RADIUS,
+    GROAN_TIMER_DELAY,
+    PICKUP_RADIUS_SQ,
+    PORTAL_RADIUS_SQ,
+    GameState,
+)
+
+from . import constants as C  # noqa: N812
+
+if TYPE_CHECKING:
+    from .bot import Bot
+    from .game import Game
+    from .map import Map
+    from .player import Player
+
+
+KILL_COMBO_PHRASES = (
+    "DAMN, I'M GOOD!",
+    "COME GET SOME!",
+    "HAIL TO THE KING!",
+    "GROOVY!",
+    "PIECE OF CAKE!",
+    "WHO WANTS SOME?",
+    "EAT THIS!",
+    "SHAKE IT BABY!",
+    "NOBODY STEALS OUR CHICKS!",
+    "IT'S TIME TO KICK ASS!",
+    "DAMN, THOSE ALIEN BASTARDS!",
+    "YOUR FACE, YOUR ASS!",
+    "WHAT'S THE DIFFERENCE?",
+    "HOLY COW!",
+    "TERMINATED!",
+    "WASTED!",
+    "OWNED!",
+    "DOMINATING!",
+    "UNSTOPPABLE!",
+    "RAMPAGE!",
+    "GODLIKE!",
+    "BOOM BABY!",
+)
+ITEM_PREFIXES = ("health", "ammo", "bomb", "pickup")
+PLAYER_HEALTH_PACK_VALUE = 50
+AMMO_BOX_AMOUNT = 20
+BOMB_ITEM_AMOUNT = 1
+SCREEN_SHAKE_DAMPING = 0.9
+SCREEN_SHAKE_MINIMUM = 0.5
+FOG_RADIUS_SQ = 16
+FOG_RADIUS_RANGE = range(-4, 5)
+
+
+class KeyState(Protocol):
+    """Minimal protocol for pygame's pressed-key state container."""
+
+    def __getitem__(self, key: int, /) -> bool: ...
+
+
+class JoystickLike(Protocol):
+    """Minimal protocol for the joystick methods used by the runtime."""
+
+    def get_axis(self, axis: int) -> float: ...
+
+    def get_numaxes(self) -> int: ...
+
+    def get_numbuttons(self) -> int: ...
+
+    def get_button(self, button: int) -> bool: ...
+
+    def get_numhats(self) -> int: ...
+
+    def get_hat(self, hat: int) -> tuple[float, float]: ...
+
+
+def check_game_over(game: Game) -> bool:
+    """Handle death, respawn, and game-over transitions."""
+    player = _require_player(game)
+    if player.alive:
+        return False
+    if game.lives > 1:
+        game.lives -= 1
+        game.respawn_player()
+        return True
+    level_time = (
+        pygame.time.get_ticks() - game.level_start_time - game.total_paused_time
+    ) / 1000.0
+    game.level_times.append(level_time)
+    game.lives = 0
+    game.state = GameState.GAME_OVER
+    game.game_over_timer = 0
+    game.sound_manager.play_sound("game_over1")
+    pygame.mouse.set_visible(True)
+    pygame.event.set_grab(False)
+    return True
+
+
+def update_screen_shake(game: Game) -> None:
+    """Decay the transient screen shake over time."""
+    if game.screen_shake <= 0:
+        return
+    game.screen_shake *= SCREEN_SHAKE_DAMPING
+    if game.screen_shake < SCREEN_SHAKE_MINIMUM:
+        game.screen_shake = 0.0
+
+
+def check_portal_completion(game: Game) -> bool:
+    """Spawn the exit portal and detect when the player reaches it."""
+    player = _require_player(game)
+    if not game.entity_manager.get_active_enemies() and game.portal is None:
+        game.spawn_portal()
+        game.damage_texts.append(
+            {
+                "x": C.SCREEN_WIDTH // 2,
+                "y": C.SCREEN_HEIGHT // 2,
+                "text": "PORTAL OPENED!",
+                "color": C.CYAN,
+                "timer": 180,
+                "vy": 0,
+            }
+        )
+    if game.portal is None:
+        return False
+    dx = game.portal["x"] - player.x
+    dy = game.portal["y"] - player.y
+    if dx * dx + dy * dy >= PORTAL_RADIUS_SQ:
+        return False
+    level_time = (
+        pygame.time.get_ticks() - game.level_start_time - game.total_paused_time
+    ) / 1000.0
+    game.level_times.append(level_time)
+    game.state = GameState.LEVEL_COMPLETE
+    pygame.mouse.set_visible(True)
+    pygame.event.set_grab(False)
+    return True
+
+
+def handle_combat_input(game: Game) -> None:
+    """Drive automatic-fire combat while the shoot input is held."""
+    player = _require_player(game)
+    is_firing = (
+        game.input_manager.is_action_pressed("shoot") or pygame.mouse.get_pressed()[0]
+    )
+    if not is_firing:
+        return
+    weapon_data = C.WEAPONS.get(player.current_weapon, {})
+    if weapon_data.get("automatic", False) and player.shoot():
+        game.combat_system.fire_weapon()
+
+
+def handle_joystick_input(game: Game, shield_active: bool) -> bool:
+    """Apply joystick movement, look, firing, and weapon switching."""
+    joystick = _require_joystick(game)
+    player = _require_player(game)
+    _move_from_joystick(game, player, joystick)
+    _look_from_joystick(player, joystick)
+    if joystick.get_numbuttons() > 0 and joystick.get_button(0):
+        shield_active = True
+    if joystick.get_numbuttons() > 2 and joystick.get_button(2):
+        player.reload()
+    if joystick.get_numbuttons() > 5 and joystick.get_button(5):
+        if player.shoot():
+            game.combat_system.fire_weapon()
+    if joystick.get_numbuttons() > 4 and joystick.get_button(4):
+        if player.fire_secondary():
+            game.combat_system.fire_weapon(is_secondary=True)
+    if joystick.get_numhats() > 0:
+        _handle_hat_switching(game, joystick)
+    return shield_active
+
+
+def update_damage_texts(game: Game) -> None:
+    """Advance floating combat text and discard expired entries."""
+    for text in game.damage_texts:
+        text["y"] += text["vy"]
+        text["timer"] -= 1
+    game.damage_texts = [text for text in game.damage_texts if text["timer"] > 0]
+
+
+def handle_keyboard_movement(game: Game, keys: KeyState) -> None:
+    """Apply keyboard movement and look input for the current frame."""
+    player = _require_player(game)
+    current_speed = _resolve_player_speed(game, player, keys)
+    moving = False
+    moving |= _move_if_pressed(game, "move_forward", True, current_speed)
+    moving |= _move_if_pressed(game, "move_backward", False, current_speed)
+    moving |= _strafe_if_pressed(game, "strafe_left", False, current_speed)
+    moving |= _strafe_if_pressed(game, "strafe_right", True, current_speed)
+    player.is_moving = moving
+    if game.input_manager.is_action_pressed("turn_left"):
+        player.rotate(-0.05)
+    if game.input_manager.is_action_pressed("turn_right"):
+        player.rotate(0.05)
+    if game.input_manager.is_action_pressed("look_up"):
+        player.pitch_view(5)
+    if game.input_manager.is_action_pressed("look_down"):
+        player.pitch_view(-5)
+
+
+def update_fog_of_war(game: Game) -> None:
+    """Reveal nearby visited cells around the player."""
+    player = _require_player(game)
+    player_x, player_y = int(player.x), int(player.y)
+    for dy in FOG_RADIUS_RANGE:
+        for dx in FOG_RADIUS_RANGE:
+            if dx * dx + dy * dy > FOG_RADIUS_SQ:
+                continue
+            cell_x, cell_y = player_x + dx, player_y + dy
+            if _in_map_bounds(game, cell_x, cell_y):
+                game.visited_cells.add((cell_x, cell_y))
+
+
+def check_item_pickups(game: Game) -> None:
+    """Resolve pickup collisions and apply their inventory effects."""
+    player = _require_player(game)
+    for bot in game.bots:
+        if not bot.alive or not bot.enemy_type.startswith(ITEM_PREFIXES):
+            continue
+        dx = bot.x - player.x
+        dy = bot.y - player.y
+        if dx * dx + dy * dy >= PICKUP_RADIUS_SQ:
+            continue
+        pickup_message, color = _apply_pickup_effect(game, bot)
+        if not pickup_message:
+            continue
+        bot.alive = False
+        bot.removed = True
+        game.damage_texts.append(
+            {
+                "x": C.SCREEN_WIDTH // 2,
+                "y": C.SCREEN_HEIGHT // 2 - 50,
+                "text": pickup_message,
+                "color": color,
+                "timer": 60,
+                "vy": -1,
+            }
+        )
+
+
+def update_large_fog_reveal(game: Game) -> None:
+    """Reveal the larger minimap halo around the player."""
+    player = _require_player(game)
+    center_x, center_y = int(player.x), int(player.y)
+    radius = FOG_REVEAL_RADIUS
+    for row_offset in range(-radius, radius + 1):
+        for col_offset in range(-radius, radius + 1):
+            if row_offset * row_offset + col_offset * col_offset <= radius * radius:
+                game.visited_cells.add((center_x + col_offset, center_y + row_offset))
+
+
+def update_atmosphere(game: Game) -> None:
+    """Drive ambient audio cues based on enemy proximity and player health."""
+    player = _require_player(game)
+    min_distance = game.entity_manager.get_nearest_enemy_distance(
+        player.x,
+        player.y,
+    )
+    if min_distance < 15:
+        game.beast_timer -= 1
+        if game.beast_timer <= 0:
+            game.sound_manager.play_sound("beast")
+            game.beast_timer = random.randint(BEAST_TIMER_MIN, BEAST_TIMER_MAX)
+    if min_distance < 20:
+        beat_delay = int(min(1.5, max(0.4, min_distance / 10.0)) * C.FPS)
+        game.heartbeat_timer -= 1
+        if game.heartbeat_timer <= 0:
+            game.sound_manager.play_sound("heartbeat")
+            game.sound_manager.play_sound("breath")
+            game.heartbeat_timer = beat_delay
+    if player.health < 50:
+        game.groan_timer -= 1
+        if game.groan_timer <= 0:
+            game.sound_manager.play_sound("groan")
+            game.groan_timer = GROAN_TIMER_DELAY
+
+
+def check_kill_combo(game: Game) -> None:
+    """Expire kill combos and surface their celebratory HUD message."""
+    if game.kill_combo_timer <= 0:
+        return
+    game.kill_combo_timer -= 1
+    if game.kill_combo_timer > 0:
+        return
+    if game.kill_combo_count >= 3:
+        game.sound_manager.play_sound("phrase_cool")
+        game.damage_texts.append(
+            {
+                "x": C.SCREEN_WIDTH // 2,
+                "y": C.SCREEN_HEIGHT // 2 - 150,
+                "text": random.choice(KILL_COMBO_PHRASES),
+                "color": C.YELLOW,
+                "timer": 180,
+                "vy": -0.2,
+                "size": "large",
+                "effect": "glow",
+            }
+        )
+    game.kill_combo_count = 0
+
+
+def update_game(game: Game) -> None:
+    """Run one gameplay tick when the game is in the active state."""
+    if game.paused:
+        return
+    player = _require_player(game)
+    game_map = _require_map(game)
+    if check_game_over(game):
+        return
+    update_screen_shake(game)
+    if check_portal_completion(game):
+        return
+    keys = pygame.key.get_pressed()
+    shield_active = game.input_manager.is_action_pressed("shield")
+    if player.alive:
+        handle_combat_input(game)
+    if game.joystick and player.alive:
+        shield_active = handle_joystick_input(game, shield_active)
+    player.set_shield(shield_active)
+    game.particle_system.update()
+    update_damage_texts(game)
+    handle_keyboard_movement(game, keys)
+    player.update()
+    update_fog_of_war(game)
+    game.entity_manager.update_bots(game_map, player, game)
+    check_item_pickups(game)
+    game.entity_manager.update_projectiles(game_map, player, game)
+    update_large_fog_reveal(game)
+    update_atmosphere(game)
+    check_kill_combo(game)
+
+
+def _move_from_joystick(
+    game: Game,
+    player: Player,
+    joystick: JoystickLike,
+) -> None:
+    """Translate left-stick input into movement and strafing."""
+    game_map = _require_map(game)
+    axis_x = joystick.get_axis(0)
+    axis_y = joystick.get_axis(1)
+    if abs(axis_x) > C.JOYSTICK_DEADZONE:
+        player.strafe(
+            game_map,
+            game.bots,
+            right=(axis_x > 0),
+            speed=abs(axis_x) * C.PLAYER_SPEED * game.movement_speed_multiplier,
+        )
+        player.is_moving = True
+    if abs(axis_y) > C.JOYSTICK_DEADZONE:
+        player.move(
+            game_map,
+            game.bots,
+            forward=(axis_y < 0),
+            speed=abs(axis_y) * C.PLAYER_SPEED * game.movement_speed_multiplier,
+        )
+        player.is_moving = True
+
+
+def _look_from_joystick(player: Player, joystick: JoystickLike) -> None:
+    """Apply right-stick look input when the controller exposes it."""
+    look_x = 0.0
+    look_y = 0.0
+    if joystick.get_numaxes() >= 4:
+        look_x = joystick.get_axis(2)
+        look_y = joystick.get_axis(3)
+    if abs(look_x) > C.JOYSTICK_DEADZONE:
+        player.rotate(look_x * C.PLAYER_ROT_SPEED * 15 * C.SENSITIVITY_X)
+    if abs(look_y) > C.JOYSTICK_DEADZONE:
+        player.pitch_view(-look_y * 10 * C.SENSITIVITY_Y)
+
+
+def _handle_hat_switching(game: Game, joystick: JoystickLike) -> None:
+    """Map D-pad hat input to the quick weapon shortcuts."""
+    hat = joystick.get_hat(0)
+    if hat[0] == -1:
+        game.switch_weapon_with_message("pistol")
+    if hat[0] == 1:
+        game.switch_weapon_with_message("rifle")
+    if hat[1] == 1:
+        game.switch_weapon_with_message("shotgun")
+    if hat[1] == -1:
+        game.switch_weapon_with_message("plasma")
+
+
+def _resolve_player_speed(game: Game, player: Player, keys: KeyState) -> float:
+    """Return the player's current movement speed based on sprint state."""
+    sprint_key = keys[pygame.K_RSHIFT]
+    is_sprinting = game.input_manager.is_action_pressed("sprint") or sprint_key
+    if is_sprinting and player.stamina > 0:
+        player.stamina -= 1
+        player.stamina_recharge_delay = 60
+        return C.PLAYER_SPRINT_SPEED * game.movement_speed_multiplier
+    return C.PLAYER_SPEED * game.movement_speed_multiplier
+
+
+def _move_if_pressed(
+    game: Game,
+    action: str,
+    forward: bool,
+    speed: float,
+) -> bool:
+    """Move the player forward/backward when the bound action is active."""
+    if not game.input_manager.is_action_pressed(action):
+        return False
+    player = _require_player(game)
+    game_map = _require_map(game)
+    player.move(game_map, game.bots, forward=forward, speed=speed)
+    return True
+
+
+def _strafe_if_pressed(
+    game: Game,
+    action: str,
+    right: bool,
+    speed: float,
+) -> bool:
+    """Strafe the player when the bound action is active."""
+    if not game.input_manager.is_action_pressed(action):
+        return False
+    player = _require_player(game)
+    game_map = _require_map(game)
+    player.strafe(game_map, game.bots, right=right, speed=speed)
+    return True
+
+
+def _in_map_bounds(game: Game, cell_x: int, cell_y: int) -> bool:
+    """Return whether a grid coordinate falls inside the current map."""
+    return bool(
+        game.game_map
+        and 0 <= cell_x < game.game_map.width
+        and 0 <= cell_y < game.game_map.height
+    )
+
+
+def _apply_pickup_effect(game: Game, bot: Bot) -> tuple[str, tuple[int, int, int]]:
+    """Apply a pickup to the player and return its HUD message."""
+    player = _require_player(game)
+    if bot.enemy_type == "health_pack":
+        if player.health >= C.PLAYER_HEALTH:
+            return "", C.GREEN
+        player.health = min(
+            C.PLAYER_HEALTH,
+            player.health + PLAYER_HEALTH_PACK_VALUE,
+        )
+        return "HEALTH +50", C.GREEN
+    if bot.enemy_type == "ammo_box":
+        for weapon_name in player.ammo:
+            player.ammo[weapon_name] += AMMO_BOX_AMOUNT
+        return "AMMO FOUND", C.YELLOW
+    if bot.enemy_type == "bomb_item":
+        player.bombs += BOMB_ITEM_AMOUNT
+        return "BOMB +1", C.ORANGE
+    return _apply_weapon_pickup(game, bot.enemy_type.replace("pickup_", ""))
+
+
+def _apply_weapon_pickup(
+    game: Game,
+    weapon_name: str,
+) -> tuple[str, tuple[int, int, int]]:
+    """Unlock a weapon or top up its ammo if already unlocked."""
+    player = _require_player(game)
+    if weapon_name not in game.unlocked_weapons:
+        game.unlocked_weapons.add(weapon_name)
+        player.switch_weapon(weapon_name)
+        return f"{weapon_name.upper()} ACQUIRED!", C.CYAN
+    if weapon_name not in player.ammo:
+        return "", C.YELLOW
+    clip_size = int(C.WEAPONS[weapon_name]["clip_size"])
+    player.ammo[weapon_name] += clip_size * 2
+    return f"{weapon_name.upper()} AMMO", C.YELLOW
+
+
+def _require_player(game: Game) -> Player:
+    """Return the current player or raise when gameplay state is incomplete."""
+    if game.player is None:
+        raise ValueError("DbC Blocked: Precondition failed.")
+    return game.player
+
+
+def _require_map(game: Game) -> Map:
+    """Return the current map or raise when gameplay state is incomplete."""
+    if game.game_map is None:
+        raise ValueError("DbC Blocked: Precondition failed.")
+    return game.game_map
+
+
+def _require_joystick(game: Game) -> JoystickLike:
+    """Return the active joystick or raise when controller input is unavailable."""
+    if game.joystick is None:
+        raise ValueError("DbC Blocked: Precondition failed.")
+    return game.joystick

--- a/src/games/Force_Field/src/screen_flow.py
+++ b/src/games/Force_Field/src/screen_flow.py
@@ -1,0 +1,261 @@
+"""State- and screen-level flow handlers for Force Field."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pygame
+
+from games.shared.constants import GameState
+
+from . import constants as C  # noqa: N812
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+MAP_SELECT_TOP = 200
+MAP_SELECT_ROW_HEIGHT = 80
+MAP_SELECT_ROWS = 4
+KEY_CONFIG_START_Y = 120
+KEY_CONFIG_ROW_HEIGHT = 40
+KEY_CONFIG_COLUMN_LIMIT = 12
+KEY_CONFIG_BIND_WIDTH = 300
+KEY_CONFIG_BIND_HEIGHT = 30
+BACK_BUTTON_WIDTH = 100
+BACK_BUTTON_HEIGHT = 40
+BACK_BUTTON_BOTTOM_OFFSET = 80
+INTRO_PHASE_DURATION_MS = 3000
+INTRO_SLIDE_DURATIONS_MS = (8000, 10000, 4000, 4000)
+
+
+def handle_intro_events(game: Game) -> None:
+    """Handle intro-state input and exit conditions."""
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            game.ui_renderer.release_intro_video()
+            game.running = False
+        elif event.type == pygame.KEYDOWN and event.key in (
+            pygame.K_SPACE,
+            pygame.K_ESCAPE,
+        ):
+            game.ui_renderer.release_intro_video()
+            game.state = GameState.MENU
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            game.ui_renderer.release_intro_video()
+            game.state = GameState.MENU
+
+
+def handle_menu_events(game: Game) -> None:
+    """Handle input on the main menu screen."""
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            game.running = False
+        elif event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                game.state = GameState.MAP_SELECT
+            elif event.key == pygame.K_ESCAPE:
+                game.running = False
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            game.state = GameState.MAP_SELECT
+
+
+def handle_map_select_events(game: Game) -> None:
+    """Handle selection changes and launch actions on the setup screen."""
+    game.ui_renderer.update_start_button(pygame.mouse.get_pos())
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            game.running = False
+        elif event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_ESCAPE:
+                game.state = GameState.MENU
+            elif event.key == pygame.K_RETURN:
+                _start_selected_game(game)
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            if game.ui_renderer.is_start_button_clicked(event.pos):
+                _start_selected_game(game)
+            _cycle_map_select_option(game, event.pos[1])
+
+
+def handle_level_complete_events(game: Game) -> None:
+    """Handle input on the level-complete screen."""
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            game.running = False
+        elif event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_SPACE:
+                game.level += 1
+                game.start_level()
+                game.state = GameState.PLAYING
+            elif event.key == pygame.K_ESCAPE:
+                game.state = GameState.MENU
+
+
+def handle_game_over_events(game: Game) -> None:
+    """Handle restart and exit actions after the player dies."""
+    game.game_over_timer += 1
+    if game.game_over_timer == 120:
+        game.sound_manager.play_sound("game_over2")
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            game.running = False
+        elif event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_SPACE:
+                game.start_game()
+                game.state = GameState.PLAYING
+            elif event.key == pygame.K_ESCAPE:
+                game.state = GameState.MENU
+
+
+def handle_key_config_events(game: Game) -> None:
+    """Handle key-binding selection and reassignment input."""
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            game.running = False
+        elif event.type == pygame.KEYDOWN:
+            if game.binding_action:
+                if event.key != pygame.K_ESCAPE:
+                    game.input_manager.bind_key(game.binding_action, event.key)
+                game.binding_action = None
+            elif event.key == pygame.K_ESCAPE:
+                game.state = GameState.PLAYING if game.paused else GameState.MENU
+        elif event.type == pygame.MOUSEBUTTONDOWN and not game.binding_action:
+            if _select_key_binding(game, event.pos):
+                return
+            if _clicks_back_button(event.pos):
+                game.state = GameState.PLAYING if game.paused else GameState.MENU
+
+
+def update_intro_logic(game: Game, elapsed: int) -> None:
+    """Advance the intro sequence and perform its timed transitions."""
+    if game.intro_phase == 2:
+        _update_intro_slides(game, elapsed)
+        return
+    if (
+        game.intro_phase == 1
+        and elapsed < 50
+        and not getattr(game, "water_played", False)
+    ):
+        game.sound_manager.play_sound("water")
+        game.water_played = True
+    if elapsed <= INTRO_PHASE_DURATION_MS:
+        return
+    game.intro_phase += 1
+    game.intro_start_time = 0
+    if game.intro_phase == 2:
+        game.ui_renderer.release_intro_video()
+
+
+def _start_selected_game(game: Game) -> None:
+    """Enter gameplay from the map-selection screen."""
+    game.start_game()
+    game.state = GameState.PLAYING
+    pygame.mouse.set_visible(False)
+    pygame.event.set_grab(True)
+
+
+def _cycle_map_select_option(game: Game, mouse_y: int) -> None:
+    """Cycle the selected map option based on the clicked row."""
+    row = _map_select_row(mouse_y)
+    if row is None:
+        return
+    if row == 0:
+        _cycle_map_size(game)
+    elif row == 1:
+        _cycle_difficulty(game)
+    elif row == 2:
+        game.selected_start_level = (game.selected_start_level % 5) + 1
+    elif row == 3:
+        game.selected_lives = (game.selected_lives % 5) + 1
+
+
+def _map_select_row(mouse_y: int) -> int | None:
+    """Return the clicked option row, or ``None`` when outside the menu."""
+    if not (
+        MAP_SELECT_TOP
+        <= mouse_y
+        < MAP_SELECT_TOP + MAP_SELECT_ROWS * MAP_SELECT_ROW_HEIGHT
+    ):
+        return None
+    return (mouse_y - MAP_SELECT_TOP) // MAP_SELECT_ROW_HEIGHT
+
+
+def _cycle_map_size(game: Game) -> None:
+    """Advance the selected map size through the supported options."""
+    try:
+        current_index = C.MAP_SIZES.index(game.selected_map_size)
+        game.selected_map_size = C.MAP_SIZES[(current_index + 1) % len(C.MAP_SIZES)]
+    except ValueError:
+        game.selected_map_size = 40
+
+
+def _cycle_difficulty(game: Game) -> None:
+    """Advance the selected difficulty through the configured options."""
+    difficulties = list(C.DIFFICULTIES.keys())
+    try:
+        current_index = difficulties.index(game.selected_difficulty)
+        game.selected_difficulty = difficulties[(current_index + 1) % len(difficulties)]
+    except ValueError:
+        game.selected_difficulty = "NORMAL"
+
+
+def _select_key_binding(game: Game, mouse_pos: tuple[int, int]) -> bool:
+    """Select a key binding slot when the user clicks its row."""
+    for action, rect in _binding_rects(game.input_manager.bindings).items():
+        if rect.collidepoint(mouse_pos):
+            game.binding_action = action
+            return True
+    return False
+
+
+def _binding_rects(bindings: dict[str, int]) -> dict[str, pygame.Rect]:
+    """Build the click targets for each key-binding row."""
+    column_x = (C.SCREEN_WIDTH // 4, C.SCREEN_WIDTH * 3 // 4)
+    rects: dict[str, pygame.Rect] = {}
+    for index, action in enumerate(sorted(bindings.keys())):
+        column = 0 if index < KEY_CONFIG_COLUMN_LIMIT else 1
+        row = (
+            index
+            if index < KEY_CONFIG_COLUMN_LIMIT
+            else index - KEY_CONFIG_COLUMN_LIMIT
+        )
+        rects[action] = pygame.Rect(
+            column_x[column] - 150,
+            KEY_CONFIG_START_Y + row * KEY_CONFIG_ROW_HEIGHT,
+            KEY_CONFIG_BIND_WIDTH,
+            KEY_CONFIG_BIND_HEIGHT,
+        )
+    return rects
+
+
+def _clicks_back_button(mouse_pos: tuple[int, int]) -> bool:
+    """Return whether the back button was clicked."""
+    center_x = C.SCREEN_WIDTH // 2 - 50
+    top_y = C.SCREEN_HEIGHT - BACK_BUTTON_BOTTOM_OFFSET
+    return pygame.Rect(
+        center_x,
+        top_y,
+        BACK_BUTTON_WIDTH,
+        BACK_BUTTON_HEIGHT,
+    ).collidepoint(mouse_pos)
+
+
+def _update_intro_slides(game: Game, elapsed: int) -> None:
+    """Advance the phase-2 intro slideshow and its one-shot audio cues."""
+    if game.intro_step >= len(INTRO_SLIDE_DURATIONS_MS):
+        game.state = GameState.MENU
+        return
+    duration = INTRO_SLIDE_DURATIONS_MS[game.intro_step]
+    if (
+        game.intro_step == 0
+        and elapsed < 50
+        and not getattr(game, "laugh_played", False)
+    ):
+        game.sound_manager.play_sound("laugh")
+        game.laugh_played = True
+    if elapsed <= duration:
+        return
+    game.intro_step += 1
+    game.intro_start_time = 0
+    if hasattr(game, "laugh_played"):
+        del game.laugh_played

--- a/src/games/Force_Field/src/ui_renderer.py
+++ b/src/games/Force_Field/src/ui_renderer.py
@@ -34,6 +34,8 @@ class UIRenderer(UIRendererBase):
     def __init__(self, screen: pygame.Surface) -> None:
         """Initialize the UI renderer"""
         super().__init__(screen, C.SCREEN_WIDTH, C.SCREEN_HEIGHT)
+        self.intro_video: Any | None = None
+        self.title_drips: list[dict[str, Any]] = []
 
         # Buttons
         self.start_button = Button(
@@ -263,6 +265,7 @@ class UIRenderer(UIRendererBase):
 
     def _render_health_bar(self, game: Game) -> None:
         """Render the player health bar at the bottom of the HUD."""
+        player = _require_player(game)
         bar_height = 12
         bar_width = 150
         start_x = 20
@@ -274,13 +277,14 @@ class UIRenderer(UIRendererBase):
             health_y,
             bar_width,
             bar_height,
-            game.player.health / game.player.max_health,
-            C.RED if game.player.health <= 50 else C.GREEN,
+            player.health / player.max_health,
+            C.RED if player.health <= 50 else C.GREEN,
             "HP",
         )
 
     def _render_status_bars(self, game: Game) -> None:
         """Render shield bar, secondary charge bar, and stamina bar."""
+        player = _require_player(game)
         bar_height = 12
         bar_spacing = 8
         bar_width = 150
@@ -296,19 +300,19 @@ class UIRenderer(UIRendererBase):
             shield_y,
             bar_width,
             bar_height,
-            game.player.shield_timer / C.SHIELD_MAX_DURATION,
+            player.shield_timer / C.SHIELD_MAX_DURATION,
             C.CYAN,
             "SHLD",
         )
         # Shield Recharging/Cooldown Text
-        if game.player.shield_recharge_delay > 0:
-            status = "RECHRG" if game.player.shield_active else "COOL"
+        if player.shield_recharge_delay > 0:
+            status = "RECHRG" if player.shield_active else "COOL"
             txt = self.tiny_font.render(status, True, C.GRAY)
             self.screen.blit(txt, (start_x + bar_width + 5, shield_y - 2))
 
         # Secondary Charge
         charge_y = shield_y - (bar_height + bar_spacing)
-        charge_pct = 1.0 - (game.player.secondary_cooldown / C.SECONDARY_COOLDOWN)
+        charge_pct = 1.0 - (player.secondary_cooldown / C.SECONDARY_COOLDOWN)
         self._render_bar(
             start_x,
             charge_y,
@@ -326,7 +330,7 @@ class UIRenderer(UIRendererBase):
             stamina_y,
             bar_width,
             bar_height,
-            game.player.stamina / game.player.max_stamina,
+            player.stamina / player.max_stamina,
             C.YELLOW,
             "STM",
         )
@@ -880,3 +884,10 @@ class UIRenderer(UIRendererBase):
             pygame.draw.rect(self.screen, C.RED, back_rect, 2)
 
         pygame.display.flip()
+
+
+def _require_player(game: Game) -> Player:
+    """Return the current player or raise when HUD rendering is unavailable."""
+    if game.player is None:
+        raise ValueError("DbC Blocked: Precondition failed.")
+    return game.player

--- a/tests/Force_Field/test_screen_flow.py
+++ b/tests/Force_Field/test_screen_flow.py
@@ -1,0 +1,89 @@
+"""Focused tests for the extracted Force Field screen-flow subsystem."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pygame
+
+from games.shared.constants import GameState
+
+
+def _screen_flow_game(**overrides: object) -> SimpleNamespace:
+    """Build a lightweight game stub for screen-flow tests."""
+    base = {
+        "ui_renderer": MagicMock(),
+        "running": True,
+        "state": GameState.MAP_SELECT,
+        "selected_map_size": 40,
+        "selected_difficulty": "NORMAL",
+        "selected_start_level": 1,
+        "selected_lives": 3,
+        "start_game": MagicMock(),
+        "start_level": MagicMock(),
+        "sound_manager": MagicMock(),
+        "game_over_timer": 0,
+        "binding_action": None,
+        "paused": False,
+        "input_manager": SimpleNamespace(
+            bindings={"move_forward": pygame.K_w, "move_backward": pygame.K_s},
+            bind_key=MagicMock(),
+        ),
+        "intro_phase": 1,
+        "intro_step": 0,
+        "intro_start_time": 100,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_handle_map_select_events_start_click_starts_game(monkeypatch) -> None:
+    """Start-button clicks should kick off gameplay and grab the mouse."""
+    from games.Force_Field.src.screen_flow import handle_map_select_events
+
+    game = _screen_flow_game()
+    game.ui_renderer.is_start_button_clicked.return_value = True
+    event = SimpleNamespace(type=pygame.MOUSEBUTTONDOWN, pos=(400, 210))
+
+    set_visible = MagicMock()
+    set_grab = MagicMock()
+
+    monkeypatch.setattr(pygame.mouse, "get_pos", lambda: (400, 300))
+    monkeypatch.setattr(pygame.mouse, "set_visible", set_visible)
+    monkeypatch.setattr(pygame.event, "get", lambda: [event])
+    monkeypatch.setattr(pygame.event, "set_grab", set_grab)
+
+    handle_map_select_events(game)
+
+    game.start_game.assert_called_once_with()
+    assert game.state == GameState.PLAYING
+    set_visible.assert_called_once_with(False)
+    set_grab.assert_called_once_with(True)
+
+
+def test_handle_key_config_events_click_binds_action(monkeypatch) -> None:
+    """Clicking a binding row should select that action for rebinding."""
+    from games.Force_Field.src.screen_flow import handle_key_config_events
+
+    game = _screen_flow_game(state=GameState.KEY_CONFIG)
+    event = SimpleNamespace(type=pygame.MOUSEBUTTONDOWN, pos=(210, 125))
+
+    monkeypatch.setattr(pygame.event, "get", lambda: [event])
+
+    handle_key_config_events(game)
+
+    assert game.binding_action == "move_backward"
+
+
+def test_update_intro_logic_releases_video_on_phase_transition() -> None:
+    """Crossing from phase 1 to phase 2 should release the intro video."""
+    from games.Force_Field.src.screen_flow import update_intro_logic
+
+    game = _screen_flow_game(state=GameState.INTRO, intro_phase=1, intro_start_time=500)
+
+    update_intro_logic(game, elapsed=3100)
+
+    assert game.intro_phase == 2
+    assert game.intro_start_time == 0
+    game.ui_renderer.release_intro_video.assert_called_once_with()


### PR DESCRIPTION
## Summary
- extract Force Field session lifecycle, combat actions, gameplay runtime, and screen-flow transitions out of the monolithic game orchestrator
- keep game.py as a thin coordinator and document the new Force Field architecture in SPEC.md
- add screen-flow regression coverage for intro transitions, map-select launch, and key-binding selection

## Root cause
src/games/Force_Field/src/game.py had grown into a god file that owned scene transitions, per-frame runtime behavior, session setup, and combat-side helpers directly. That centralization made the file hard to test and violated the repo's monolith constraints.

## Validation
- python -m ruff check src/games/Force_Field/src/game.py src/games/Force_Field/src/combat_actions.py src/games/Force_Field/src/game_session.py src/games/Force_Field/src/gameplay_runtime.py src/games/Force_Field/src/screen_flow.py src/games/Force_Field/src/ui_renderer.py tests/Force_Field/test_screen_flow.py
- python -m black --check src/games/Force_Field/src/game.py src/games/Force_Field/src/combat_actions.py src/games/Force_Field/src/game_session.py src/games/Force_Field/src/gameplay_runtime.py src/games/Force_Field/src/screen_flow.py src/games/Force_Field/src/ui_renderer.py tests/Force_Field/test_screen_flow.py
- python -m mypy src/games/Force_Field/src/game.py src/games/Force_Field/src/combat_actions.py src/games/Force_Field/src/game_session.py src/games/Force_Field/src/gameplay_runtime.py src/games/Force_Field/src/screen_flow.py src/games/Force_Field/src/ui_renderer.py
- python -m pytest tests/Force_Field -q

Closes #715