### PR TITLE
Refactor Duum screen event handling

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,8 +10,8 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.8                                                |
-| **Last Spec Update**    | 2026-04-07                                           |
+| **Spec Version**        | 1.1.9                                                |
+| **Last Spec Update**    | 2026-04-08                                           |
 
 ## 2. Purpose & Mission
 
@@ -113,6 +113,7 @@ Games/
 | Game Launcher         | `src/games/`                     | Central entry point, game discovery, selection UI, execution orchestration      |
 | Force Field Engine    | `src/games/Force_Field/engine/`  | Raycasting renderer, 3D-to-2D projection, collision detection                   |
 | Force Field Runtime   | `src/games/Force_Field/src/`     | Thin game facade plus extracted loop, session, combat, gameplay, and screen-flow subsystems |
+| Duum Screen Flow      | `src/games/Duum/src/`            | Thin Duum game facade with delegated per-screen event handling and play-state orchestration |
 | Duum Level Generation | `src/games/Duum/levels/`         | Procedural dungeon generation, room connectivity                                |
 | Tetris Logic          | `src/games/Tetris/`              | Piece mechanics, board state, gravity, line clearing                            |
 | Shared Renderers      | `src/games/shared/renderers/`    | Common rendering abstractions, 2D drawing, sprite management                    |

--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -15,7 +15,6 @@ from games.shared.constants import (
     GROAN_TIMER_DELAY,
     MINIGUN_BULLETS_PER_SHOT,
     MINIGUN_SPREAD,
-    PAUSE_HEARTBEAT_DELAY,
     PICKUP_RADIUS_SQ,
     PORTAL_RADIUS_SQ,
     GameState,
@@ -35,6 +34,7 @@ from .particle_system import ParticleSystem
 from .player import Player
 from .projectile import Projectile
 from .renderer import GameRenderer
+from .screen_event_handler import ScreenEventHandler
 from .sound import SoundManager
 from .spawn_manager import DuumSpawnManager
 from .ui_renderer import UIRenderer
@@ -143,6 +143,7 @@ class Game(FPSGameBase):
             self.sound_manager,
             on_kill=lambda bot: self.event_bus.emit("bot_killed", x=bot.x, y=bot.y),
         )
+        self.screen_event_handler = ScreenEventHandler(self)
 
         # Input
         self.joystick = None
@@ -305,61 +306,27 @@ class Game(FPSGameBase):
 
     def handle_intro_events(self) -> None:
         """Handle events during intro sequence"""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_ESCAPE or event.key == pygame.K_SPACE:
-                    self.state = GameState.MENU
+        self.screen_event_handler.handle_intro_events()
 
     def handle_menu_events(self) -> None:
         """Handle events in main menu"""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_ESCAPE:
-                    self.running = False
+        self.screen_event_handler.handle_menu_events()
 
     def handle_key_config_events(self) -> None:
         """Handle events in key configuration screen"""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_ESCAPE:
-                    self.state = GameState.MENU
+        self.screen_event_handler.handle_key_config_events()
 
     def handle_map_select_events(self) -> None:
         """Handle events in map selection screen"""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_ESCAPE:
-                    self.state = GameState.MENU
+        self.screen_event_handler.handle_map_select_events()
 
     def handle_level_complete_events(self) -> None:
         """Handle events in level complete screen"""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_SPACE or event.key == pygame.K_RETURN:
-                    self.state = GameState.MENU
-                elif event.key == pygame.K_ESCAPE:
-                    self.state = GameState.MENU
+        self.screen_event_handler.handle_level_complete_events()
 
     def handle_game_over_events(self) -> None:
         """Handle events in game over screen"""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_SPACE or event.key == pygame.K_RETURN:
-                    self.state = GameState.MENU
-                elif event.key == pygame.K_ESCAPE:
-                    self.state = GameState.MENU
+        self.screen_event_handler.handle_game_over_events()
 
     # _handle_cheat_input, _handle_pause_toggle, _handle_weapon_keys,
     # _handle_pause_menu_click, _handle_gameplay_mouse_click,
