### PR TITLE
refactor: split Duum HUD rendering from ui_renderer

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.14                                               |
+| **Spec Version**        | 1.1.15                                               |
 | **Last Spec Update**    | 2026-04-10                                           |
 
 ## 2. Purpose & Mission
@@ -113,7 +113,7 @@ Games/
 | Game Launcher         | `src/games/`                     | Central entry point, game discovery, selection UI, execution orchestration      |
 | Force Field Engine    | `src/games/Force_Field/engine/`  | Raycasting renderer, 3D-to-2D projection, collision detection                   |
 | Force Field Runtime   | `src/games/Force_Field/src/`     | Thin game facade plus extracted loop, session, combat, gameplay, and screen-flow subsystems |
-| Duum Screen Flow      | `src/games/Duum/src/`            | Thin Duum game facade with delegated per-screen event handling, extracted loop dispatch, gameplay updates, and ambient-state management |
+| Duum Screen Flow      | `src/games/Duum/src/`            | Thin Duum game facade with delegated per-screen event handling, extracted loop dispatch, gameplay updates, ambient-state management, and HUD view helpers |
 | Zombie Gameplay Flow  | `src/games/Zombie_Survival/src/` | Thin Zombie Survival game facade with delegated screen handling, extracted gameplay updates, loop dispatch, ambient-state management, and HUD view helpers |
 | Duum Level Generation | `src/games/Duum/levels/`         | Procedural dungeon generation, room connectivity                                |
 | Tetris Logic          | `src/games/Tetris/`              | Piece mechanics, board state, gravity, line clearing                            |
@@ -408,6 +408,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.1.15  | Partially addressed issue `#721` by extracting Duum HUD rendering out of `src/games/Duum/src/ui_renderer.py` into `ui_hud_views.py`, keeping `UIRenderer` as the public façade, and adding seam tests around the new HUD delegation points.                                                                                                                                                                                                               |
 | 2026-04-10 | 1.1.14  | Partially addressed issue `#721` by extracting Zombie Survival HUD rendering out of `src/games/Zombie_Survival/src/ui_renderer.py` into `ui_hud_views.py`, keeping `UIRenderer` as the public façade, and adding seam tests around the new HUD delegation points.                                                                                                                                                                                            |
 | 2026-04-10 | 1.1.13  | Partially addressed issue `#721` by extracting Zombie Survival session/level progression out of `src/games/Zombie_Survival/src/game.py` into `progression_flow.py`, delegating full-game start, level start, game-over, and portal-completion transitions through a focused helper module, and adding seam tests around the extracted progression behavior.                                                                                                  |
 | 2026-04-07 | 1.1.8   | Partially addressed issue `#721` by splitting Zombie Survival menu, pause/config, and progression rendering out of `src/games/Zombie_Survival/src/ui_renderer.py` into dedicated helper modules (`ui_menu_views.py`, `ui_overlay_views.py`, `ui_progress_views.py`), keeping `UIRenderer` as the public façade, and adding targeted delegation tests around the extracted seams.                                                                                                                         |

