### PR TITLE
Extract Duum game loop dispatch

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.9                                                |
+| **Spec Version**        | 1.1.10                                               |
 | **Last Spec Update**    | 2026-04-08                                           |
 
 ## 2. Purpose & Mission
@@ -113,7 +113,7 @@ Games/
 | Game Launcher         | `src/games/`                     | Central entry point, game discovery, selection UI, execution orchestration      |
 | Force Field Engine    | `src/games/Force_Field/engine/`  | Raycasting renderer, 3D-to-2D projection, collision detection                   |
 | Force Field Runtime   | `src/games/Force_Field/src/`     | Thin game facade plus extracted loop, session, combat, gameplay, and screen-flow subsystems |
-| Duum Screen Flow      | `src/games/Duum/src/`            | Thin Duum game facade with delegated per-screen event handling and play-state orchestration |
+| Duum Screen Flow      | `src/games/Duum/src/`            | Thin Duum game facade with delegated per-screen event handling, play-state orchestration, and extracted loop dispatch |
 | Duum Level Generation | `src/games/Duum/levels/`         | Procedural dungeon generation, room connectivity                                |
 | Tetris Logic          | `src/games/Tetris/`              | Piece mechanics, board state, gravity, line clearing                            |
 | Shared Renderers      | `src/games/shared/renderers/`    | Common rendering abstractions, 2D drawing, sprite management                    |

--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -25,6 +25,7 @@ from games.shared.raycaster import Raycaster
 from games.shared.sound_manager_base import SoundManagerBase
 
 from . import constants as C  # noqa: N812
+from . import game_loop
 from .combat_manager import DuumCombatManager
 from .custom_types import DamageText, Portal
 from .entity_manager import EntityManager
@@ -814,43 +815,4 @@ class Game(FPSGameBase):
 
     def run(self) -> None:
         """Main game loop"""
-        try:
-            while self.running:
-                if self.state == GameState.INTRO:
-                    self.handle_intro_events()
-                    if self.intro_start_time == 0:
-                        self.intro_start_time = pygame.time.get_ticks()
-                    elapsed = pygame.time.get_ticks() - self.intro_start_time
-
-                    self.ui_renderer.render_intro(
-                        self.intro_phase, self.intro_step, elapsed
-                    )
-                    self._update_intro_logic(elapsed)
-
-                elif self.state == GameState.MENU:
-                    self.handle_menu_events()
-                    self.ui_renderer.render_menu()
-
-                elif self.state == GameState.KEY_CONFIG:
-                    self.handle_key_config_events()
-                    self.ui_renderer.render_key_config(self)
-
-                elif self.state == GameState.MAP_SELECT:
-                    self.handle_map_select_events()
-                    self.ui_renderer.render_map_select(self)
-
-                elif self.state == GameState.PLAYING:
-                    self.screen_event_handler.handle_playing_state()
-
-                elif self.state == GameState.LEVEL_COMPLETE:
-                    self.handle_level_complete_events()
-                    self.ui_renderer.render_level_complete(self)
-
-                elif self.state == GameState.GAME_OVER:
-                    self.handle_game_over_events()
-                    self.ui_renderer.render_game_over(self)
-
-                self.clock.tick(C.FPS)
-        except (RuntimeError, pygame.error, OSError, ValueError, TypeError) as e:
-            logger.critical("CRASH: %s", e, exc_info=True)
-            raise
+        game_loop.run(self)