@@ -843,41 +810,7 @@ class Game(FPSGameBase):
         Args:
             elapsed: Elapsed time in milliseconds since intro started.
         """
-        duration = 0
-        if self.intro_phase == 0:
-            duration = 3000
-        elif self.intro_phase == 1:
-            duration = 3000
-        elif self.intro_phase == 2:
-            slides_durations = [8000, 10000, 4000, 4000]
-            if self.intro_step < len(slides_durations):
-                duration = slides_durations[self.intro_step]
-
-                if self.intro_step == 0 and elapsed < 50:
-                    if not self.laugh_played:
-                        self.sound_manager.play_sound("laugh")
-                        self.laugh_played = True
-
-                if elapsed > duration:
-                    self.intro_step += 1
-                    self.intro_start_time = 0
-                    self.laugh_played = False
-            else:
-                self.state = GameState.MENU
-                return
-
-        if self.intro_phase < 2:
-            if self.intro_phase == 1 and elapsed < 50:
-                if not self.water_played:
-                    self.sound_manager.play_sound("water")
-                    self.water_played = True
-
-            if elapsed > duration:
-                self.intro_phase += 1
-                self.intro_start_time = 0
-                # Only release video when transitioning from phase 1 to phase 2
-                if self.intro_phase == 2:
-                    self.ui_renderer.release_intro_video()
+        self.screen_event_handler.update_intro_logic(elapsed)
 
     def run(self) -> None:
         """Main game loop"""
@@ -907,28 +840,7 @@ class Game(FPSGameBase):
                     self.ui_renderer.render_map_select(self)
 
                 elif self.state == GameState.PLAYING:
-                    self.handle_game_events()
-                    if self.paused:
-                        # Pause Menu Audio
-                        beat_delay = PAUSE_HEARTBEAT_DELAY
-                        self.heartbeat_timer -= 1
-                        if self.heartbeat_timer <= 0:
-                            self.sound_manager.play_sound("heartbeat")
-                            self.sound_manager.play_sound("breath")
-                            self.heartbeat_timer = beat_delay
-
-                        if self.player and self.player.health < 50:
-                            self.groan_timer -= 1
-                            if self.groan_timer <= 0:
-                                self.sound_manager.play_sound("groan")
-                                self.groan_timer = GROAN_TIMER_DELAY
-                    else:
-                        self.update_game()
-                    self.renderer.render_game(self, self.flash_intensity)
-                    # Decrement damage flash timer after rendering
-                    # to maintain correct frame count
-                    if not self.paused and self.damage_flash_timer > 0:
-                        self.damage_flash_timer -= 1
+                    self.screen_event_handler.handle_playing_state()
 
                 elif self.state == GameState.LEVEL_COMPLETE:
                     self.handle_level_complete_events()

--- a/src/games/Duum/src/screen_event_handler.py
+++ b/src/games/Duum/src/screen_event_handler.py
@@ -1,0 +1,146 @@
+"""Per-screen event handlers for Duum.
+
+Extracted from game.py to keep that file within the 1 000-line budget.
+Each method corresponds to one GameState and is called from the main
+game loop.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pygame
+
+from games.shared.constants import (
+    GROAN_TIMER_DELAY,
+    PAUSE_HEARTBEAT_DELAY,
+    GameState,
+)
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+class ScreenEventHandler:
+    """Handles per-screen event dispatching for all Duum GameState screens."""
+
+    def __init__(self, game: Game) -> None:
+        self._game = game
+
+    def handle_intro_events(self) -> None:
+        """Handle events during the intro sequence."""
+        game = self._game
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                game.running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_ESCAPE, pygame.K_SPACE):
+                    game.state = GameState.MENU
+
+    def handle_menu_events(self) -> None:
+        """Handle events in the main menu."""
+        game = self._game
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                game.running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                game.running = False
+
+    def handle_key_config_events(self) -> None:
+        """Handle events in the key configuration screen."""
+        game = self._game
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                game.running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                game.state = GameState.MENU
+
+    def handle_map_select_events(self) -> None:
+        """Handle events in the map selection screen."""
+        game = self._game
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                game.running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                game.state = GameState.MENU
+
+    def handle_level_complete_events(self) -> None:
+        """Handle events in the level-complete screen."""
+        game = self._game
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                game.running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_SPACE, pygame.K_RETURN, pygame.K_ESCAPE):
+                    game.state = GameState.MENU
+
+    def handle_game_over_events(self) -> None:
+        """Handle events in the game-over screen."""
+        game = self._game
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                game.running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_SPACE, pygame.K_RETURN, pygame.K_ESCAPE):
+                    game.state = GameState.MENU
+
+    def update_intro_logic(self, elapsed: int) -> None:
+        """Update intro sequence logic and transitions."""
+        game = self._game
+        duration = 0
+        if game.intro_phase == 0:
+            duration = 3000
+        elif game.intro_phase == 1:
+            duration = 3000
+        elif game.intro_phase == 2:
+            slides_durations = [8000, 10000, 4000, 4000]
+            if game.intro_step < len(slides_durations):
+                duration = slides_durations[game.intro_step]
+
+                if game.intro_step == 0 and elapsed < 50:
+                    if not game.laugh_played:
+                        game.sound_manager.play_sound("laugh")
+                        game.laugh_played = True
+
+                if elapsed > duration:
+                    game.intro_step += 1
+                    game.intro_start_time = 0
+                    game.laugh_played = False
+            else:
+                game.state = GameState.MENU
+                return
+
+        if game.intro_phase < 2:
+            if game.intro_phase == 1 and elapsed < 50:
+                if not game.water_played:
+                    game.sound_manager.play_sound("water")
+                    game.water_played = True
+
+            if elapsed > duration:
+                game.intro_phase += 1
+                game.intro_start_time = 0
+                if game.intro_phase == 2:
+                    game.ui_renderer.release_intro_video()
+
+    def handle_playing_state(self) -> None:
+        """Handle the PLAYING state: events, pause audio, update, and render."""
+        game = self._game
+        game.handle_game_events()
+        if game.paused:
+            game.heartbeat_timer -= 1
+            if game.heartbeat_timer <= 0:
+                game.sound_manager.play_sound("heartbeat")
+                game.sound_manager.play_sound("breath")
+                game.heartbeat_timer = PAUSE_HEARTBEAT_DELAY
+
+            if game.player and game.player.health < 50:
+                game.groan_timer -= 1
+                if game.groan_timer <= 0:
+                    game.sound_manager.play_sound("groan")
+                    game.groan_timer = GROAN_TIMER_DELAY
+        else:
+            game.update_game()
+
+        game.renderer.render_game(game, game.flash_intensity)
+        if not game.paused and game.damage_flash_timer > 0:
+            game.damage_flash_timer -= 1