--- a/src/games/Duum/src/ui_hud_views.py
+++ b/src/games/Duum/src/ui_hud_views.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pygame
+
+from . import constants as C  # noqa: N812
+from .custom_types import DamageText
+
+if TYPE_CHECKING:
+    from .game import Game
+    from .player import Player
+    from .ui_renderer import UIRenderer
+
+
+def render_hud(renderer: UIRenderer, game: Game) -> None:
+    """Render the full Duum gameplay HUD."""
+    if not (game.player is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+    if not (game.raycaster is not None):
+        raise ValueError("DbC Blocked: Precondition failed.")
+
+    renderer.overlay_surface.fill((0, 0, 0, 0))
+    render_low_health_tint(renderer, game.player)
+    render_damage_flash(renderer, game.damage_flash_timer)
+    render_shield_effect(renderer, game.player)
+    renderer.screen.blit(renderer.overlay_surface, (0, 0))
+
+    renderer.screen.blit(renderer.vignette, (0, 0))
+
+    render_crosshair(renderer)
+    render_secondary_charge(renderer, game.player)
+
+    render_messages(renderer, game)
+    render_health_bar(renderer, game)
+    render_ammo_display(renderer, game)
+    render_weapon_slots(renderer, game)
+    render_level_info(renderer, game)
+    render_minimap(renderer, game)
+    render_status_bars(renderer, game)
+    render_controls_hint(renderer)
+    render_pause_overlay(renderer, game)
+
+
+def render_health_bar(renderer: UIRenderer, game: Game) -> None:
+    """Render the player health bar."""
+    hud_bottom = C.SCREEN_HEIGHT - 80
+    health_width = 150
+    health_height = 25
+    health_x = 20
+    health_y = hud_bottom
+
+    pygame.draw.rect(
+        renderer.screen,
+        C.DARK_GRAY,
+        (health_x, health_y, health_width, health_height),
+    )
+    health_percent = max(0, game.player.health / game.player.max_health)
+    fill_width = int(health_width * health_percent)
+    health_color = C.RED
+    if health_percent > 0.5:
+        health_color = C.GREEN
+    elif health_percent > 0.25:
+        health_color = C.ORANGE
+    health_rect = (health_x, health_y, fill_width, health_height)
+    pygame.draw.rect(renderer.screen, health_color, health_rect)
+    pygame.draw.rect(
+        renderer.screen,
+        C.WHITE,
+        (health_x, health_y, health_width, health_height),
+        2,
+    )
+
+
+def render_ammo_display(renderer: UIRenderer, game: Game) -> None:
+    """Render the ammo counter and weapon name."""
+    hud_bottom = C.SCREEN_HEIGHT - 80
+
+    weapon_state = game.player.weapon_state[game.player.current_weapon]
+    weapon_name = C.WEAPONS[game.player.current_weapon]["name"]
+
+    status_text = ""
+    status_color = C.WHITE
+    if weapon_state["reloading"]:
+        status_text = "RELOADING..."
+        status_color = C.YELLOW
+    elif weapon_state["overheated"]:
+        status_text = "OVERHEATED!"
+        status_color = C.RED
+
+    if status_text:
+        text = renderer.small_font.render(status_text, True, status_color)
+        text_rect = text.get_rect(
+            center=(C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2 + 60)
+        )
+        renderer.screen.blit(text, text_rect)
+
+    ammo_val = game.player.ammo[game.player.current_weapon]
+    ammo_text = f"{weapon_name}: {weapon_state['clip']} / {ammo_val}"
+    bomb_text = f"BOMBS: {game.player.bombs}"
+
+    ammo_surface = renderer.font.render(ammo_text, True, C.WHITE)
+    bomb_surface = renderer.font.render(bomb_text, True, C.ORANGE)
+    ammo_rect = ammo_surface.get_rect(
+        bottomright=(C.SCREEN_WIDTH - 20, hud_bottom + 25)
+    )
+    bomb_rect = bomb_surface.get_rect(
+        bottomright=(C.SCREEN_WIDTH - 20, hud_bottom - 15)
+    )
+    renderer.screen.blit(ammo_surface, ammo_rect)
+    renderer.screen.blit(bomb_surface, bomb_rect)
+
+
+def render_weapon_slots(renderer: UIRenderer, game: Game) -> None:
+    """Render the weapon inventory slots."""
+    hud_bottom = C.SCREEN_HEIGHT - 80
+    inv_y = hud_bottom - 80
+
+    for weapon_name in (
+        "pistol",
+        "rifle",
+        "shotgun",
+        "laser",
+        "plasma",
+        "rocket",
+        "minigun",
+    ):
+        color = C.GRAY
+        if weapon_name in game.unlocked_weapons:
+            color = C.GREEN if weapon_name == game.player.current_weapon else C.WHITE
+
+        key_display = C.WEAPONS[weapon_name]["key"]
+        text_str = f"[{key_display}] {C.WEAPONS[weapon_name]['name']}"
+        inv_text = renderer.tiny_font.render(text_str, True, color)
+        inv_rect = inv_text.get_rect(bottomright=(C.SCREEN_WIDTH - 20, inv_y))
+        renderer.screen.blit(inv_text, inv_rect)
+        inv_y -= 25
+
+
+def render_level_info(renderer: UIRenderer, game: Game) -> None:
+    """Render level number, enemy count, and score."""
+    level_text = renderer.small_font.render(f"Level: {game.level}", True, C.YELLOW)
+    level_rect = level_text.get_rect(topright=(C.SCREEN_WIDTH - 20, 20))
+    renderer.screen.blit(level_text, level_rect)
+
+    bots_alive = sum(
+        1
+        for bot in game.bots
+        if bot.alive
+        and bot.enemy_type != "health_pack"
+        and C.ENEMY_TYPES[bot.enemy_type].get("visual_style") != "item"
+    )
+    kills_text = renderer.small_font.render(f"Enemies: {bots_alive}", True, C.RED)
+    kills_rect = kills_text.get_rect(topright=(C.SCREEN_WIDTH - 20, 50))
+    renderer.screen.blit(kills_text, kills_rect)
+
+    score = game.kills * 100
+    score_text = renderer.small_font.render(f"Score: {score}", True, C.YELLOW)
+    score_rect = score_text.get_rect(topright=(C.SCREEN_WIDTH - 20, 80))
+    renderer.screen.blit(score_text, score_rect)
+
+
+def render_minimap(renderer: UIRenderer, game: Game) -> None:
+    """Render the minimap when enabled."""
+    if game.show_minimap:
+        game.raycaster.render_minimap(
+            renderer.screen,
+            game.player,
+            game.bots,
+            game.visited_cells,
+            game.portal,
+        )
+
+
+def render_status_bars(renderer: UIRenderer, game: Game) -> None:
+    """Render shield, laser cooldown, and stamina bars."""
+    hud_bottom = C.SCREEN_HEIGHT - 80
+    health_x = 20
+    health_y = hud_bottom
+
+    shield_width = 150
+    shield_height = 10
+    shield_x = health_x
+    shield_y = health_y - 20
+
+    shield_pct = game.player.shield_timer / C.SHIELD_MAX_DURATION
+    pygame.draw.rect(
+        renderer.screen,
+        C.DARK_GRAY,
+        (shield_x, shield_y, shield_width, shield_height),
+    )
+    shield_rect = (
+        shield_x,
+        shield_y,
+        int(shield_width * shield_pct),
+        shield_height,
+    )
+    pygame.draw.rect(renderer.screen, C.CYAN, shield_rect)
+    border_rect = (shield_x, shield_y, shield_width, shield_height)
+    pygame.draw.rect(renderer.screen, C.WHITE, border_rect, 1)
+
+    if game.player.shield_recharge_delay > 0:
+        status_text = "RECHARGING" if game.player.shield_active else "COOLDOWN"
+        status_surf = renderer.tiny_font.render(status_text, True, C.WHITE)
+        renderer.screen.blit(status_surf, (shield_x + shield_width + 5, shield_y - 2))
+
+    laser_y = shield_y - 15
+    laser_pct = 1.0 - (game.player.secondary_cooldown / C.SECONDARY_COOLDOWN)
+    laser_pct = max(0, min(1, laser_pct))
+    bg_rect = (shield_x, laser_y, shield_width, shield_height)
+    pygame.draw.rect(renderer.screen, C.DARK_GRAY, bg_rect)
+    pygame.draw.rect(
+        renderer.screen,
+        (255, 50, 50),
+        (shield_x, laser_y, int(shield_width * laser_pct), shield_height),
+    )
+
+    stamina_y = laser_y - 15
+    stamina_pct = game.player.stamina / game.player.max_stamina
+    pygame.draw.rect(
+        renderer.screen,
+        C.DARK_GRAY,
+        (shield_x, stamina_y, shield_width, shield_height),
+    )
+    pygame.draw.rect(
+        renderer.screen,
+        (255, 255, 0),
+        (shield_x, stamina_y, int(shield_width * stamina_pct), shield_height),
+    )
+    if stamina_pct < 1.0:
+        stamina_text = renderer.tiny_font.render("STAMINA", True, C.WHITE)
+        renderer.screen.blit(
+            stamina_text,
+            (shield_x + shield_width + 5, stamina_y - 2),
+        )
+
+
+def render_messages(renderer: UIRenderer, game: Game) -> None:
+    """Render floating damage texts and messages."""
+    render_damage_texts(renderer, game.damage_texts)
+
+
+def render_controls_hint(renderer: UIRenderer) -> None:
+    """Render the controls hint text at the top of the screen."""
+    controls_hint = renderer.tiny_font.render(
+        "WASD:Move | 1-5:Wpn | R:Reload | F:Bomb | SPACE:Shield | M:Map | ESC:Menu",
+        True,
+        C.WHITE,
+    )
+    controls_hint_rect = controls_hint.get_rect(topleft=(10, 10))
+    bg_surface = pygame.Surface(
+        (
+            controls_hint_rect.width + C.HINT_BG_PADDING_H,
+            controls_hint_rect.height + C.HINT_BG_PADDING_V,
+        ),
+        pygame.SRCALPHA,
+    )
+    bg_surface.fill(C.HINT_BG_COLOR)
+    renderer.screen.blit(
+        bg_surface,
+        (
+            controls_hint_rect.x - C.HINT_BG_PADDING_H // 2,
+            controls_hint_rect.y - C.HINT_BG_PADDING_V // 2,
+        ),
+    )
+    renderer.screen.blit(controls_hint, controls_hint_rect)
+
+
+def render_pause_overlay(renderer: UIRenderer, game: Game) -> None:
+    """Render the pause menu overlay when the game is paused."""
+    if game.paused:
+        renderer._render_pause_menu()
+
+
+def render_damage_texts(renderer: UIRenderer, texts: list[DamageText]) -> None:
+    """Render floating damage text indicators."""
+    for text in texts:
+        surf = renderer.small_font.render(text["text"], True, text["color"])
+        rect = surf.get_rect(center=(int(text["x"]), int(text["y"])))
+        renderer.screen.blit(surf, rect)
+
+
+def render_damage_flash(renderer: UIRenderer, timer: int) -> None:
+    """Render red screen flash effect when player takes damage."""
+    if timer > 0:
+        alpha = int(100 * (timer / 10.0))
+        renderer.overlay_surface.fill(
+            (255, 0, 0, alpha),
+            special_flags=pygame.BLEND_RGBA_ADD,
+        )
+
+
+def render_shield_effect(renderer: UIRenderer, player: Player) -> None:
+    """Render shield activation visual effects and status."""
+    if player.shield_active:
+        pygame.draw.rect(
+            renderer.overlay_surface,
+            (*C.SHIELD_COLOR, C.SHIELD_ALPHA),
+            (0, 0, C.SCREEN_WIDTH, C.SCREEN_HEIGHT),
+        )
+        pygame.draw.rect(
+            renderer.overlay_surface,
+            C.SHIELD_COLOR,
+            (0, 0, C.SCREEN_WIDTH, C.SCREEN_HEIGHT),
+            10,
+        )
+
+        shield_text = renderer.title_font.render("SHIELD ACTIVE", True, C.SHIELD_COLOR)
+        renderer.screen.blit(
+            shield_text,
+            (C.SCREEN_WIDTH // 2 - shield_text.get_width() // 2, 100),
+        )
+
+        time_left = player.shield_timer / 60.0
+        timer_text = renderer.small_font.render(f"{time_left:.1f}s", True, C.WHITE)
+        renderer.screen.blit(
+            timer_text,
+            (C.SCREEN_WIDTH // 2 - timer_text.get_width() // 2, 160),
+        )
+
+        if player.shield_timer < 120 and (player.shield_timer // 10) % 2 == 0:
+            pygame.draw.rect(
+                renderer.overlay_surface,
+                (255, 0, 0, 50),
+                (0, 0, C.SCREEN_WIDTH, C.SCREEN_HEIGHT),
+            )
+
+    elif (
+        player.shield_timer == C.SHIELD_MAX_DURATION
+        and player.shield_recharge_delay <= 0
+    ):
+        ready_text = renderer.tiny_font.render("SHIELD READY", True, C.CYAN)
+        renderer.screen.blit(ready_text, (20, C.SCREEN_HEIGHT - 120))
+
+
+def render_low_health_tint(renderer: UIRenderer, player: Player) -> None:
+    """Render red screen tint when health is low."""
+    if player.health < 50:
+        alpha = int(100 * (1.0 - (player.health / 50.0)))
+        renderer.overlay_surface.fill(
+            (255, 0, 0, alpha),
+            special_flags=pygame.BLEND_RGBA_ADD,
+        )
+
+
+def render_crosshair(renderer: UIRenderer) -> None:
+    """Render the enhanced aiming crosshair at the center of the screen."""
+    center_x = C.SCREEN_WIDTH // 2
+    center_y = C.SCREEN_HEIGHT // 2
+    gap = 5
+    length = 10
+    color = (255, 255, 255)
+    outline = (0, 0, 0)
+
+    pygame.draw.line(
+        renderer.screen,
+        outline,
+        (center_x - length - 2, center_y),
+        (center_x - gap + 2, center_y),
+        4,
+    )
+    pygame.draw.line(
+        renderer.screen,
+        outline,
+        (center_x + gap - 2, center_y),
+        (center_x + length + 2, center_y),
+        4,
+    )
+    pygame.draw.line(
+        renderer.screen,
+        outline,
+        (center_x, center_y - length - 2),
+        (center_x, center_y - gap + 2),
+        4,
+    )
+    pygame.draw.line(
+        renderer.screen,
+        outline,
+        (center_x, center_y + gap - 2),
+        (center_x, center_y + length + 2),
+        4,
+    )
+
+    pygame.draw.line(
+        renderer.screen,
+        color,
+        (center_x - length, center_y),
+        (center_x - gap, center_y),
+        2,
+    )
+    pygame.draw.line(
+        renderer.screen,
+        color,
+        (center_x + gap, center_y),
+        (center_x + length, center_y),
+        2,
+    )
+    pygame.draw.line(
+        renderer.screen,
+        color,
+        (center_x, center_y - length),
+        (center_x, center_y - gap),
+        2,
+    )
+    pygame.draw.line(
+        renderer.screen,
+        color,
+        (center_x, center_y + gap),
+        (center_x, center_y + length),
+        2,
+    )
+
+    pygame.draw.circle(renderer.screen, outline, (center_x, center_y), 3)
+    pygame.draw.circle(renderer.screen, color, (center_x, center_y), 1)
+
+
+def render_secondary_charge(renderer: UIRenderer, player: Player) -> None:
+    """Render the secondary weapon charge bar."""
+    charge_pct = 1.0 - (player.secondary_cooldown / C.SECONDARY_COOLDOWN)
+    if charge_pct < 1.0:
+        bar_width = 40
+        bar_height = 4
+        center_x = C.SCREEN_WIDTH // 2
+        center_y = C.SCREEN_HEIGHT // 2 + 30
+        pygame.draw.rect(
+            renderer.screen,
+            C.DARK_GRAY,
+            (center_x - bar_width // 2, center_y, bar_width, bar_height),
+        )
+        pygame.draw.rect(
+            renderer.screen,
+            C.CYAN,
+            (
+                center_x - bar_width // 2,
+                center_y,
+                int(bar_width * charge_pct),
+                bar_height,
+            ),
+        )

--- a/src/games/Duum/src/ui_renderer.py
+++ b/src/games/Duum/src/ui_renderer.py
@@ -10,7 +10,7 @@ from games.shared.ui import Button
 from games.shared.ui_renderer_base import UIRendererBase
 
 from . import constants as C  # noqa: N812
-from . import ui_menu_views, ui_overlay_views, ui_progress_views
+from . import ui_hud_views, ui_menu_views, ui_overlay_views, ui_progress_views
 from .custom_types import DamageText
 
 try:
@@ -112,345 +112,67 @@ class UIRenderer(UIRendererBase):
 
     def render_hud(self, game: Game) -> None:
         """Render the heads-up display including health, ammo, and game stats."""
-        if not (game.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        if not (game.raycaster is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-
-        # Render overlays first
-        self.overlay_surface.fill((0, 0, 0, 0))
-        self._render_low_health_tint(game.player)
-        self._render_damage_flash(game.damage_flash_timer)
-        self._render_shield_effect(game.player)
-        self.screen.blit(self.overlay_surface, (0, 0))
-
-        # Vignette
-        self.screen.blit(self.vignette, (0, 0))
-
-        # Crosshair
-        self._render_crosshair()
-        self._render_secondary_charge(game.player)
-
-        # HUD elements
-        self._render_messages(game)
-        self._render_health_bar(game)
-        self._render_ammo_display(game)
-        self._render_weapon_slots(game)
-        self._render_level_info(game)
-        self._render_minimap(game)
-        self._render_status_bars(game)
-        self._render_controls_hint(game)
-        self._render_pause_overlay(game)
+        ui_hud_views.render_hud(self, game)
 
     def _render_health_bar(self, game: Game) -> None:
         """Render the player health bar."""
-        hud_bottom = C.SCREEN_HEIGHT - 80
-        health_width = 150
-        health_height = 25
-        health_x = 20
-        health_y = hud_bottom
-
-        pygame.draw.rect(
-            self.screen, C.DARK_GRAY, (health_x, health_y, health_width, health_height)
-        )
-        health_percent = max(0, game.player.health / game.player.max_health)
-        fill_width = int(health_width * health_percent)
-        health_color = C.RED
-        if health_percent > 0.5:
-            health_color = C.GREEN
-        elif health_percent > 0.25:
-            health_color = C.ORANGE
-        health_rect = (health_x, health_y, fill_width, health_height)
-        pygame.draw.rect(self.screen, health_color, health_rect)
-        pygame.draw.rect(
-            self.screen,
-            C.WHITE,
-            (health_x, health_y, health_width, health_height),
-            2,
-        )
+        ui_hud_views.render_health_bar(self, game)
 
     def _render_ammo_display(self, game: Game) -> None:
         """Render the ammo counter and weapon name."""
-        hud_bottom = C.SCREEN_HEIGHT - 80
-
-        w_state = game.player.weapon_state[game.player.current_weapon]
-        w_name = C.WEAPONS[game.player.current_weapon]["name"]
-
-        status_text = ""
-        status_color = C.WHITE
-        if w_state["reloading"]:
-            status_text = "RELOADING..."
-            status_color = C.YELLOW
-        elif w_state["overheated"]:
-            status_text = "OVERHEATED!"
-            status_color = C.RED
-
-        if status_text:
-            txt = self.small_font.render(status_text, True, status_color)
-            tr = txt.get_rect(center=(C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2 + 60))
-            self.screen.blit(txt, tr)
-
-        ammo_val = game.player.ammo[game.player.current_weapon]
-        ammo_text = f"{w_name}: {w_state['clip']} / {ammo_val}"
-        bomb_text = f"BOMBS: {game.player.bombs}"
-
-        at = self.font.render(ammo_text, True, C.WHITE)
-        bt = self.font.render(bomb_text, True, C.ORANGE)
-        at_rect = at.get_rect(bottomright=(C.SCREEN_WIDTH - 20, hud_bottom + 25))
-        bt_rect = bt.get_rect(bottomright=(C.SCREEN_WIDTH - 20, hud_bottom - 15))
-        self.screen.blit(at, at_rect)
-        self.screen.blit(bt, bt_rect)
+        ui_hud_views.render_ammo_display(self, game)
 
     def _render_weapon_slots(self, game: Game) -> None:
         """Render the weapon inventory slots."""
-        hud_bottom = C.SCREEN_HEIGHT - 80
-
-        inv_y = hud_bottom - 80
-        for w in ["pistol", "rifle", "shotgun", "laser", "plasma", "rocket", "minigun"]:
-            color = C.GRAY
-            if w in game.unlocked_weapons:
-                color = C.GREEN if w == game.player.current_weapon else C.WHITE
-
-            key_display = C.WEAPONS[w]["key"]
-            # Just use key from dict
-
-            text_str = f"[{key_display}] {C.WEAPONS[w]['name']}"
-            inv_txt = self.tiny_font.render(text_str, True, color)
-            inv_rect = inv_txt.get_rect(bottomright=(C.SCREEN_WIDTH - 20, inv_y))
-            self.screen.blit(inv_txt, inv_rect)
-            inv_y -= 25
+        ui_hud_views.render_weapon_slots(self, game)
 
     def _render_level_info(self, game: Game) -> None:
         """Render level number, enemy count, and score."""
-        level_text = self.small_font.render(f"Level: {game.level}", True, C.YELLOW)
-        level_rect = level_text.get_rect(topright=(C.SCREEN_WIDTH - 20, 20))
-        self.screen.blit(level_text, level_rect)
-
-        bots_alive = sum(
-            1
-            for bot in game.bots
-            if bot.alive
-            and bot.enemy_type != "health_pack"
-            and C.ENEMY_TYPES[bot.enemy_type].get("visual_style") != "item"
-        )
-        kills_text = self.small_font.render(f"Enemies: {bots_alive}", True, C.RED)
-        kills_rect = kills_text.get_rect(topright=(C.SCREEN_WIDTH - 20, 50))
-        self.screen.blit(kills_text, kills_rect)
-
-        # Score
-        score = game.kills * 100
-        score_text = self.small_font.render(f"Score: {score}", True, C.YELLOW)
-        score_rect = score_text.get_rect(topright=(C.SCREEN_WIDTH - 20, 80))
-        self.screen.blit(score_text, score_rect)
+        ui_hud_views.render_level_info(self, game)
 
     def _render_minimap(self, game: Game) -> None:
         """Render the minimap if enabled."""
-        if game.show_minimap:
-            game.raycaster.render_minimap(
-                self.screen, game.player, game.bots, game.visited_cells, game.portal
-            )
+        ui_hud_views.render_minimap(self, game)
 
     def _render_status_bars(self, game: Game) -> None:
         """Render shield bar, stamina bar, and laser charge bar."""
-        hud_bottom = C.SCREEN_HEIGHT - 80
-        health_x = 20
-        health_y = hud_bottom
-
-        shield_width = 150
-        shield_height = 10
-        shield_x = health_x
-        shield_y = health_y - 20
-
-        shield_pct = game.player.shield_timer / C.SHIELD_MAX_DURATION
-        pygame.draw.rect(
-            self.screen, C.DARK_GRAY, (shield_x, shield_y, shield_width, shield_height)
-        )
-        shield_rect = (
-            shield_x,
-            shield_y,
-            int(shield_width * shield_pct),
-            shield_height,
-        )
-        pygame.draw.rect(self.screen, C.CYAN, shield_rect)
-        border_rect = (shield_x, shield_y, shield_width, shield_height)
-        pygame.draw.rect(self.screen, C.WHITE, border_rect, 1)
-
-        if game.player.shield_recharge_delay > 0:
-            status_text = "RECHARGING" if game.player.shield_active else "COOLDOWN"
-            status_surf = self.tiny_font.render(status_text, True, C.WHITE)
-            self.screen.blit(status_surf, (shield_x + shield_width + 5, shield_y - 2))
-
-        # Laser Charge
-        laser_y = shield_y - 15
-        laser_pct = 1.0 - (game.player.secondary_cooldown / C.SECONDARY_COOLDOWN)
-        laser_pct = max(0, min(1, laser_pct))
-        bg_rect = (shield_x, laser_y, shield_width, shield_height)
-        pygame.draw.rect(self.screen, C.DARK_GRAY, bg_rect)
-        pygame.draw.rect(
-            self.screen,
-            (255, 50, 50),
-            (shield_x, laser_y, int(shield_width * laser_pct), shield_height),
-        )
-
-        # Stamina Bar
-        stamina_y = laser_y - 15
-        stamina_pct = game.player.stamina / game.player.max_stamina
-        pygame.draw.rect(
-            self.screen, C.DARK_GRAY, (shield_x, stamina_y, shield_width, shield_height)
-        )
-        pygame.draw.rect(
-            self.screen,
-            (255, 255, 0),
-            (shield_x, stamina_y, int(shield_width * stamina_pct), shield_height),
-        )
-        if stamina_pct < 1.0:
-            s_txt = self.tiny_font.render("STAMINA", True, C.WHITE)
-            self.screen.blit(s_txt, (shield_x + shield_width + 5, stamina_y - 2))
+        ui_hud_views.render_status_bars(self, game)
 
     def _render_messages(self, game: Game) -> None:
         """Render floating damage texts and messages."""
-        self._render_damage_texts(game.damage_texts)
+        ui_hud_views.render_messages(self, game)
 
     def _render_controls_hint(self, game: Game) -> None:
         """Render the controls hint text at the top of the screen."""
-        controls_hint = self.tiny_font.render(
-            "WASD:Move | 1-5:Wpn | R:Reload | F:Bomb | SPACE:Shield | M:Map | ESC:Menu",
-            True,
-            C.WHITE,
-        )
-        controls_hint_rect = controls_hint.get_rect(topleft=(10, 10))
-        bg_surface = pygame.Surface(
-            (
-                controls_hint_rect.width + C.HINT_BG_PADDING_H,
-                controls_hint_rect.height + C.HINT_BG_PADDING_V,
-            ),
-            pygame.SRCALPHA,
-        )
-        bg_surface.fill(C.HINT_BG_COLOR)
-        self.screen.blit(
-            bg_surface,
-            (
-                controls_hint_rect.x - C.HINT_BG_PADDING_H // 2,
-                controls_hint_rect.y - C.HINT_BG_PADDING_V // 2,
-            ),
-        )
-        self.screen.blit(controls_hint, controls_hint_rect)
+        ui_hud_views.render_controls_hint(self)
 
     def _render_pause_overlay(self, game: Game) -> None:
         """Render the pause menu overlay if the game is paused."""
-        if game.paused:
-            self._render_pause_menu()
+        ui_hud_views.render_pause_overlay(self, game)
 
     def _render_damage_texts(self, texts: list[DamageText]) -> None:
         """Render floating damage text indicators."""
-        for t in texts:
-            surf = self.small_font.render(t["text"], True, t["color"])
-            rect = surf.get_rect(center=(int(t["x"]), int(t["y"])))
-            self.screen.blit(surf, rect)
+        ui_hud_views.render_damage_texts(self, texts)
 
     def _render_damage_flash(self, timer: int) -> None:
         """Render red screen flash effect when player takes damage."""
-        if timer > 0:
-            alpha = int(100 * (timer / 10.0))
-            self.overlay_surface.fill(
-                (255, 0, 0, alpha), special_flags=pygame.BLEND_RGBA_ADD
-            )
+        ui_hud_views.render_damage_flash(self, timer)
 
     def _render_shield_effect(self, player: Player) -> None:
         """Render shield activation visual effects and status."""
-        if player.shield_active:
-            # Simple fill
-            pygame.draw.rect(
-                self.overlay_surface,
-                (*C.SHIELD_COLOR, C.SHIELD_ALPHA),
-                (0, 0, C.SCREEN_WIDTH, C.SCREEN_HEIGHT),
-            )
-            # Border
-            pygame.draw.rect(
-                self.overlay_surface,
-                C.SHIELD_COLOR,
-                (0, 0, C.SCREEN_WIDTH, C.SCREEN_HEIGHT),
-                10,
-            )
-
-            shield_text = self.title_font.render("SHIELD ACTIVE", True, C.SHIELD_COLOR)
-            self.screen.blit(
-                shield_text,
-                (C.SCREEN_WIDTH // 2 - shield_text.get_width() // 2, 100),
-            )
-
-            time_left = player.shield_timer / 60.0
-            timer_text = self.small_font.render(f"{time_left:.1f}s", True, C.WHITE)
-            self.screen.blit(
-                timer_text,
-                (C.SCREEN_WIDTH // 2 - timer_text.get_width() // 2, 160),
-            )
-
-            if player.shield_timer < 120 and (player.shield_timer // 10) % 2 == 0:
-                pygame.draw.rect(
-                    self.overlay_surface,
-                    (255, 0, 0, 50),
-                    (0, 0, C.SCREEN_WIDTH, C.SCREEN_HEIGHT),
-                )
-
-        elif (
-            player.shield_timer == C.SHIELD_MAX_DURATION
-            and player.shield_recharge_delay <= 0
-        ):
-            ready_text = self.tiny_font.render("SHIELD READY", True, C.CYAN)
-            self.screen.blit(ready_text, (20, C.SCREEN_HEIGHT - 120))
+        ui_hud_views.render_shield_effect(self, player)
 
     def _render_low_health_tint(self, player: Player) -> None:
         """Render red screen tint when health is low."""
-        if player.health < 50:
-            alpha = int(100 * (1.0 - (player.health / 50.0)))
-            self.overlay_surface.fill(
-                (255, 0, 0, alpha), special_flags=pygame.BLEND_RGBA_ADD
-            )
+        ui_hud_views.render_low_health_tint(self, player)
 
     def _render_crosshair(self) -> None:
         """Render the aiming crosshair at the center of the screen."""
-        cx = C.SCREEN_WIDTH // 2
-        cy = C.SCREEN_HEIGHT // 2
-
-        # Enhanced crosshair with outline and gap
-        gap = 5
-        length = 10
-        color = (255, 255, 255)
-        outline = (0, 0, 0)
-
-        # Draw outline (thicker lines behind)
-        ln, gp = length, gap
-        pygame.draw.line(self.screen, outline, (cx - ln - 2, cy), (cx - gp + 2, cy), 4)
-        pygame.draw.line(self.screen, outline, (cx + gp - 2, cy), (cx + ln + 2, cy), 4)
-        pygame.draw.line(self.screen, outline, (cx, cy - ln - 2), (cx, cy - gp + 2), 4)
-        pygame.draw.line(self.screen, outline, (cx, cy + gp - 2), (cx, cy + ln + 2), 4)
-
-        # Draw main lines
-        pygame.draw.line(self.screen, color, (cx - length, cy), (cx - gap, cy), 2)
-        pygame.draw.line(self.screen, color, (cx + gap, cy), (cx + length, cy), 2)
-        pygame.draw.line(self.screen, color, (cx, cy - length), (cx, cy - gap), 2)
-        pygame.draw.line(self.screen, color, (cx, cy + gap), (cx, cy + length), 2)
-
-        # Center dot
-        pygame.draw.circle(self.screen, outline, (cx, cy), 3)
-        pygame.draw.circle(self.screen, color, (cx, cy), 1)
+        ui_hud_views.render_crosshair(self)
 
     def _render_secondary_charge(self, player: Player) -> None:
         """Render secondary weapon charge bar."""
-        charge_pct = 1.0 - (player.secondary_cooldown / C.SECONDARY_COOLDOWN)
-        if charge_pct < 1.0:
-            bar_w = 40
-            bar_h = 4
-            cx, cy = C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2 + 30
-            pygame.draw.rect(
-                self.screen, C.DARK_GRAY, (cx - bar_w // 2, cy, bar_w, bar_h)
-            )
-            pygame.draw.rect(
-                self.screen,
-                C.CYAN,
-                (cx - bar_w // 2, cy, int(bar_w * charge_pct), bar_h),
-            )
+        ui_hud_views.render_secondary_charge(self, player)
 
     def _render_pause_menu(self) -> None:
         """Render the pause menu overlay."""

--- a/tests/Duum/test_ui_renderer.py
+++ b/tests/Duum/test_ui_renderer.py
@@ -134,6 +134,12 @@ class TestUIRenderer:
         renderer = UIRenderer(mock_screen)
         renderer.render_hud(mock_game)
 
+    def test_render_hud_delegates_to_hud_views(self, mock_screen, mock_game):
+        renderer = UIRenderer(mock_screen)
+        with patch("games.Duum.src.ui_renderer.ui_hud_views.render_hud") as render_hud:
+            renderer.render_hud(mock_game)
+        render_hud.assert_called_once_with(renderer, mock_game)
+
     def test_render_hud_paused(self, mock_screen, mock_game):
         # Additional coverage for paused mode
         mock_game.paused = True
@@ -214,6 +220,14 @@ class TestUIRenderer:
         ) as render_pause_menu:
             renderer._render_pause_menu()
         render_pause_menu.assert_called_once_with(renderer)
+
+    def test_render_crosshair_delegates_to_hud_views(self, mock_screen):
+        renderer = UIRenderer(mock_screen)
+        with patch(
+            "games.Duum.src.ui_renderer.ui_hud_views.render_crosshair"
+        ) as render_crosshair:
+            renderer._render_crosshair()
+        render_crosshair.assert_called_once_with(renderer)
 
     def test_blood_drips(self, mock_screen):
         renderer = UIRenderer(mock_screen)


### PR DESCRIPTION
## Summary
- extract Duum gameplay HUD helpers into `ui_hud_views.py`
- keep `UIRenderer` as the public facade while delegating HUD responsibilities to the helper module
- add seam tests around the new HUD delegation points and refresh `SPEC.md`

## Testing
- python3 -m pytest tests/Duum/test_ui_renderer.py -q
- python3 -m pytest tests/Duum -q
- python3 -m ruff check src/games/Duum/src/ui_renderer.py src/games/Duum/src/ui_hud_views.py tests/Duum/test_ui_renderer.py
- python3 -m ruff format --check src/games/Duum/src/ui_renderer.py src/games/Duum/src/ui_hud_views.py tests/Duum/test_ui_renderer.py
- git diff --check

Partial progress on #721.