--- a/src/games/Duum/src/game_loop.py
+++ b/src/games/Duum/src/game_loop.py
@@ -1,0 +1,62 @@
+"""Top-level state dispatch loop for Duum."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pygame
+
+from games.shared.constants import GameState
+
+from . import constants as C  # noqa: N812
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+logger = logging.getLogger(__name__)
+
+
+def run(game: Game) -> None:
+    """Execute the main loop until the game stops running."""
+    try:
+        while game.running:
+            run_frame(game)
+            game.clock.tick(C.FPS)
+    except (RuntimeError, pygame.error, OSError, ValueError, TypeError) as exc:
+        logger.critical("CRASH: %s", exc, exc_info=True)
+        raise
+
+
+def run_frame(game: Game) -> None:
+    """Dispatch one frame based on the active top-level game state."""
+    if game.state == GameState.INTRO:
+        _run_intro_frame(game)
+    elif game.state == GameState.MENU:
+        game.handle_menu_events()
+        game.ui_renderer.render_menu()
+    elif game.state == GameState.KEY_CONFIG:
+        game.handle_key_config_events()
+        game.ui_renderer.render_key_config(game)
+    elif game.state == GameState.MAP_SELECT:
+        game.handle_map_select_events()
+        game.ui_renderer.render_map_select(game)
+    elif game.state == GameState.PLAYING:
+        game.screen_event_handler.handle_playing_state()
+    elif game.state == GameState.LEVEL_COMPLETE:
+        game.handle_level_complete_events()
+        game.ui_renderer.render_level_complete(game)
+    elif game.state == GameState.GAME_OVER:
+        game.handle_game_over_events()
+        game.ui_renderer.render_game_over(game)
+
+
+def _run_intro_frame(game: Game) -> None:
+    """Run one frame of the intro state."""
+    game.handle_intro_events()
+    if game.intro_start_time == 0:
+        game.intro_start_time = pygame.time.get_ticks()
+    elapsed = pygame.time.get_ticks() - game.intro_start_time
+    game.ui_renderer.render_intro(game.intro_phase, game.intro_step, elapsed)
+    game._update_intro_logic(elapsed)

--- a/tests/Duum/test_game_loop.py
+++ b/tests/Duum/test_game_loop.py
@@ -1,0 +1,77 @@
+"""Focused tests for the extracted Duum game-loop subsystem."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pygame
+
+from games.shared.constants import GameState
+
+
+def _loop_game(**overrides: object) -> SimpleNamespace:
+    """Build a lightweight game stub for game-loop tests."""
+    base = {
+        "running": True,
+        "state": GameState.PLAYING,
+        "intro_start_time": 0,
+        "intro_phase": 0,
+        "intro_step": 0,
+        "clock": MagicMock(),
+        "ui_renderer": MagicMock(),
+        "screen_event_handler": MagicMock(),
+        "handle_intro_events": MagicMock(),
+        "handle_menu_events": MagicMock(),
+        "handle_key_config_events": MagicMock(),
+        "handle_map_select_events": MagicMock(),
+        "handle_level_complete_events": MagicMock(),
+        "handle_game_over_events": MagicMock(),
+        "_update_intro_logic": MagicMock(),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_run_frame_delegates_playing_state() -> None:
+    """Playing frames should delegate to the extracted screen-event handler."""
+    from games.Duum.src.game_loop import run_frame
+
+    game = _loop_game(state=GameState.PLAYING)
+
+    run_frame(game)
+
+    game.screen_event_handler.handle_playing_state.assert_called_once_with()
+
+
+def test_run_frame_intro_initializes_timer_and_renders(monkeypatch) -> None:
+    """Intro frames should initialize timing and delegate rendering/logic."""
+    from games.Duum.src.game_loop import run_frame
+
+    game = _loop_game(state=GameState.INTRO, intro_start_time=0)
+    monkeypatch.setattr(pygame.time, "get_ticks", lambda: 1234)
+
+    run_frame(game)
+
+    game.handle_intro_events.assert_called_once_with()
+    game.ui_renderer.render_intro.assert_called_once_with(0, 0, 0)
+    game._update_intro_logic.assert_called_once_with(0)
+    assert game.intro_start_time == 1234
+
+
+def test_run_ticks_clock_until_stopped() -> None:
+    """The outer loop should keep dispatching frames while running is true."""
+    from games.Duum.src import game_loop
+
+    game = _loop_game()
+
+    def stop_after_first_frame(current_game) -> None:
+        current_game.running = False
+
+    game_loop.run_frame = stop_after_first_frame  # type: ignore[assignment]
+    try:
+        game_loop.run(game)
+    finally:
+        del game_loop.run_frame
+
+    game.clock.tick.assert_called_once()


### PR DESCRIPTION
## What changed
- extracted Duum's top-level state dispatch into `src/games/Duum/src/game_loop.py`
- kept `Game.run()` as the stable facade by delegating to the new loop module
- added focused game-loop tests for intro timing, PLAYING-state delegation, and outer-loop ticking
- refreshed `SPEC.md` to reflect the additional Duum decomposition

## Why it changed
`Games #721` is still centered on oversized per-game orchestration modules. After extracting the screen-event handler in the previous slice, the main loop dispatch remained as another mixed-responsibility block in `src/games/Duum/src/game.py`.

## Impact
- reduces `src/games/Duum/src/game.py` from 856 to 818 lines
- aligns Duum with the repo's existing extracted-loop pattern from Force Field
- gives the next `#721` review another narrow, behavior-preserving refactor slice

## Validation
- `python3 -m pytest tests/Duum/test_game_loop.py tests/Duum/test_screen_event_handler.py tests/Duum/test_ui_renderer.py -q`
- `python3 -m pytest tests/Duum -q`
- `python3 -m ruff check src/games/Duum/src/game.py src/games/Duum/src/game_loop.py tests/Duum/test_game_loop.py`
- `python3 -m black --check src/games/Duum/src/game.py src/games/Duum/src/game_loop.py tests/Duum/test_game_loop.py`

Addresses #721.
