### PR TITLE
refactor: split Zombie Survival progression flow from game.py

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,8 +10,8 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.12                                               |
-| **Last Spec Update**    | 2026-04-09                                           |
+| **Spec Version**        | 1.1.13                                               |
+| **Last Spec Update**    | 2026-04-10                                           |
 
 ## 2. Purpose & Mission
 
@@ -408,6 +408,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.1.13  | Partially addressed issue `#721` by extracting Zombie Survival session/level progression out of `src/games/Zombie_Survival/src/game.py` into `progression_flow.py`, delegating full-game start, level start, game-over, and portal-completion transitions through a focused helper module, and adding seam tests around the extracted progression behavior.                                                                                                  |
 | 2026-04-07 | 1.1.8   | Partially addressed issue `#721` by splitting Zombie Survival menu, pause/config, and progression rendering out of `src/games/Zombie_Survival/src/ui_renderer.py` into dedicated helper modules (`ui_menu_views.py`, `ui_overlay_views.py`, `ui_progress_views.py`), keeping `UIRenderer` as the public façade, and adding targeted delegation tests around the extracted seams.                                                                                                                         |
 | 2026-04-07 | 1.1.7   | Partially addressed issue `#721` by splitting Duum menu, pause/config, and progression rendering out of `src/games/Duum/src/ui_renderer.py` into dedicated helper modules (`ui_menu_views.py`, `ui_overlay_views.py`, `ui_progress_views.py`), keeping `UIRenderer` as the public façade, and adding targeted delegation tests around the extracted seams.                                                                                                                                           |
 | 2026-04-07 | 1.1.6   | Partially addressed issue `#721` by splitting Force Field menu, pause/config, and progression rendering into dedicated helper modules (`ui_menu_views.py`, `ui_overlay_views.py`, `ui_progress_views.py`), keeping `UIRenderer` as the public façade, and adding targeted delegation tests around the extracted seams.                                                                                                                         |

--- a/src/games/Zombie_Survival/src/game.py
+++ b/src/games/Zombie_Survival/src/game.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
 import logging
-import random
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pygame
 
-from games.shared.config import RaycasterConfig
-from games.shared.constants import (
-    PORTAL_RADIUS_SQ,
-    GameState,
-)
+from games.shared.constants import GameState
 from games.shared.event_bus import EventBus
 from games.shared.fps_game_base import FPSGameBase
 from games.shared.interfaces import Portal
@@ -18,14 +13,12 @@ from games.shared.raycaster import Raycaster
 from games.shared.sound_manager_base import SoundManagerBase
 
 from . import constants as C  # noqa: N812
-from . import game_loop, gameplay_updater
+from . import game_loop, gameplay_updater, progression_flow
 from .atmosphere_manager import AtmosphereManager
 from .combat_manager import ZSCombatManager
 from .entity_manager import EntityManager
 from .input_manager import InputManager
-from .map import Map
 from .particle_system import ParticleSystem
-from .player import Player
 from .projectile import Projectile
 from .renderer import GameRenderer
 from .screen_event_handler import ScreenEventHandler
@@ -33,6 +26,10 @@ from .sound import SoundManager
 from .spawn_manager import ZSSpawnManager
 from .ui_renderer import UIRenderer
 from .weapon_system import WeaponSystem
+
+if TYPE_CHECKING:
+    from .map import Map
+    from .player import Player
 
 logger = logging.getLogger(__name__)
 
@@ -251,121 +248,11 @@ class Game(FPSGameBase):
 
     def start_game(self) -> None:
         """Start new game"""
