### PR TITLE
refactor(#721): extract Duum weapon system from game facade

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.15                                               |
+| **Spec Version**        | 1.1.16                                               |
 | **Last Spec Update**    | 2026-04-10                                           |
 
 ## 2. Purpose & Mission
@@ -113,7 +113,7 @@ Games/
 | Game Launcher         | `src/games/`                     | Central entry point, game discovery, selection UI, execution orchestration      |
 | Force Field Engine    | `src/games/Force_Field/engine/`  | Raycasting renderer, 3D-to-2D projection, collision detection                   |
 | Force Field Runtime   | `src/games/Force_Field/src/`     | Thin game facade plus extracted loop, session, combat, gameplay, screen-flow, and HUD view helper subsystems |
-| Duum Screen Flow      | `src/games/Duum/src/`            | Thin Duum game facade with delegated per-screen event handling, extracted loop dispatch, gameplay updates, ambient-state management, and HUD view helpers |
+| Duum Screen Flow      | `src/games/Duum/src/`            | Thin Duum game facade with delegated per-screen event handling, extracted loop dispatch, gameplay updates, ambient-state management, HUD view helpers, and weapon-system orchestration |
 | Zombie Gameplay Flow  | `src/games/Zombie_Survival/src/` | Thin Zombie Survival game facade with delegated screen handling, extracted gameplay updates, loop dispatch, ambient-state management, and HUD view helpers |
 | Duum Level Generation | `src/games/Duum/levels/`         | Procedural dungeon generation, room connectivity                                |
 | Tetris Logic          | `src/games/Tetris/`              | Piece mechanics, board state, gravity, line clearing                            |
@@ -408,6 +408,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.1.16  | Partially addressed issue `#721` by extracting Duum weapon/combat orchestration out of `src/games/Duum/src/game.py` into `weapon_system.py`, keeping `Game` as the public façade, and adding focused weapon-system plus delegation tests around the new seam. |
 | 2026-04-10 | 1.1.15  | Partially addressed issue `#721` by extracting Force Field and Duum HUD rendering out of their respective `ui_renderer.py` files into `ui_hud_views.py` modules, keeping `UIRenderer` as the public façade, and adding seam tests around the new HUD delegation points. Force Field `ui_renderer.py` reduced from 556 → 260 lines; Duum from 594 → 254 lines. |
 | 2026-04-10 | 1.1.14  | Partially addressed issue `#721` by extracting Zombie Survival HUD rendering out of `src/games/Zombie_Survival/src/ui_renderer.py` into `ui_hud_views.py`, keeping `UIRenderer` as the public façade, and adding seam tests around the new HUD delegation points.                                                                                                                                                                                            |
 | 2026-04-10 | 1.1.13  | Partially addressed issue `#721` by extracting Zombie Survival session/level progression out of `src/games/Zombie_Survival/src/game.py` into `progression_flow.py`, delegating full-game start, level start, game-over, and portal-completion transitions through a focused helper module, and adding seam tests around the extracted progression behavior.                                                                                                  |

--- a/src/games/Duum/src/game.py
+++ b/src/games/Duum/src/game.py
@@ -5,11 +5,8 @@ import random
 
 import pygame
 
-from games.shared.combat_manager import ShotResolutionRequest
 from games.shared.config import RaycasterConfig
 from games.shared.constants import (
-    MINIGUN_BULLETS_PER_SHOT,
-    MINIGUN_SPREAD,
     PORTAL_RADIUS_SQ,
     GameState,
 )
@@ -34,6 +31,7 @@ from .screen_event_handler import ScreenEventHandler
 from .sound import SoundManager
 from .spawn_manager import DuumSpawnManager
 from .ui_renderer import UIRenderer
+from .weapon_system import WeaponSystem
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +139,7 @@ class Game(FPSGameBase):
         )
         self.atmosphere_manager = AtmosphereManager(self)
         self.screen_event_handler = ScreenEventHandler(self)
+        self.weapon_system = WeaponSystem(self)
 
         # Input
         self.joystick = None
