### PR TITLE
refactor: split Zombie Survival gameplay flow from game.py

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.11                                               |
+| **Spec Version**        | 1.1.12                                               |
 | **Last Spec Update**    | 2026-04-09                                           |
 
 ## 2. Purpose & Mission
@@ -114,6 +114,7 @@ Games/
 | Force Field Engine    | `src/games/Force_Field/engine/`  | Raycasting renderer, 3D-to-2D projection, collision detection                   |
 | Force Field Runtime   | `src/games/Force_Field/src/`     | Thin game facade plus extracted loop, session, combat, gameplay, and screen-flow subsystems |
 | Duum Screen Flow      | `src/games/Duum/src/`            | Thin Duum game facade with delegated per-screen event handling, extracted loop dispatch, gameplay updates, and ambient-state management |
+| Zombie Gameplay Flow  | `src/games/Zombie_Survival/src/` | Thin Zombie Survival game facade with delegated screen handling, extracted gameplay updates, loop dispatch, and ambient-state management |
 | Duum Level Generation | `src/games/Duum/levels/`         | Procedural dungeon generation, room connectivity                                |
 | Tetris Logic          | `src/games/Tetris/`              | Piece mechanics, board state, gravity, line clearing                            |
 | Shared Renderers      | `src/games/shared/renderers/`    | Common rendering abstractions, 2D drawing, sprite management                    |

--- a/src/games/Zombie_Survival/src/game.py
+++ b/src/games/Zombie_Survival/src/game.py
@@ -8,7 +8,6 @@ import pygame
 
 from games.shared.config import RaycasterConfig
 from games.shared.constants import (
-    PICKUP_RADIUS_SQ,
     PORTAL_RADIUS_SQ,
     GameState,
 )
@@ -19,6 +18,7 @@ from games.shared.raycaster import Raycaster
 from games.shared.sound_manager_base import SoundManagerBase
 
 from . import constants as C  # noqa: N812
+from . import game_loop, gameplay_updater
 from .atmosphere_manager import AtmosphereManager
 from .combat_manager import ZSCombatManager
 from .entity_manager import EntityManager
@@ -531,149 +531,9 @@ class Game(FPSGameBase):
 
         return shield_active
 