-        self.level = self.selected_start_level
-        self.lives = self.selected_lives
-        self.kills = 0
-        self.level_times = []
-        self.paused = False
-        self.particle_system.particles = []
-        self.damage_texts = []
-        self.entity_manager.reset()
-
-        # Reset Cheats/Progress
-        self.unlocked_weapons = {"pistol", "rifle"}
-        self.god_mode = False
-        self.cheat_mode_active = False
-
-        # Reset Combo & Atmosphere
-        self.kill_combo_count = 0
-        self.kill_combo_timer = 0
-        self.heartbeat_timer = 0
-        self.breath_timer = 0
-        self.groan_timer = 0
-        self.beast_timer = 0
-
-        # Reset combat manager state
-        self.kills = 0
-        self.kill_combo_count = 0
-        self.kill_combo_timer = 0
-        self.last_death_pos = None
-
-        # Create map with selected size
-        self.game_map = Map(self.selected_map_size)
-
-        # Initialize Raycaster with Config
-        ray_config = RaycasterConfig(
-            SCREEN_WIDTH=C.SCREEN_WIDTH,
-            SCREEN_HEIGHT=C.SCREEN_HEIGHT,
-            FOV=C.FOV,
-            HALF_FOV=C.HALF_FOV,
-            ZOOM_FOV_MULT=C.ZOOM_FOV_MULT,
-            DEFAULT_RENDER_SCALE=self.render_scale,
-            MAX_DEPTH=C.MAX_DEPTH,
-            FOG_START=C.FOG_START,
-            FOG_COLOR=C.FOG_COLOR,
-            LEVEL_THEMES=C.LEVEL_THEMES,
-            ENEMY_TYPES=C.ENEMY_TYPES,
-        )
-        self.raycaster = Raycaster(self.game_map, ray_config)
-        self.last_death_pos = None
-        self.portal = None
-
-        # Grab mouse
-        pygame.mouse.set_visible(False)
-        pygame.event.set_grab(True)
-
-        self.start_level()
+        progression_flow.start_game(self)
 
     def start_level(self) -> None:
         """Start a new level"""