--- a/tests/Duum/test_screen_event_handler.py
+++ b/tests/Duum/test_screen_event_handler.py
@@ -1,0 +1,98 @@
+"""Focused tests for the extracted Duum screen-event handler."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pygame
+
+from games.shared.constants import GROAN_TIMER_DELAY, PAUSE_HEARTBEAT_DELAY, GameState
+
+
+def _screen_game(**overrides: object) -> SimpleNamespace:
+    base = {
+        "running": True,
+        "state": GameState.INTRO,
+        "intro_phase": 1,
+        "intro_step": 0,
+        "intro_start_time": 500,
+        "laugh_played": False,
+        "water_played": False,
+        "paused": False,
+        "heartbeat_timer": 0,
+        "groan_timer": 0,
+        "damage_flash_timer": 2,
+        "flash_intensity": 0.75,
+        "player": SimpleNamespace(health=40),
+        "sound_manager": MagicMock(),
+        "ui_renderer": MagicMock(),
+        "renderer": MagicMock(),
+        "handle_game_events": MagicMock(),
+        "update_game": MagicMock(),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_handle_intro_events_space_transitions_to_menu(monkeypatch) -> None:
+    from games.Duum.src.screen_event_handler import ScreenEventHandler
+
+    game = _screen_game(state=GameState.INTRO)
+    monkeypatch.setattr(
+        pygame.event,
+        "get",
+        lambda: [SimpleNamespace(type=pygame.KEYDOWN, key=pygame.K_SPACE)],
+    )
+
+    ScreenEventHandler(game).handle_intro_events()
+
+    assert game.state == GameState.MENU
+
+
+def test_update_intro_logic_releases_video_on_phase_transition() -> None:
+    from games.Duum.src.screen_event_handler import ScreenEventHandler
+
+    game = _screen_game(state=GameState.INTRO, intro_phase=1, intro_start_time=500)
+
+    ScreenEventHandler(game).update_intro_logic(elapsed=3100)
+
+    assert game.intro_phase == 2
+    assert game.intro_start_time == 0
+    game.ui_renderer.release_intro_video.assert_called_once_with()
+
+
+def test_handle_playing_state_updates_game_and_decays_flash() -> None:
+    from games.Duum.src.screen_event_handler import ScreenEventHandler
+
+    game = _screen_game(state=GameState.PLAYING, paused=False, damage_flash_timer=2)
+
+    ScreenEventHandler(game).handle_playing_state()
+
+    game.handle_game_events.assert_called_once_with()
+    game.update_game.assert_called_once_with()
+    game.renderer.render_game.assert_called_once_with(game, 0.75)
+    assert game.damage_flash_timer == 1
+
+
+def test_handle_playing_state_paused_runs_pause_audio_without_update() -> None:
+    from games.Duum.src.screen_event_handler import ScreenEventHandler
+
+    game = _screen_game(
+        state=GameState.PLAYING,
+        paused=True,
+        heartbeat_timer=0,
+        groan_timer=0,
+        damage_flash_timer=2,
+        player=SimpleNamespace(health=40),
+    )
+
+    ScreenEventHandler(game).handle_playing_state()
+
+    game.update_game.assert_not_called()
+    game.renderer.render_game.assert_called_once_with(game, 0.75)
+    assert game.heartbeat_timer == PAUSE_HEARTBEAT_DELAY
+    assert game.groan_timer == GROAN_TIMER_DELAY
+    game.sound_manager.play_sound.assert_has_calls(
+        [call("heartbeat"), call("breath"), call("groan")]
+    )


### PR DESCRIPTION
## What changed
- extracted Duum's per-screen event and intro/play-state flow into `src/games/Duum/src/screen_event_handler.py`
- kept `Game` as the stable public facade by delegating the existing screen handler methods and PLAYING-state loop
- added focused regression coverage for intro transitions and paused/unpaused play-state handling
- refreshed `SPEC.md` to document the extracted Duum screen-flow seam

## Why it changed
`src/games/Duum/src/game.py` was still one of the largest live hotspots behind `Games #721`. This slice removes mixed screen-state orchestration from the monolith without changing gameplay behavior and gives us a narrow seam for follow-on refactors.

## Impact
- reduces `Duum/src/game.py` to a thinner orchestrator
- aligns Duum with the existing `Zombie_Survival` screen-event-handler pattern
- gives `#721` another bounded, reviewable slice instead of waiting for the full epic to finish at once

## Validation
- `python3 -m pytest tests/Duum/test_screen_event_handler.py tests/Duum/test_ui_renderer.py -q`
- `python3 -m pytest tests/Duum -q`
- `python3 -m ruff check src/games/Duum/src/game.py src/games/Duum/src/screen_event_handler.py tests/Duum/test_screen_event_handler.py`
- `python3 -m black --check src/games/Duum/src/game.py src/games/Duum/src/screen_event_handler.py tests/Duum/test_screen_event_handler.py`
- `git diff --check`

Addresses #721.