@@ -192,12 +191,16 @@ class Game(FPSGameBase):
             lambda **kw: self.sound_manager.play_sound("scream"),
         )
 
-    def _sync_combat_state(self) -> None:
+    def sync_combat_state(self) -> None:
         """Synchronize kill/combo state from the combat manager back to Game."""
         self.kills = self.combat_manager.kills
         self.kill_combo_count = self.combat_manager.kill_combo_count
         self.kill_combo_timer = self.combat_manager.kill_combo_timer
         self.last_death_pos = self.combat_manager.last_death_pos
+
+    def _sync_combat_state(self) -> None:
+        """Backward-compatible wrapper for older internal call sites."""
+        self.sync_combat_state()
 
     def start_game(self) -> None:
         """Start new game"""
@@ -329,90 +332,13 @@ class Game(FPSGameBase):
     # _handle_pause_menu_click, _handle_gameplay_mouse_click,
     # handle_game_events, and save_game are inherited from FPSGameBase.
 
-    _FIRE_DISPATCH: dict[str, str] = {
-        "hitscan": "_fire_hitscan",
-        "projectile": "_fire_projectile",
-        "spread": "_fire_spread",
-        "beam": "_fire_beam",
-        "burst": "_fire_burst",
-    }
+    # ------------------------------------------------------------------
+    # Weapon firing — delegated to WeaponSystem
+    # ------------------------------------------------------------------
 
     def fire_weapon(self, is_secondary: bool = False) -> None:
         """Handle weapon firing via data-driven dispatch."""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        weapon_name = self.player.current_weapon