-    def _update_damage_texts(self) -> None:
-        """Tick floating damage text positions and remove expired entries."""
-        for t in self.damage_texts:
-            t["y"] += t["vy"]
-            t["timer"] -= 1
-        self.damage_texts = [t for t in self.damage_texts if t["timer"] > 0]
-
-    def _handle_keyboard_movement(self, keys: pygame.key.ScancodeWrapper) -> None:
-        """Apply keyboard-driven player movement and camera rotation."""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        if not (self.game_map is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        sprint_key = keys[pygame.K_RSHIFT]
-        is_sprinting = self.input_manager.is_action_pressed("sprint") or sprint_key
-        if is_sprinting and self.player_stamina > 0:
-            current_speed = C.PLAYER_SPRINT_SPEED
-            self.player_stamina -= 1
-            self.player_stamina_recharge_delay = 60
-        else:
-            current_speed = C.PLAYER_SPEED
-
-        moving = False
-        if self.input_manager.is_action_pressed("move_forward"):
-            self.player.move(
-                self.game_map, self.bots, forward=True, speed=current_speed
-            )
-            moving = True
-        if self.input_manager.is_action_pressed("move_backward"):
-            self.player.move(
-                self.game_map, self.bots, forward=False, speed=current_speed
-            )
-            moving = True
-        if self.input_manager.is_action_pressed("strafe_left"):
-            self.player.strafe(
-                self.game_map, self.bots, right=False, speed=current_speed
-            )
-            moving = True
-        if self.input_manager.is_action_pressed("strafe_right"):
-            self.player.strafe(
-                self.game_map, self.bots, right=True, speed=current_speed
-            )
-            moving = True
-
-        self.player_is_moving = moving
-
-        if self.input_manager.is_action_pressed("turn_left"):
-            self.player.rotate(-0.05)
-        if self.input_manager.is_action_pressed("turn_right"):
-            self.player.rotate(0.05)
-        if self.input_manager.is_action_pressed("look_up"):
-            self.player.pitch_view(5)
-        if self.input_manager.is_action_pressed("look_down"):
-            self.player.pitch_view(-5)
-
-    def _check_item_pickups(self) -> None:
-        """Detect player proximity to pickup items and apply their effects."""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        for bot in self.bots:
-            is_item = bot.enemy_type.startswith(("health", "ammo", "bomb", "pickup"))
-            if not (bot.alive and is_item):
-                continue
-            dx = bot.x - self.player_x
-            dy = bot.y - self.player_y
-            if dx * dx + dy * dy >= PICKUP_RADIUS_SQ:
-                continue
-
-            pickup_msg = ""
-            color = C.GREEN
-            if bot.enemy_type == "health_pack":
-                if self.player_health < 100:
-                    self.player_health = min(100, self.player_health + 50)
-                    pickup_msg = "HEALTH +50"
-            elif bot.enemy_type == "ammo_box":
-                for w in self.player.ammo:
-                    self.player.ammo[w] += 20
-                pickup_msg = "AMMO FOUND"
-                color = C.YELLOW
-            elif bot.enemy_type == "bomb_item":
-                self.player_bombs += 1
-                pickup_msg = "BOMB +1"
-                color = C.ORANGE
-            elif bot.enemy_type.startswith("pickup_"):
-                w_name = bot.enemy_type.replace("pickup_", "")
-                if w_name not in self.unlocked_weapons:
-                    self.unlocked_weapons.add(w_name)
-                    self.player.switch_weapon(w_name)
-                    pickup_msg = f"{w_name.upper()} ACQUIRED!"
-                    color = C.CYAN
-                elif w_name in self.player.ammo:
-                    clip_size = int(C.WEAPONS[w_name]["clip_size"])
-                    self.player.ammo[w_name] += clip_size * 2
-                    pickup_msg = f"{w_name.upper()} AMMO"
-                    color = C.YELLOW
-
-            if pickup_msg:
-                bot.alive = False
-                bot.removed = True
-                self.damage_texts.append(
-                    {
-                        "x": C.SCREEN_WIDTH // 2,
-                        "y": C.SCREEN_HEIGHT // 2 - 50,
-                        "text": pickup_msg,
-                        "color": color,
-                        "timer": 60,
-                        "vy": -1,
-                    }
-                )
-
     def update_game(self) -> None:
-        """Update game state"""
-        if self.paused:
-            return
-
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        if not (self.game_map is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        if self._check_game_over():
-            return
-        if self._check_portal_completion():
-            return
-
-        keys = pygame.key.get_pressed()
-        shield_active = self.input_manager.is_action_pressed("shield")
-
-        if self.joystick and self.player_alive:
-            shield_active = self._handle_joystick_input(shield_active)
-
-        self.player.set_shield(shield_active)
-        self.particle_system.update()
-        self._update_damage_texts()
-        self._handle_keyboard_movement(keys)
-        self.player.update()
-
-        self.entity_manager.update_bots(self.game_map, self.player, self)
-        self._check_item_pickups()
-        self.entity_manager.update_projectiles(self.game_map, self.player, self)
-
-        self.atmosphere_manager.update_fog_reveal()
-        self.atmosphere_manager.update_atmosphere()
-        self.atmosphere_manager.check_kill_combo()
+        """Update game state through the extracted gameplay updater."""
+        gameplay_updater.update_game(self)
 
     # ------------------------------------------------------------------
     # Screen event handlers — delegated to ScreenEventHandler
@@ -708,44 +568,5 @@ class Game(FPSGameBase):
         self.screen_event_handler.update_intro_logic(elapsed)
 
     def run(self) -> None:
-        """Main game loop"""
-        try:
-            while self.running:
-                if self.state == GameState.INTRO:
-                    self.handle_intro_events()
-                    if self.intro_start_time == 0:
-                        self.intro_start_time = pygame.time.get_ticks()
-                    elapsed = pygame.time.get_ticks() - self.intro_start_time
-
-                    self.ui_renderer.render_intro(
-                        self.intro_phase, self.intro_step, elapsed
-                    )
-                    self._update_intro_logic(elapsed)
-
-                elif self.state == GameState.MENU:
-                    self.handle_menu_events()
-                    self.ui_renderer.render_menu()
-
-                elif self.state == GameState.KEY_CONFIG:
-                    self.handle_key_config_events()
-                    self.ui_renderer.render_key_config(self)
-
-                elif self.state == GameState.MAP_SELECT:
-                    self.handle_map_select_events()
-                    self.ui_renderer.render_map_select(self)
-
-                elif self.state == GameState.PLAYING:
-                    self.screen_event_handler.handle_playing_state()
-
-                elif self.state == GameState.LEVEL_COMPLETE:
-                    self.handle_level_complete_events()
-                    self.ui_renderer.render_level_complete(self)
-
-                elif self.state == GameState.GAME_OVER:
-                    self.handle_game_over_events()
-                    self.ui_renderer.render_game_over(self)
-
-                self.clock.tick(C.FPS)
-        except (RuntimeError, pygame.error, OSError, ValueError, TypeError) as e:
-            logger.critical("CRASH: %s", e, exc_info=True)
-            raise
+        """Main game loop."""
+        game_loop.run(self)

--- a/src/games/Zombie_Survival/src/game_loop.py
+++ b/src/games/Zombie_Survival/src/game_loop.py
@@ -1,0 +1,62 @@
+"""Top-level state dispatch loop for Zombie Survival."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pygame
+
+from games.shared.constants import GameState
+
+from . import constants as C  # noqa: N812
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+logger = logging.getLogger(__name__)
+
+
+def run(game: Game) -> None:
+    """Execute the main loop until the game stops running."""
+    try:
+        while game.running:
+            run_frame(game)
+            game.clock.tick(C.FPS)
+    except (RuntimeError, pygame.error, OSError, ValueError, TypeError) as exc:
+        logger.critical("CRASH: %s", exc, exc_info=True)
+        raise
+
+
+def run_frame(game: Game) -> None:
+    """Dispatch one frame based on the active top-level game state."""
+    if game.state == GameState.INTRO:
+        _run_intro_frame(game)
+    elif game.state == GameState.MENU:
+        game.handle_menu_events()
+        game.ui_renderer.render_menu()
+    elif game.state == GameState.KEY_CONFIG:
+        game.handle_key_config_events()
+        game.ui_renderer.render_key_config(game)
+    elif game.state == GameState.MAP_SELECT:
+        game.handle_map_select_events()
+        game.ui_renderer.render_map_select(game)
+    elif game.state == GameState.PLAYING:
+        game.screen_event_handler.handle_playing_state()
+    elif game.state == GameState.LEVEL_COMPLETE:
+        game.handle_level_complete_events()
+        game.ui_renderer.render_level_complete(game)
+    elif game.state == GameState.GAME_OVER:
+        game.handle_game_over_events()
+        game.ui_renderer.render_game_over(game)
+
+
+def _run_intro_frame(game: Game) -> None:
+    """Run one frame of the intro state."""
+    game.handle_intro_events()
+    if game.intro_start_time == 0:
+        game.intro_start_time = pygame.time.get_ticks()
+    elapsed = pygame.time.get_ticks() - game.intro_start_time
+    game.ui_renderer.render_intro(game.intro_phase, game.intro_step, elapsed)
+    game._update_intro_logic(elapsed)

--- a/src/games/Zombie_Survival/src/gameplay_updater.py
+++ b/src/games/Zombie_Survival/src/gameplay_updater.py
@@ -1,0 +1,158 @@
+"""Gameplay-frame update helpers for Zombie Survival."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pygame
+
+from games.shared.constants import PICKUP_RADIUS_SQ
+
+from . import constants as C  # noqa: N812
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+def update_damage_texts(game: Game) -> None:
+    """Tick floating damage text positions and prune expired messages."""
+    for text in game.damage_texts:
+        text["y"] += text["vy"]
+        text["timer"] -= 1
+    game.damage_texts = [text for text in game.damage_texts if text["timer"] > 0]
+
+
+def handle_keyboard_movement(
+    game: Game,
+    keys: pygame.key.ScancodeWrapper,
+) -> None:
+    """Apply keyboard-driven movement and view updates."""
+    if not (game.player is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+    if not (game.game_map is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+
+    sprint_key = keys[pygame.K_RSHIFT]
+    is_sprinting = game.input_manager.is_action_pressed("sprint") or sprint_key
+    if is_sprinting and game.player_stamina > 0:
+        current_speed = C.PLAYER_SPRINT_SPEED
+        game.player_stamina -= 1
+        game.player_stamina_recharge_delay = 60
+    else:
+        current_speed = C.PLAYER_SPEED
+
+    moving = False
+    if game.input_manager.is_action_pressed("move_forward"):
+        game.player.move(game.game_map, game.bots, forward=True, speed=current_speed)
+        moving = True
+    if game.input_manager.is_action_pressed("move_backward"):
+        game.player.move(game.game_map, game.bots, forward=False, speed=current_speed)
+        moving = True
+    if game.input_manager.is_action_pressed("strafe_left"):
+        game.player.strafe(game.game_map, game.bots, right=False, speed=current_speed)
+        moving = True
+    if game.input_manager.is_action_pressed("strafe_right"):
+        game.player.strafe(game.game_map, game.bots, right=True, speed=current_speed)
+        moving = True
+
+    game.player_is_moving = moving
+
+    if game.input_manager.is_action_pressed("turn_left"):
+        game.player.rotate(-0.05)
+    if game.input_manager.is_action_pressed("turn_right"):
+        game.player.rotate(0.05)
+    if game.input_manager.is_action_pressed("look_up"):
+        game.player.pitch_view(5)
+    if game.input_manager.is_action_pressed("look_down"):
+        game.player.pitch_view(-5)
+
+
+def check_item_pickups(game: Game) -> None:
+    """Apply nearby pickup effects and announce successful pickups."""
+    if not (game.player is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+
+    for bot in game.bots:
+        is_item = bot.enemy_type.startswith(("health", "ammo", "bomb", "pickup"))
+        if not (bot.alive and is_item):
+            continue
+
+        dx = bot.x - game.player_x
+        dy = bot.y - game.player_y
+        if dx * dx + dy * dy >= PICKUP_RADIUS_SQ:
+            continue
+
+        pickup_msg = ""
+        color = C.GREEN
+        if bot.enemy_type == "health_pack":
+            if game.player_health < 100:
+                game.player_health = min(100, game.player_health + 50)
+                pickup_msg = "HEALTH +50"
+        elif bot.enemy_type == "ammo_box":
+            for weapon_name in game.player.ammo:
+                game.player.ammo[weapon_name] += 20
+            pickup_msg = "AMMO FOUND"
+            color = C.YELLOW
+        elif bot.enemy_type == "bomb_item":
+            game.player_bombs += 1
+            pickup_msg = "BOMB +1"
+            color = C.ORANGE
+        elif bot.enemy_type.startswith("pickup_"):
+            weapon_name = bot.enemy_type.replace("pickup_", "")
+            if weapon_name not in game.unlocked_weapons:
+                game.unlocked_weapons.add(weapon_name)
+                game.player.switch_weapon(weapon_name)
+                pickup_msg = f"{weapon_name.upper()} ACQUIRED!"
+                color = C.CYAN
+            elif weapon_name in game.player.ammo:
+                clip_size = int(C.WEAPONS[weapon_name]["clip_size"])
+                game.player.ammo[weapon_name] += clip_size * 2
+                pickup_msg = f"{weapon_name.upper()} AMMO"
+                color = C.YELLOW
+
+        if pickup_msg:
+            bot.alive = False
+            bot.removed = True
+            game.damage_texts.append(
+                {
+                    "x": C.SCREEN_WIDTH // 2,
+                    "y": C.SCREEN_HEIGHT // 2 - 50,
+                    "text": pickup_msg,
+                    "color": color,
+                    "timer": 60,
+                    "vy": -1,
+                }
+            )
+
+
+def update_game(game: Game) -> None:
+    """Advance one active gameplay frame for Zombie Survival."""
+    if game.paused:
+        return
+    if not (game.player is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+    if not (game.game_map is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+    if game._check_game_over():
+        return
+    if game._check_portal_completion():
+        return
+
+    keys = pygame.key.get_pressed()
+    shield_active = game.input_manager.is_action_pressed("shield")
+    if game.joystick and game.player_alive:
+        shield_active = game._handle_joystick_input(shield_active)
+
+    game.player.set_shield(shield_active)
+    game.particle_system.update()
+    update_damage_texts(game)
+    handle_keyboard_movement(game, keys)
+    game.player.update()
+
+    game.entity_manager.update_bots(game.game_map, game.player, game)
+    check_item_pickups(game)
+    game.entity_manager.update_projectiles(game.game_map, game.player, game)
+
+    game.atmosphere_manager.update_fog_reveal()
+    game.atmosphere_manager.update_atmosphere()
+    game.atmosphere_manager.check_kill_combo()

--- a/tests/Zombie_Survival/test_game_loop.py
+++ b/tests/Zombie_Survival/test_game_loop.py
@@ -1,0 +1,77 @@
+"""Focused tests for the extracted Zombie Survival game loop."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pygame
+
+from games.shared.constants import GameState
+
+
+def _loop_game(**overrides: object) -> SimpleNamespace:
+    """Build a lightweight game stub for loop tests."""
+    base = {
+        "running": True,
+        "state": GameState.PLAYING,
+        "intro_start_time": 0,
+        "intro_phase": 0,
+        "intro_step": 0,
+        "clock": MagicMock(),
+        "ui_renderer": MagicMock(),
+        "screen_event_handler": MagicMock(),
+        "handle_intro_events": MagicMock(),
+        "handle_menu_events": MagicMock(),
+        "handle_key_config_events": MagicMock(),
+        "handle_map_select_events": MagicMock(),
+        "handle_level_complete_events": MagicMock(),
+        "handle_game_over_events": MagicMock(),
+        "_update_intro_logic": MagicMock(),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_run_frame_delegates_playing_state() -> None:
+    """Playing frames should delegate to the extracted screen-event handler."""
+    from games.Zombie_Survival.src.game_loop import run_frame
+
+    game = _loop_game(state=GameState.PLAYING)
+
+    run_frame(game)
+
+    game.screen_event_handler.handle_playing_state.assert_called_once_with()
+
+
+def test_run_frame_intro_initializes_timer_and_renders(monkeypatch) -> None:
+    """Intro frames should initialize timing and delegate rendering/logic."""
+    from games.Zombie_Survival.src.game_loop import run_frame
+
+    game = _loop_game(state=GameState.INTRO, intro_start_time=0)
+    monkeypatch.setattr(pygame.time, "get_ticks", lambda: 1234)
+
+    run_frame(game)
+
+    game.handle_intro_events.assert_called_once_with()
+    game.ui_renderer.render_intro.assert_called_once_with(0, 0, 0)
+    game._update_intro_logic.assert_called_once_with(0)
+    assert game.intro_start_time == 1234
+
+
+def test_run_ticks_clock_until_stopped() -> None:
+    """The outer loop should keep dispatching frames while running is true."""
+    from games.Zombie_Survival.src import game_loop
+
+    game = _loop_game()
+
+    def stop_after_first_frame(current_game) -> None:
+        current_game.running = False
+
+    game_loop.run_frame = stop_after_first_frame  # type: ignore[assignment]
+    try:
+        game_loop.run(game)
+    finally:
+        del game_loop.run_frame
+
+    game.clock.tick.assert_called_once()

--- a/tests/Zombie_Survival/test_gameplay_updater.py
+++ b/tests/Zombie_Survival/test_gameplay_updater.py
@@ -1,0 +1,163 @@
+"""Focused tests for the extracted Zombie Survival gameplay updater."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pygame
+
+
+class _PressedKeys:
+    """Tiny indexable key-state stub for pygame-style lookups."""
+
+    def __init__(self, pressed: set[int] | None = None) -> None:
+        self._pressed = pressed or set()
+
+    def __getitem__(self, key: int) -> bool:
+        return key in self._pressed
+
+
+def test_update_damage_texts_ticks_and_filters_expired() -> None:
+    """Damage text updates should move entries and prune expired rows."""
+    from games.Zombie_Survival.src import gameplay_updater
+
+    game = SimpleNamespace(
+        damage_texts=[
+            {"y": 20, "vy": -1, "timer": 2},
+            {"y": 10, "vy": 1, "timer": 1},
+        ]
+    )
+
+    gameplay_updater.update_damage_texts(game)
+
+    assert game.damage_texts == [{"y": 19, "vy": -1, "timer": 1}]
+
+
+def test_handle_keyboard_movement_applies_forward_motion_and_turn() -> None:
+    """Keyboard movement should drive the player and set movement state."""
+    from games.Zombie_Survival.src import gameplay_updater
+
+    player = SimpleNamespace(
+        rotate=MagicMock(),
+        pitch_view=MagicMock(),
+        move=MagicMock(),
+        strafe=MagicMock(),
+    )
+    actions = {"move_forward", "turn_left"}
+    game = SimpleNamespace(
+        player=player,
+        game_map=object(),
+        bots=[],
+        player_stamina=10,
+        player_stamina_recharge_delay=0,
+        player_is_moving=False,
+        input_manager=SimpleNamespace(
+            is_action_pressed=lambda action: action in actions
+        ),
+    )
+
+    gameplay_updater.handle_keyboard_movement(game, _PressedKeys())
+
+    player.move.assert_called_once()
+    player.rotate.assert_called_once_with(-0.05)
+    assert game.player_is_moving is True
+
+
+def test_check_item_pickups_unlocks_weapon_and_announces() -> None:
+    """Weapon pickups should unlock the weapon and append a screen message."""
+    from games.Zombie_Survival.src import gameplay_updater
+
+    player = SimpleNamespace(
+        ammo={"pistol": 5},
+        switch_weapon=MagicMock(),
+    )
+    bot = SimpleNamespace(
+        x=5.0,
+        y=5.0,
+        enemy_type="pickup_shotgun",
+        alive=True,
+        removed=False,
+    )
+    game = SimpleNamespace(
+        player=player,
+        player_x=5.0,
+        player_y=5.0,
+        player_health=100,
+        player_bombs=0,
+        bots=[bot],
+        unlocked_weapons={"pistol"},
+        damage_texts=[],
+    )
+
+    gameplay_updater.check_item_pickups(game)
+
+    player.switch_weapon.assert_called_once_with("shotgun")
+    assert "shotgun" in game.unlocked_weapons
+    assert bot.alive is False
+    assert bot.removed is True
+    assert game.damage_texts[0]["text"] == "SHOTGUN ACQUIRED!"
+
+
+def test_update_game_delegates_live_frame_components(monkeypatch) -> None:
+    """Gameplay updates should run the extracted subsystems in order."""
+    from games.Zombie_Survival.src import gameplay_updater
+
+    keys = _PressedKeys()
+    update_damage_texts = MagicMock()
+    handle_keyboard_movement = MagicMock()
+    check_item_pickups = MagicMock()
+    monkeypatch.setattr(gameplay_updater, "update_damage_texts", update_damage_texts)
+    monkeypatch.setattr(
+        gameplay_updater,
+        "handle_keyboard_movement",
+        handle_keyboard_movement,
+    )
+    monkeypatch.setattr(gameplay_updater, "check_item_pickups", check_item_pickups)
+    monkeypatch.setattr(pygame.key, "get_pressed", lambda: keys)
+
+    player = SimpleNamespace(alive=True, set_shield=MagicMock(), update=MagicMock())
+    particle_system = SimpleNamespace(update=MagicMock())
+    entity_manager = SimpleNamespace(
+        update_bots=MagicMock(),
+        update_projectiles=MagicMock(),
+    )
+    atmosphere_manager = SimpleNamespace(
+        update_fog_reveal=MagicMock(),
+        update_atmosphere=MagicMock(),
+        check_kill_combo=MagicMock(),
+    )
+    game = SimpleNamespace(
+        paused=False,
+        player=player,
+        player_alive=True,
+        game_map=object(),
+        input_manager=SimpleNamespace(
+            is_action_pressed=lambda action: action == "shield"
+        ),
+        joystick=None,
+        particle_system=particle_system,
+        entity_manager=entity_manager,
+        atmosphere_manager=atmosphere_manager,
+        _check_game_over=MagicMock(return_value=False),
+        _check_portal_completion=MagicMock(return_value=False),
+        bots=[],
+    )
+
+    gameplay_updater.update_game(game)
+
+    player.set_shield.assert_called_once_with(True)
+    particle_system.update.assert_called_once_with()
+    update_damage_texts.assert_called_once_with(game)
+    handle_keyboard_movement.assert_called_once_with(game, keys)
+    player.update.assert_called_once_with()
+    entity_manager.update_bots.assert_called_once_with(game.game_map, player, game)
+    check_item_pickups.assert_called_once_with(game)
+    entity_manager.update_projectiles.assert_called_once_with(
+        game.game_map,
+        player,
+        game,
+    )
+    atmosphere_manager.update_fog_reveal.assert_called_once_with()
+    atmosphere_manager.update_atmosphere.assert_called_once_with()
+    atmosphere_manager.check_kill_combo.assert_called_once_with()


### PR DESCRIPTION
## Summary
- extract Zombie Survival main-loop dispatch into game_loop.py
- move gameplay update helpers into gameplay_updater.py
- add focused seam tests for the new loop and updater modules

## Validation
- python3 -m pytest tests/Zombie_Survival -q
- python3 -m pytest tests/Zombie_Survival/test_game_loop.py tests/Zombie_Survival/test_gameplay_updater.py tests/Zombie_Survival/test_ui_renderer.py -q
- python3 -m ruff check src/games/Zombie_Survival/src/game.py src/games/Zombie_Survival/src/game_loop.py src/games/Zombie_Survival/src/gameplay_updater.py tests/Zombie_Survival/test_game_loop.py tests/Zombie_Survival/test_gameplay_updater.py
- python3 -m ruff format --check src/games/Zombie_Survival/src/game.py src/games/Zombie_Survival/src/game_loop.py src/games/Zombie_Survival/src/gameplay_updater.py tests/Zombie_Survival/test_game_loop.py tests/Zombie_Survival/test_gameplay_updater.py
- git diff --check

Partial for #721.