-        if not (self.game_map is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        self.level_start_time = pygame.time.get_ticks()
-        self.total_paused_time = 0
-        self.pause_start_time = 0
-        self.particle_system.particles = []
-        self.damage_texts = []
-        self.damage_flash_timer = 0
-        self.visited_cells = set()  # Reset fog of war
-        self.portal = None
-
-        # Grab mouse for FPS gameplay
-        pygame.mouse.set_visible(False)
-        pygame.event.set_grab(True)
-
-        # Player Spawn Logic
-        player_pos = self._get_best_spawn_point()
-
-        # Preserve ammo and weapon selection from previous level if player exists
-        previous_ammo = None
-        previous_weapon = "pistol"
-        old_player = self.player
-        if old_player:
-            previous_ammo = old_player.ammo
-            previous_weapon = old_player.current_weapon
-
-        self.player = Player(player_pos[0], player_pos[1], player_pos[2])
-        if previous_ammo:
-            self.player.ammo = previous_ammo
-            if previous_weapon in self.unlocked_weapons:
-                self.player_current_weapon = previous_weapon
-            else:
-                self.player_current_weapon = "pistol"
-        # Validate current weapon is unlocked
-        # (e.g. Player init sets 'rifle' but it might be locked)
-        if self.player_current_weapon not in self.unlocked_weapons:
-            self.player_current_weapon = "pistol"
-
-        # Propagate God Mode state
-        self.player.god_mode = self.god_mode
-
-        # Delegate spawning to SpawnManager
-        self.entity_manager.reset()
-        self.spawn_manager.spawn_all(
-            player_pos, self.game_map, self.level, self.selected_difficulty
-        )
-
-        # Start Music
-        music_tracks = [
-            "music_loop",
-            "music_drums",
-            "music_wind",
-            "music_horror",
-            "music_piano",
-            "music_action",
-        ]
-        if hasattr(self, "sound_manager"):
-            self.sound_manager.start_music(random.choice(music_tracks))
+        progression_flow.start_level(self)
 
     # _handle_cheat_input, _handle_pause_toggle, _handle_weapon_keys,
     # _handle_pause_menu_click, _handle_gameplay_mouse_click,
@@ -417,58 +304,14 @@ class Game(FPSGameBase):
 
         Returns True when the caller should stop further update processing.
         """
-        if not self.player_alive:
-            if self.lives > 1:
-                self.lives -= 1
-                self.respawn_player()
-                return True
-            level_time = (
-                pygame.time.get_ticks() - self.level_start_time - self.total_paused_time
-            ) / 1000.0
-            self.level_times.append(level_time)
-            self.lives = 0
-            self.state = GameState.GAME_OVER
-            self.game_over_timer = 0
-            self.sound_manager.play_sound("game_over1")
-            pygame.mouse.set_visible(True)
-            pygame.event.set_grab(False)
-            return True
-        return False
+        return progression_flow.check_game_over(self)
 
     def _check_portal_completion(self) -> bool:
         """Spawn portal when all enemies are dead; transition on portal entry.
 
         Returns True when the caller should stop further update processing.
         """
-        enemies_alive = self.entity_manager.get_active_enemies()
-        if not enemies_alive:
-            if self.portal is None:
-                self.spawn_portal()
-                self.damage_texts.append(
-                    {
-                        "x": C.SCREEN_WIDTH // 2,
-                        "y": C.SCREEN_HEIGHT // 2,
-                        "text": "PORTAL OPENED!",
-                        "color": C.CYAN,
-                        "timer": 180,
-                        "vy": 0,
-                    }
-                )
-
-        if self.portal:
-            dx = self.portal["x"] - self.player_x
-            dy = self.portal["y"] - self.player_y
-            dist_sq = dx * dx + dy * dy
-            if dist_sq < PORTAL_RADIUS_SQ:
-                paused = self.total_paused_time
-                now = pygame.time.get_ticks()
-                level_time = (now - self.level_start_time - paused) / 1000.0
-                self.level_times.append(level_time)
-                self.state = GameState.LEVEL_COMPLETE
-                pygame.mouse.set_visible(True)
-                pygame.event.set_grab(False)
-                return True
-        return False
+        return progression_flow.check_portal_completion(self)
 
     def _handle_joystick_input(self, shield_active: bool) -> bool:
         """Process joystick axes and buttons; returns updated shield_active."""

--- a/src/games/Zombie_Survival/src/progression_flow.py
+++ b/src/games/Zombie_Survival/src/progression_flow.py
@@ -1,0 +1,189 @@
+"""Lifecycle and progression helpers for Zombie Survival."""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+import pygame
+
+from games.shared.config import RaycasterConfig
+from games.shared.constants import PORTAL_RADIUS_SQ, GameState
+from games.shared.raycaster import Raycaster
+
+from . import constants as C  # noqa: N812
+from .map import Map
+from .player import Player
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+def start_game(game: Game) -> None:
+    """Reset the full game session and initialize the first level."""
+    game.level = game.selected_start_level
+    game.lives = game.selected_lives
+    game.kills = 0
+    game.level_times = []
+    game.paused = False
+    game.particle_system.particles = []
+    game.damage_texts = []
+    game.entity_manager.reset()
+
+    game.unlocked_weapons = {"pistol", "rifle"}
+    game.god_mode = False
+    game.cheat_mode_active = False
+
+    game.kill_combo_count = 0
+    game.kill_combo_timer = 0
+    game.heartbeat_timer = 0
+    game.breath_timer = 0
+    game.groan_timer = 0
+    game.beast_timer = 0
+
+    game.kills = 0
+    game.kill_combo_count = 0
+    game.kill_combo_timer = 0
+    game.last_death_pos = None
+
+    game.game_map = Map(game.selected_map_size)
+    game.raycaster = Raycaster(game.game_map, _build_raycaster_config(game))
+    game.portal = None
+
+    pygame.mouse.set_visible(False)
+    pygame.event.set_grab(True)
+
+    start_level(game)
+
+
+def start_level(game: Game) -> None:
+    """Start a new level and respawn the player into a fresh world state."""
+    if not (game.game_map is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+
+    game.level_start_time = pygame.time.get_ticks()
+    game.total_paused_time = 0
+    game.pause_start_time = 0
+    game.particle_system.particles = []
+    game.damage_texts = []
+    game.damage_flash_timer = 0
+    game.visited_cells = set()
+    game.portal = None
+
+    pygame.mouse.set_visible(False)
+    pygame.event.set_grab(True)
+
+    player_pos = game._get_best_spawn_point()
+
+    previous_ammo = None
+    previous_weapon = "pistol"
+    old_player = game.player
+    if old_player:
+        previous_ammo = old_player.ammo
+        previous_weapon = old_player.current_weapon
+
+    game.player = Player(player_pos[0], player_pos[1], player_pos[2])
+    if previous_ammo:
+        game.player.ammo = previous_ammo
+        if previous_weapon in game.unlocked_weapons:
+            game.player_current_weapon = previous_weapon
+        else:
+            game.player_current_weapon = "pistol"
+    if game.player_current_weapon not in game.unlocked_weapons:
+        game.player_current_weapon = "pistol"
+
+    game.player.god_mode = game.god_mode
+
+    game.entity_manager.reset()
+    game.spawn_manager.spawn_all(
+        player_pos,
+        game.game_map,
+        game.level,
+        game.selected_difficulty,
+    )
+
+    music_tracks = [
+        "music_loop",
+        "music_drums",
+        "music_wind",
+        "music_horror",
+        "music_piano",
+        "music_action",
+    ]
+    if hasattr(game, "sound_manager"):
+        game.sound_manager.start_music(random.choice(music_tracks))
+
+
+def check_game_over(game: Game) -> bool:
+    """Handle player death transitions and report whether the frame should stop."""
+    if game.player_alive:
+        return False
+
+    if game.lives > 1:
+        game.lives -= 1
+        game.respawn_player()
+        return True
+
+    level_time = (
+        pygame.time.get_ticks() - game.level_start_time - game.total_paused_time
+    ) / 1000.0
+    game.level_times.append(level_time)
+    game.lives = 0
+    game.state = GameState.GAME_OVER
+    game.game_over_timer = 0
+    game.sound_manager.play_sound("game_over1")
+    pygame.mouse.set_visible(True)
+    pygame.event.set_grab(False)
+    return True
+
+
+def check_portal_completion(game: Game) -> bool:
+    """Open the exit portal when the arena clears and handle level completion."""
+    enemies_alive = game.entity_manager.get_active_enemies()
+    if not enemies_alive and game.portal is None:
+        game.spawn_portal()
+        game.damage_texts.append(
+            {
+                "x": C.SCREEN_WIDTH // 2,
+                "y": C.SCREEN_HEIGHT // 2,
+                "text": "PORTAL OPENED!",
+                "color": C.CYAN,
+                "timer": 180,
+                "vy": 0,
+            }
+        )
+
+    if not game.portal:
+        return False
+
+    dx = game.portal["x"] - game.player_x
+    dy = game.portal["y"] - game.player_y
+    dist_sq = dx * dx + dy * dy
+    if dist_sq >= PORTAL_RADIUS_SQ:
+        return False
+
+    level_time = (
+        pygame.time.get_ticks() - game.level_start_time - game.total_paused_time
+    ) / 1000.0
+    game.level_times.append(level_time)
+    game.state = GameState.LEVEL_COMPLETE
+    pygame.mouse.set_visible(True)
+    pygame.event.set_grab(False)
+    return True
+
+
+def _build_raycaster_config(game: Game) -> RaycasterConfig:
+    """Construct the raycaster config from the current game constants/state."""
+    return RaycasterConfig(
+        SCREEN_WIDTH=C.SCREEN_WIDTH,
+        SCREEN_HEIGHT=C.SCREEN_HEIGHT,
+        FOV=C.FOV,
+        HALF_FOV=C.HALF_FOV,
+        ZOOM_FOV_MULT=C.ZOOM_FOV_MULT,
+        DEFAULT_RENDER_SCALE=game.render_scale,
+        MAX_DEPTH=C.MAX_DEPTH,
+        FOG_START=C.FOG_START,
+        FOG_COLOR=C.FOG_COLOR,
+        LEVEL_THEMES=C.LEVEL_THEMES,
+        ENEMY_TYPES=C.ENEMY_TYPES,
+    )

--- a/tests/Zombie_Survival/test_progression_flow.py
+++ b/tests/Zombie_Survival/test_progression_flow.py
@@ -1,0 +1,244 @@
+"""Focused tests for the extracted Zombie Survival progression helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pygame
+
+from games.shared.constants import GameState
+
+
+class _GameStub(SimpleNamespace):
+    """Small game-like stub with the properties progression helpers expect."""
+
+    @property
+    def player_current_weapon(self) -> str:
+        if self.player is None:
+            return "pistol"
+        return self.player.current_weapon
+
+    @player_current_weapon.setter
+    def player_current_weapon(self, value: str) -> None:
+        if self.player is not None:
+            self.player.current_weapon = value
+
+    @property
+    def player_alive(self) -> bool:
+        return bool(self.player and self.player.alive)
+
+    @property
+    def player_x(self) -> float:
+        return self.player.x if self.player else 0.0
+
+    @property
+    def player_y(self) -> float:
+        return self.player.y if self.player else 0.0
+
+
+def test_start_game_resets_session_and_initializes_map(monkeypatch) -> None:
+    """Full game restarts should reset shared state and build the world shell."""
+    from games.Zombie_Survival.src import progression_flow
+
+    start_level = MagicMock()
+
+    class FakeMap:
+        def __init__(self, size: int) -> None:
+            self.size = size
+
+    class FakeRaycaster:
+        def __init__(self, game_map: FakeMap, config: object) -> None:
+            self.game_map = game_map
+            self.config = config
+
+    mouse_visible = MagicMock()
+    event_grab = MagicMock()
+    monkeypatch.setattr(progression_flow, "Map", FakeMap)
+    monkeypatch.setattr(progression_flow, "Raycaster", FakeRaycaster)
+    monkeypatch.setattr(progression_flow, "start_level", start_level)
+    monkeypatch.setattr(pygame.mouse, "set_visible", mouse_visible)
+    monkeypatch.setattr(pygame.event, "set_grab", event_grab)
+
+    game = _GameStub(
+        selected_start_level=3,
+        selected_lives=4,
+        selected_map_size=42,
+        render_scale=2,
+        kills=99,
+        level_times=[1.0],
+        paused=True,
+        particle_system=SimpleNamespace(particles=[1, 2]),
+        damage_texts=[{"text": "old"}],
+        entity_manager=SimpleNamespace(reset=MagicMock()),
+        unlocked_weapons={"rocket"},
+        god_mode=True,
+        cheat_mode_active=True,
+        kill_combo_count=5,
+        kill_combo_timer=9,
+        heartbeat_timer=1,
+        breath_timer=2,
+        groan_timer=3,
+        beast_timer=4,
+        last_death_pos=(5.0, 7.0),
+        portal={"x": 1.0, "y": 1.0},
+    )
+
+    progression_flow.start_game(game)
+
+    assert game.level == 3
+    assert game.lives == 4
+    assert game.kills == 0
+    assert game.level_times == []
+    assert game.paused is False
+    assert game.unlocked_weapons == {"pistol", "rifle"}
+    assert game.god_mode is False
+    assert game.cheat_mode_active is False
+    assert game.last_death_pos is None
+    assert isinstance(game.game_map, FakeMap)
+    assert isinstance(game.raycaster, FakeRaycaster)
+    game.entity_manager.reset.assert_called_once_with()
+    start_level.assert_called_once_with(game)
+    mouse_visible.assert_called_once_with(False)
+    event_grab.assert_called_once_with(True)
+
+
+def test_start_level_restores_previous_ammo_and_weapon(monkeypatch) -> None:
+    """Level starts should preserve compatible player progression state."""
+    from games.Zombie_Survival.src import progression_flow
+
+    class FakePlayer:
+        def __init__(self, x: float, y: float, angle: float) -> None:
+            self.x = x
+            self.y = y
+            self.angle = angle
+            self.ammo = {"pistol": 0, "rifle": 0}
+            self.current_weapon = "pistol"
+            self.god_mode = False
+
+    mouse_visible = MagicMock()
+    event_grab = MagicMock()
+    monkeypatch.setattr(progression_flow, "Player", FakePlayer)
+    monkeypatch.setattr(pygame.time, "get_ticks", lambda: 4321)
+    monkeypatch.setattr(pygame.mouse, "set_visible", mouse_visible)
+    monkeypatch.setattr(pygame.event, "set_grab", event_grab)
+    monkeypatch.setattr(progression_flow.random, "choice", lambda tracks: tracks[0])
+
+    old_player = SimpleNamespace(
+        ammo={"pistol": 15, "rifle": 90},
+        current_weapon="rifle",
+    )
+    entity_manager = SimpleNamespace(reset=MagicMock())
+    spawn_manager = SimpleNamespace(spawn_all=MagicMock())
+    sound_manager = SimpleNamespace(start_music=MagicMock())
+    game = _GameStub(
+        game_map=SimpleNamespace(),
+        particle_system=SimpleNamespace(particles=["old"]),
+        damage_texts=[{"text": "old"}],
+        damage_flash_timer=10,
+        visited_cells={(1, 1)},
+        portal={"x": 1.0, "y": 1.0},
+        _get_best_spawn_point=lambda: (10.5, 11.5, 0.75),
+        player=old_player,
+        unlocked_weapons={"pistol", "rifle"},
+        god_mode=True,
+        entity_manager=entity_manager,
+        spawn_manager=spawn_manager,
+        sound_manager=sound_manager,
+        level=2,
+        selected_difficulty="normal",
+    )
+
+    progression_flow.start_level(game)
+
+    assert game.level_start_time == 4321
+    assert game.total_paused_time == 0
+    assert game.pause_start_time == 0
+    assert game.damage_texts == []
+    assert game.visited_cells == set()
+    assert game.portal is None
+    assert isinstance(game.player, FakePlayer)
+    assert game.player.x == 10.5
+    assert game.player.ammo == {"pistol": 15, "rifle": 90}
+    assert game.player.current_weapon == "rifle"
+    assert game.player.god_mode is True
+    entity_manager.reset.assert_called_once_with()
+    spawn_manager.spawn_all.assert_called_once_with(
+        (10.5, 11.5, 0.75),
+        game.game_map,
+        2,
+        "normal",
+    )
+    sound_manager.start_music.assert_called_once_with("music_loop")
+    mouse_visible.assert_called_once_with(False)
+    event_grab.assert_called_once_with(True)
+
+
+def test_check_game_over_transitions_to_game_over(monkeypatch) -> None:
+    """A final death should end the level and show the game-over screen."""
+    from games.Zombie_Survival.src import progression_flow
+
+    mouse_visible = MagicMock()
+    event_grab = MagicMock()
+    monkeypatch.setattr(pygame.time, "get_ticks", lambda: 3200)
+    monkeypatch.setattr(pygame.mouse, "set_visible", mouse_visible)
+    monkeypatch.setattr(pygame.event, "set_grab", event_grab)
+
+    game = _GameStub(
+        player=SimpleNamespace(alive=False),
+        lives=1,
+        level_start_time=1000,
+        total_paused_time=200,
+        level_times=[],
+        state=GameState.PLAYING,
+        game_over_timer=7,
+        sound_manager=SimpleNamespace(play_sound=MagicMock()),
+    )
+
+    result = progression_flow.check_game_over(game)
+
+    assert result is True
+    assert game.level_times == [2.0]
+    assert game.lives == 0
+    assert game.state == GameState.GAME_OVER
+    assert game.game_over_timer == 0
+    game.sound_manager.play_sound.assert_called_once_with("game_over1")
+    mouse_visible.assert_called_once_with(True)
+    event_grab.assert_called_once_with(False)
+
+
+def test_check_portal_completion_opens_and_completes_level(monkeypatch) -> None:
+    """Clearing enemies and entering the portal should finish the level."""
+    from games.Zombie_Survival.src import progression_flow
+
+    mouse_visible = MagicMock()
+    event_grab = MagicMock()
+    monkeypatch.setattr(pygame.time, "get_ticks", lambda: 2100)
+    monkeypatch.setattr(pygame.mouse, "set_visible", mouse_visible)
+    monkeypatch.setattr(pygame.event, "set_grab", event_grab)
+
+    game = _GameStub(
+        entity_manager=SimpleNamespace(get_active_enemies=MagicMock(return_value=[])),
+        portal=None,
+        damage_texts=[],
+        player=SimpleNamespace(x=5.0, y=5.0),
+        level_start_time=1000,
+        total_paused_time=100,
+        level_times=[],
+        state=GameState.PLAYING,
+    )
+
+    def spawn_portal() -> None:
+        game.portal = {"x": 5.0, "y": 5.0}
+
+    game.spawn_portal = MagicMock(side_effect=spawn_portal)
+
+    result = progression_flow.check_portal_completion(game)
+
+    assert result is True
+    game.spawn_portal.assert_called_once_with()
+    assert game.damage_texts[0]["text"] == "PORTAL OPENED!"
+    assert game.level_times == [1.0]
+    assert game.state == GameState.LEVEL_COMPLETE
+    mouse_visible.assert_called_once_with(True)
+    event_grab.assert_called_once_with(False)


### PR DESCRIPTION
Summary:\n- extract Zombie Survival session and level progression into progression_flow.py\n- delegate full-game start, level start, game-over, and portal-completion checks from Game\n- add focused progression seam tests while keeping issue #721 moving in bounded slices\n\nValidation:\n- python3 -m pytest tests/Zombie_Survival/test_progression_flow.py tests/Zombie_Survival/test_game_loop.py tests/Zombie_Survival/test_gameplay_updater.py tests/Zombie_Survival/test_ui_renderer.py -q\n- python3 -m pytest tests/Zombie_Survival -q\n- python3 -m ruff check src/games/Zombie_Survival/src/game.py src/games/Zombie_Survival/src/progression_flow.py tests/Zombie_Survival/test_progression_flow.py\n- python3 -m ruff format --check src/games/Zombie_Survival/src/game.py src/games/Zombie_Survival/src/progression_flow.py tests/Zombie_Survival/test_progression_flow.py\n- git diff --check\n\nPartial for #721.