-        weapon_data = C.WEAPONS[weapon_name]
-
-        # Sound
-        self.sound_manager.play_sound(f"shoot_{weapon_name}")
-
-        # Muzzle Flash Light
-        self.flash_intensity = 0.8
-
-        if is_secondary:
-            self.check_shot_hit(is_secondary=True)
-            return
-
-        fire_mode = weapon_data.get("fire_mode", "hitscan")
-        handler = getattr(self, self._FIRE_DISPATCH[fire_mode])
-        handler(weapon_data, weapon_name)
-
-    def _fire_hitscan(self, weapon_data: dict, weapon_name: str) -> None:
-        """Fire a single hitscan ray."""
-        self.check_shot_hit(is_secondary=False)
-
-    def _fire_projectile(self, weapon_data: dict, weapon_name: str) -> None:
-        """Spawn a projectile based on weapon data."""
-        size_map = {"plasma": 0.225, "rocket": 0.3}
-        p = Projectile(
-            self.player.x,
-            self.player.y,
-            self.player.angle,
-            speed=float(weapon_data.get("projectile_speed", 0.5)),
-            damage=self.player.get_current_weapon_damage(),
-            is_player=True,
-            color=weapon_data.get("projectile_color", (0, 255, 255)),
-            size=size_map.get(weapon_name, 0.3),
-            weapon_type=weapon_name,
-        )
-        self.entity_manager.add_projectile(p)
-
-    def _fire_spread(self, weapon_data: dict, weapon_name: str) -> None:
-        """Fire multiple pellets with spread."""
-        pellets = int(weapon_data.get("pellets", 8))
-        spread = float(weapon_data.get("spread", 0.15))
-        for _ in range(pellets):
-            angle_off = random.uniform(-spread, spread)
-            self.check_shot_hit(angle_offset=angle_off)
-
-    def _fire_beam(self, weapon_data: dict, weapon_name: str) -> None:
-        """Fire a hitscan beam with visual trail."""
-        self.check_shot_hit(is_secondary=False, is_laser=True)
-
-    def _fire_burst(self, weapon_data: dict, weapon_name: str) -> None:
-        """Fire a burst of fast projectiles."""
-        damage = self.player.get_current_weapon_damage()
-        num_bullets = MINIGUN_BULLETS_PER_SHOT
-        for _ in range(num_bullets):
-            angle_off = random.uniform(-MINIGUN_SPREAD, MINIGUN_SPREAD)
-            final_angle = self.player.angle + angle_off
-            p = Projectile(
-                self.player.x,
-                self.player.y,
-                final_angle,
-                damage,
-                speed=2.0,
-                is_player=True,
-                color=(255, 255, 0),
-                size=0.1,
-                weapon_type="minigun",
-            )
-            self.entity_manager.add_projectile(p)
-
-        self.particle_system.add_explosion(
-            C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2, count=8, color=(255, 255, 0)
-        )
+        self.weapon_system.fire_weapon(is_secondary=is_secondary)
 
     def check_shot_hit(
         self,
@@ -421,68 +347,27 @@ class Game(FPSGameBase):
         is_laser: bool = False,
     ) -> None:
         """Delegate hitscan hit detection to the combat manager."""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        if not (self.raycaster is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        self.damage_texts = self.combat_manager.check_shot_hit(
-            ShotResolutionRequest(
-                player=self.player,
-                raycaster=self.raycaster,
-                bots=self.bots,
-                damage_texts=self.damage_texts,
-                show_damage=self.show_damage,
-                is_secondary=is_secondary,
-                angle_offset=angle_offset,
-                is_laser=is_laser,
-            )
+        self.weapon_system.check_shot_hit(
+            is_secondary=is_secondary,
+            angle_offset=angle_offset,
+            is_laser=is_laser,
         )
-        self._sync_combat_state()
 
     def handle_bomb_explosion(self) -> None:
         """Delegate bomb explosion to the combat manager."""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        self.damage_texts = self.combat_manager.handle_bomb_explosion(
-            player=self.player,
-            bots=self.bots,
-            damage_texts=self.damage_texts,
-        )
-        self._sync_combat_state()
+        self.weapon_system.handle_bomb_explosion()
 
     def explode_laser(self, impact_x: float, impact_y: float) -> None:
         """Delegate laser explosion to the combat manager."""
-        self.damage_texts = self.combat_manager.explode_laser(
-            impact_x, impact_y, self.damage_texts
-        )
-        self._sync_combat_state()
+        self.weapon_system.explode_laser(impact_x, impact_y)
 
     def explode_plasma(self, projectile: Projectile) -> None:
         """Delegate plasma explosion to the combat manager."""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        self.damage_flash_timer = self.combat_manager.explode_generic(
-            projectile,
-            C.PLASMA_AOE_RADIUS,
-            "plasma",
-            self.player,
-            self.damage_flash_timer,
-        )
-        self._sync_combat_state()
+        self.weapon_system.explode_plasma(projectile)
 
     def explode_rocket(self, projectile: Projectile) -> None:
         """Delegate rocket explosion to the combat manager."""
-        if not (self.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-        radius = float(C.WEAPONS["rocket"].get("aoe_radius", 6.0))
-        self.damage_flash_timer = self.combat_manager.explode_generic(
-            projectile,
-            radius,
-            "rocket",
-            self.player,
-            self.damage_flash_timer,
-        )
-        self._sync_combat_state()
+        self.weapon_system.explode_rocket(projectile)
 
     def _check_game_over(self) -> bool:
         if not self.player.alive:

--- a/src/games/Duum/src/weapon_system.py
+++ b/src/games/Duum/src/weapon_system.py
@@ -1,0 +1,191 @@
+"""Weapon firing system for Duum.
+
+Extracted from game.py to keep that file within the repository's size budget.
+Provides WeaponSystem, a focused helper that owns fire-mode dispatch, hitscan
+checks, projectile spawning, and explosion delegation.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING, Any
+
+from games.shared.combat_manager import ShotResolutionRequest
+from games.shared.constants import MINIGUN_BULLETS_PER_SHOT, MINIGUN_SPREAD
+
+from . import constants as C  # noqa: N812
+from .projectile import Projectile
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+class WeaponSystem:
+    """Handle weapon firing and combat delegation on behalf of Game."""
+
+    _FIRE_DISPATCH: dict[str, str] = {
+        "hitscan": "_fire_hitscan",
+        "projectile": "_fire_projectile",
+        "spread": "_fire_spread",
+        "beam": "_fire_beam",
+        "burst": "_fire_burst",
+    }
+
+    def __init__(self, game: Game) -> None:
+        """Store a back-reference to the owning game."""
+        self._game = game
+
+    def fire_weapon(self, is_secondary: bool = False) -> None:
+        """Handle weapon firing via data-driven dispatch."""
+        game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
+        weapon_name = game.player.current_weapon
+        weapon_data = C.WEAPONS[weapon_name]
+
+        game.sound_manager.play_sound(f"shoot_{weapon_name}")
+        game.flash_intensity = 0.8
+
+        if is_secondary:
+            self.check_shot_hit(is_secondary=True)
+            return
+
+        fire_mode = weapon_data.get("fire_mode", "hitscan")
+        handler = getattr(self, self._FIRE_DISPATCH[fire_mode])
+        handler(weapon_data, weapon_name)
+
+    def check_shot_hit(
+        self,
+        is_secondary: bool = False,
+        angle_offset: float = 0.0,
+        is_laser: bool = False,
+    ) -> None:
+        """Delegate hitscan hit detection to the combat manager."""
+        game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
+        if not (game.raycaster is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
+        game.damage_texts = game.combat_manager.check_shot_hit(
+            ShotResolutionRequest(
+                player=game.player,
+                raycaster=game.raycaster,
+                bots=game.bots,
+                damage_texts=game.damage_texts,
+                show_damage=game.show_damage,
+                is_secondary=is_secondary,
+                angle_offset=angle_offset,
+                is_laser=is_laser,
+            )
+        )
+        game.sync_combat_state()
+
+    def handle_bomb_explosion(self) -> None:
+        """Delegate bomb explosion to the combat manager."""
+        game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
+        game.damage_texts = game.combat_manager.handle_bomb_explosion(
+            player=game.player,
+            bots=game.bots,
+            damage_texts=game.damage_texts,
+        )
+        game.sync_combat_state()
+
+    def explode_laser(self, impact_x: float, impact_y: float) -> None:
+        """Delegate laser explosion to the combat manager."""
+        game = self._game
+        game.damage_texts = game.combat_manager.explode_laser(
+            impact_x, impact_y, game.damage_texts
+        )
+        game.sync_combat_state()
+
+    def explode_plasma(self, projectile: Projectile) -> None:
+        """Delegate plasma explosion to the combat manager."""
+        game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
+        game.damage_flash_timer = game.combat_manager.explode_generic(
+            projectile,
+            C.PLASMA_AOE_RADIUS,
+            "plasma",
+            game.player,
+            game.damage_flash_timer,
+        )
+        game.sync_combat_state()
+
+    def explode_rocket(self, projectile: Projectile) -> None:
+        """Delegate rocket explosion to the combat manager."""
+        game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
+        radius = float(C.WEAPONS["rocket"].get("aoe_radius", 6.0))
+        game.damage_flash_timer = game.combat_manager.explode_generic(
+            projectile,
+            radius,
+            "rocket",
+            game.player,
+            game.damage_flash_timer,
+        )
+        game.sync_combat_state()
+
+    def _fire_hitscan(self, weapon_data: dict[str, Any], weapon_name: str) -> None:
+        """Fire a single hitscan ray."""
+        self.check_shot_hit(is_secondary=False)
+
+    def _fire_projectile(self, weapon_data: dict[str, Any], weapon_name: str) -> None:
+        """Spawn a projectile based on weapon data."""
+        game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
+        size_map = {"plasma": 0.225, "rocket": 0.3}
+        projectile = Projectile(
+            game.player.x,
+            game.player.y,
+            game.player.angle,
+            speed=float(weapon_data.get("projectile_speed", 0.5)),
+            damage=game.player.get_current_weapon_damage(),
+            is_player=True,
+            color=weapon_data.get("projectile_color", (0, 255, 255)),
+            size=size_map.get(weapon_name, 0.3),
+            weapon_type=weapon_name,
+        )
+        game.entity_manager.add_projectile(projectile)
+
+    def _fire_spread(self, weapon_data: dict[str, Any], weapon_name: str) -> None:
+        """Fire multiple pellets with spread."""
+        pellets = int(weapon_data.get("pellets", 8))
+        spread = float(weapon_data.get("spread", 0.15))
+        for _ in range(pellets):
+            angle_off = random.uniform(-spread, spread)
+            self.check_shot_hit(angle_offset=angle_off)
+
+    def _fire_beam(self, weapon_data: dict[str, Any], weapon_name: str) -> None:
+        """Fire a hitscan beam with visual trail."""
+        self.check_shot_hit(is_secondary=False, is_laser=True)
+
+    def _fire_burst(self, weapon_data: dict[str, Any], weapon_name: str) -> None:
+        """Fire a burst of fast projectiles."""
+        game = self._game
+        if not (game.player is not None):
+            raise ValueError("DbC Blocked: Precondition failed.")
+        damage = game.player.get_current_weapon_damage()
+        for _ in range(MINIGUN_BULLETS_PER_SHOT):
+            angle_off = random.uniform(-MINIGUN_SPREAD, MINIGUN_SPREAD)
+            final_angle = game.player.angle + angle_off
+            projectile = Projectile(
+                game.player.x,
+                game.player.y,
+                final_angle,
+                damage,
+                speed=2.0,
+                is_player=True,
+                color=(255, 255, 0),
+                size=0.1,
+                weapon_type="minigun",
+            )
+            game.entity_manager.add_projectile(projectile)
+
+        game.particle_system.add_explosion(
+            C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2, count=8, color=(255, 255, 0)
+        )

--- a/tests/Duum/test_weapon_system.py
+++ b/tests/Duum/test_weapon_system.py
@@ -1,0 +1,151 @@
+"""Focused tests for the extracted Duum weapon system."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from games.Duum.src.game import Game
+from games.Duum.src.projectile import Projectile
+from games.Duum.src.weapon_system import WeaponSystem
+from games.shared.constants import MINIGUN_BULLETS_PER_SHOT
+
+
+def _make_game(weapon_name: str = "pistol") -> MagicMock:
+    """Build a lightweight Duum game stub for weapon-system tests."""
+    game = MagicMock()
+    player = MagicMock()
+    player.x = 5.0
+    player.y = 7.0
+    player.angle = 0.25
+    player.current_weapon = weapon_name
+    player.get_current_weapon_damage.return_value = 25
+
+    game.player = player
+    game.bots = []
+    game.damage_texts = []
+    game.damage_flash_timer = 0
+    game.show_damage = False
+    game.flash_intensity = 0.0
+    game.raycaster = MagicMock()
+    game.entity_manager = MagicMock()
+    game.particle_system = MagicMock()
+    game.combat_manager = MagicMock()
+    game.sound_manager = MagicMock()
+    game.sync_combat_state = MagicMock()
+    return game
+
+
+def test_fire_weapon_secondary_delegates_to_hitscan() -> None:
+    game = _make_game("pistol")
+    weapon_system = WeaponSystem(game)
+
+    with patch.object(weapon_system, "check_shot_hit") as check_shot_hit:
+        weapon_system.fire_weapon(is_secondary=True)
+
+    game.sound_manager.play_sound.assert_called_once_with("shoot_pistol")
+    check_shot_hit.assert_called_once_with(is_secondary=True)
+    assert game.flash_intensity == 0.8
+
+
+def test_fire_weapon_projectile_adds_projectile() -> None:
+    game = _make_game("plasma")
+    weapon_system = WeaponSystem(game)
+
+    weapon_system.fire_weapon()
+
+    game.entity_manager.add_projectile.assert_called_once()
+    projectile = game.entity_manager.add_projectile.call_args.args[0]
+    assert isinstance(projectile, Projectile)
+    assert projectile.weapon_type == "plasma"
+
+
+def test_fire_spread_calls_hitscan_for_each_pellet() -> None:
+    from games.Duum.src import constants as C  # noqa: N812
+
+    game = _make_game("shotgun")
+    weapon_system = WeaponSystem(game)
+
+    with patch.object(weapon_system, "check_shot_hit") as check_shot_hit:
+        weapon_system._fire_spread(C.WEAPONS["shotgun"], "shotgun")
+
+    assert check_shot_hit.call_count == int(C.WEAPONS["shotgun"].get("pellets", 8))
+
+
+def test_fire_burst_adds_projectiles_and_muzzle_explosion() -> None:
+    game = _make_game("minigun")
+    weapon_system = WeaponSystem(game)
+
+    weapon_system.fire_weapon()
+
+    assert game.entity_manager.add_projectile.call_count == MINIGUN_BULLETS_PER_SHOT
+    game.particle_system.add_explosion.assert_called_once()
+
+
+def test_check_shot_hit_updates_damage_texts_and_syncs_state() -> None:
+    game = _make_game("rifle")
+    weapon_system = WeaponSystem(game)
+    expected_texts = [{"text": "hit"}]
+    game.combat_manager.check_shot_hit.return_value = expected_texts
+
+    weapon_system.check_shot_hit(is_laser=True, angle_offset=0.1)
+
+    request = game.combat_manager.check_shot_hit.call_args.args[0]
+    assert request.player is game.player
+    assert request.raycaster is game.raycaster
+    assert request.is_laser is True
+    assert request.angle_offset == 0.1
+    assert game.damage_texts == expected_texts
+    game.sync_combat_state.assert_called_once_with()
+
+
+def test_handle_bomb_explosion_updates_damage_texts_and_syncs_state() -> None:
+    game = _make_game()
+    weapon_system = WeaponSystem(game)
+    game.combat_manager.handle_bomb_explosion.return_value = [{"text": "boom"}]
+
+    weapon_system.handle_bomb_explosion()
+
+    assert game.damage_texts == [{"text": "boom"}]
+    game.sync_combat_state.assert_called_once_with()
+
+
+def test_explode_rocket_updates_flash_timer_and_syncs_state() -> None:
+    game = _make_game("rocket")
+    weapon_system = WeaponSystem(game)
+    projectile = MagicMock(spec=Projectile)
+    game.combat_manager.explode_generic.return_value = 9
+
+    weapon_system.explode_rocket(projectile)
+
+    assert game.damage_flash_timer == 9
+    game.sync_combat_state.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args", "kwargs"),
+    [
+        ("fire_weapon", (), {"is_secondary": True}),
+        (
+            "check_shot_hit",
+            (),
+            {"is_secondary": True, "angle_offset": 0.2, "is_laser": True},
+        ),
+        ("handle_bomb_explosion", (), {}),
+        ("explode_laser", (1.0, 2.0), {}),
+        ("explode_plasma", (MagicMock(spec=Projectile),), {}),
+        ("explode_rocket", (MagicMock(spec=Projectile),), {}),
+    ],
+)
+def test_game_weapon_methods_delegate_to_weapon_system(
+    method_name: str,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> None:
+    game = Game.__new__(Game)
+    game.weapon_system = MagicMock()
+
+    getattr(Game, method_name)(game, *args, **kwargs)
+
+    getattr(game.weapon_system, method_name).assert_called_once_with(*args, **kwargs)


### PR DESCRIPTION
## Summary
- extract Duum weapon and combat orchestration from `src/games/Duum/src/game.py` into `weapon_system.py`
- keep `Game` as the public facade via delegation methods
- add focused weapon-system and delegation tests for the new seam

## Validation
- `python3 -m pytest tests/Duum/test_weapon_system.py tests/Duum/test_entity_manager.py tests/Duum/test_gameplay_updater.py -q`
- `python3 -m ruff check src/games/Duum/src/game.py src/games/Duum/src/weapon_system.py tests/Duum/test_weapon_system.py`
- `python3 -m ruff format --check src/games/Duum/src/game.py src/games/Duum/src/weapon_system.py tests/Duum/test_weapon_system.py`
- `git diff --check`

## Impact
- `src/games/Duum/src/game.py` reduced from 611 to 496 lines