### PR TITLE
[codex] Introduce parameter objects for render helpers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.17                                               |
+| **Spec Version**        | 1.1.18                                               |
 | **Last Spec Update**    | 2026-04-11                                           |
 
 ## 2. Purpose & Mission
@@ -139,7 +139,7 @@ Games/
 | F6  | Zombie Survival (Web 3D)        | ✅     | Web-based 3D game using Three.js, multiplayer-ready backend, spawn waves, survival mechanics          |
 | F7  | QuatGolf (Quaternion Golf)      | 🔄     | Golf game with quaternion-based ball rotation physics, procedural courses, AI opponents               |
 | F8  | Unified Launcher                | ✅     | Central game selection interface, launch management, window handling, game exit/resume                |
-| F9  | Shared Rendering Infrastructure | ✅     | Common rendering abstractions supporting 2D drawing, sprite management, color/texture handling        |
+| F9  | Shared Rendering Infrastructure | ✅     | Common rendering abstractions supporting 2D drawing, sprite management, color/texture handling, and immutable raycaster render contexts        |
 
 ### API / Interface Contract
 
@@ -408,6 +408,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-11 | 1.1.18  | Introduced immutable parameter objects for the raycaster sprite, textured wall, and minimap render helpers, updated the raycaster wrappers to pass those render contexts, and added validation coverage for the new bundles. |
 | 2026-04-10 | 1.1.16  | Partially addressed issue `#721` by extracting Duum weapon/combat orchestration out of `src/games/Duum/src/game.py` into `weapon_system.py`, keeping `Game` as the public façade, and adding focused weapon-system plus delegation tests around the new seam. |
 | 2026-04-10 | 1.1.15  | Partially addressed issue `#721` by extracting Force Field and Duum HUD rendering out of their respective `ui_renderer.py` files into `ui_hud_views.py` modules, keeping `UIRenderer` as the public façade, and adding seam tests around the new HUD delegation points. Force Field `ui_renderer.py` reduced from 556 → 260 lines; Duum from 594 → 254 lines. |
 | 2026-04-10 | 1.1.14  | Partially addressed issue `#721` by extracting Zombie Survival HUD rendering out of `src/games/Zombie_Survival/src/ui_renderer.py` into `ui_hud_views.py`, keeping `UIRenderer` as the public façade, and adding seam tests around the new HUD delegation points.                                                                                                                                                                                            |

--- a/src/games/shared/raycaster.py
+++ b/src/games/shared/raycaster.py
@@ -16,6 +16,11 @@ from .raycaster_math import (
     init_dda_params,
     perform_dda_loop,
 )
+from .raycaster_render_contexts import (
+    MinimapRenderContext,
+    SpriteRenderContext,
+    TexturedWallColumnContext,
+)
 from .raycaster_rendering import (
     generate_background_surface as _generate_background_surface_fn,
 )
@@ -354,7 +359,9 @@ class Raycaster:
             self.grid = self.game_map.grid
             self.np_grid = np.array(self.game_map.grid, dtype=np.int8)
 
-    def _calculate_rays(self, player: Player) -> tuple[
+    def _calculate_rays(
+        self, player: Player
+    ) -> tuple[
         np.ndarray[Any, np.dtype[Any]],
         np.ndarray[Any, np.dtype[Any]],
         np.ndarray[Any, np.dtype[Any]],
@@ -641,22 +648,24 @@ class Raycaster:
     ) -> None:
         """Render a single textured wall column with shading and fog."""
         render_textured_wall_column(
-            i,
-            wt,
-            h,
-            top,
-            wall_x_hit,
-            shade,
-            fog,
-            wall_strips,
-            wall_colors,
-            view_surface,
-            blits_sequence,
-            self.config.GRAY,
-            self.texture_map,
-            self.shading_surfaces,
-            self.fog_surfaces,
-            self._get_cached_strip,
+            TexturedWallColumnContext(
+                i,
+                wt,
+                h,
+                top,
+                wall_x_hit,
+                shade,
+                fog,
+                wall_strips,
+                wall_colors,
+                view_surface,
+                blits_sequence,
+                self.config.GRAY,
+                self.texture_map,
+                self.shading_surfaces,
+                self.fog_surfaces,
+                self._get_cached_strip,
+            )
         )
 
     def _render_solid_wall(
@@ -699,25 +708,27 @@ class Raycaster:
         Delegates to raycaster_sprites module for the actual rendering logic.
         """
         _render_sprites_fn(
-            player,
-            bots,
-            projectiles,
-            particles,
-            half_fov,
-            view_offset_y,
-            flash_intensity,
-            self.config,
-            self.num_rays,
-            self.render_scale,
-            self.view_surface,
-            self.z_buffer,
-            self.sprite_cache,
-            self._SPRITE_CACHE_MAX,
-            self._SPRITE_CACHE_EVICT,
-            self._scaled_sprite_cache,
-            self._SCALED_SPRITE_CACHE_MAX,
-            self._SCALED_SPRITE_CACHE_EVICT,
-            self._evict_lru,
+            SpriteRenderContext(
+                player,
+                bots,
+                projectiles,
+                particles,
+                half_fov,
+                view_offset_y,
+                flash_intensity,
+                self.config,
+                self.num_rays,
+                self.render_scale,
+                self.view_surface,
+                self.z_buffer,
+                self.sprite_cache,
+                self._SPRITE_CACHE_MAX,
+                self._SPRITE_CACHE_EVICT,
+                self._scaled_sprite_cache,
+                self._SCALED_SPRITE_CACHE_MAX,
+                self._SCALED_SPRITE_CACHE_EVICT,
+                self._evict_lru,
+            )
         )
 
     def _generate_background_surface(self, level: int) -> None:
@@ -792,21 +803,23 @@ class Raycaster:
         minimap_y = 20
 
         self._fog_surface, self._fog_visited_count = _render_minimap_fn(
-            screen,
-            player,
-            bots,
-            self.minimap_surface,
-            self.minimap_size,
-            self.minimap_scale,
-            minimap_x,
-            minimap_y,
-            self._fog_surface,
-            self._fog_visited_count,
-            visited_cells,
-            portal,
-            self.config.ENEMY_TYPES,
-            self.config.BLACK,
-            self.config.RED,
-            self.config.GREEN,
-            self.config.CYAN,
+            MinimapRenderContext(
+                screen,
+                player,
+                bots,
+                self.minimap_surface,
+                self.minimap_size,
+                self.minimap_scale,
+                minimap_x,
+                minimap_y,
+                self._fog_surface,
+                self._fog_visited_count,
+                visited_cells,
+                portal,
+                self.config.ENEMY_TYPES,
+                self.config.BLACK,
+                self.config.RED,
+                self.config.GREEN,
+                self.config.CYAN,
+            )
         )

--- a/src/games/shared/raycaster.py
+++ b/src/games/shared/raycaster.py
@@ -359,9 +359,7 @@ class Raycaster:
             self.grid = self.game_map.grid
             self.np_grid = np.array(self.game_map.grid, dtype=np.int8)
 
-    def _calculate_rays(
-        self, player: Player
-    ) -> tuple[
+    def _calculate_rays(self, player: Player) -> tuple[
         np.ndarray[Any, np.dtype[Any]],
         np.ndarray[Any, np.dtype[Any]],
         np.ndarray[Any, np.dtype[Any]],

--- a/src/games/shared/raycaster_render_contexts.py
+++ b/src/games/shared/raycaster_render_contexts.py
@@ -1,0 +1,136 @@
+"""Immutable parameter bundles for raycaster render helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import pygame
+
+from .contracts import (
+    ContractViolation,
+    validate_non_negative,
+    validate_not_none,
+    validate_positive,
+    validate_range,
+)
+
+
+@dataclass(frozen=True)
+class SpriteRenderContext:
+    """Inputs required to render all sprites for a raycasting frame."""
+
+    player: Any
+    bots: Sequence[Any]
+    projectiles: Sequence[Any]
+    particles: Sequence[Any]
+    half_fov: float
+    view_offset_y: float
+    flash_intensity: float
+    config: Any
+    num_rays: int
+    render_scale: int
+    view_surface: pygame.Surface
+    z_buffer: Any
+    sprite_cache: Any
+    sprite_cache_max: int
+    sprite_cache_evict: int
+    scaled_sprite_cache: Any
+    scaled_cache_max: int
+    scaled_cache_evict: int
+    evict_fn: Callable[..., None]
+
+    def __post_init__(self) -> None:
+        validate_not_none(self.player, "player")
+        validate_not_none(self.bots, "bots")
+        validate_not_none(self.projectiles, "projectiles")
+        validate_not_none(self.particles, "particles")
+        validate_positive(self.half_fov, "half_fov")
+        validate_non_negative(self.flash_intensity, "flash_intensity")
+        validate_not_none(self.config, "config")
+        validate_positive(self.num_rays, "num_rays")
+        validate_positive(self.render_scale, "render_scale")
+        validate_not_none(self.view_surface, "view_surface")
+        validate_not_none(self.z_buffer, "z_buffer")
+        validate_not_none(self.sprite_cache, "sprite_cache")
+        validate_positive(self.sprite_cache_max, "sprite_cache_max")
+        validate_non_negative(self.sprite_cache_evict, "sprite_cache_evict")
+        validate_not_none(self.scaled_sprite_cache, "scaled_sprite_cache")
+        validate_positive(self.scaled_cache_max, "scaled_cache_max")
+        validate_non_negative(self.scaled_cache_evict, "scaled_cache_evict")
+        if not callable(self.evict_fn):
+            raise ContractViolation("evict_fn must be callable")
+
+
+@dataclass(frozen=True)
+class TexturedWallColumnContext:
+    """Inputs required to render a single textured wall column."""
+
+    i: int
+    wt: int
+    h: int
+    top: int
+    wall_x_hit: float
+    shade: float
+    fog: float
+    wall_strips: dict[int, list[pygame.Surface]]
+    wall_colors: dict[int, tuple[int, int, int]]
+    view_surface: pygame.Surface
+    blits_sequence: list[Any]
+    gray: tuple[int, int, int]
+    texture_map: dict[int, str]
+    shading_surfaces: list[pygame.Surface]
+    fog_surfaces: list[pygame.Surface]
+    get_cached_strip_fn: Callable[[str, int, int], pygame.Surface | None]
+
+    def __post_init__(self) -> None:
+        validate_positive(self.h, "h")
+        validate_range(self.wall_x_hit, 0.0, 1.0, "wall_x_hit")
+        validate_range(self.shade, 0.0, 1.0, "shade")
+        validate_range(self.fog, 0.0, 1.0, "fog")
+        validate_not_none(self.wall_strips, "wall_strips")
+        validate_not_none(self.wall_colors, "wall_colors")
+        validate_not_none(self.view_surface, "view_surface")
+        validate_not_none(self.blits_sequence, "blits_sequence")
+        validate_not_none(self.gray, "gray")
+        validate_not_none(self.texture_map, "texture_map")
+        validate_not_none(self.shading_surfaces, "shading_surfaces")
+        validate_not_none(self.fog_surfaces, "fog_surfaces")
+        if not callable(self.get_cached_strip_fn):
+            raise ContractViolation("get_cached_strip_fn must be callable")
+
+
+@dataclass(frozen=True)
+class MinimapRenderContext:
+    """Inputs required to render a minimap frame."""
+
+    screen: pygame.Surface
+    player: Any
+    bots: Sequence[Any]
+    minimap_surface: pygame.Surface | None
+    minimap_size: int
+    minimap_scale: float
+    minimap_x: int
+    minimap_y: int
+    fog_surface: pygame.Surface | None
+    fog_visited_count: int
+    visited_cells: set[tuple[int, int]] | None
+    portal: Any
+    enemy_types: dict[str, Any] | None
+    black: tuple[int, int, int]
+    red: tuple[int, int, int]
+    green: tuple[int, int, int]
+    cyan: tuple[int, int, int]
+
+    def __post_init__(self) -> None:
+        validate_not_none(self.screen, "screen")
+        validate_not_none(self.player, "player")
+        validate_not_none(self.bots, "bots")
+        validate_positive(self.minimap_size, "minimap_size")
+        validate_positive(self.minimap_scale, "minimap_scale")
+        validate_non_negative(self.fog_visited_count, "fog_visited_count")
+        validate_not_none(self.black, "black")
+        validate_not_none(self.red, "red")
+        validate_not_none(self.green, "green")
+        validate_not_none(self.cyan, "cyan")

--- a/src/games/shared/raycaster_rendering.py
+++ b/src/games/shared/raycaster_rendering.py
@@ -16,11 +16,15 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pygame
 
+from .raycaster_render_contexts import (
+    MinimapRenderContext,
+    TexturedWallColumnContext,
+)
+
 if TYPE_CHECKING:
     from collections import OrderedDict
-    from collections.abc import Sequence
 
-    from .interfaces import Bot, Player, Portal, Projectile
+    from .interfaces import Player, Projectile
 
 
 # ---------------------------------------------------------------------------
@@ -69,57 +73,66 @@ def prepare_wall_render_data(
     )
 
 
-def render_textured_wall_column(  # noqa: PLR0913
-    i: int,
-    wt: int,
-    h: int,
-    top: int,
-    wall_x_hit: float,
-    shade: float,
-    fog: float,
-    wall_strips: dict[int, list[pygame.Surface]],
-    wall_colors: dict[int, tuple[int, int, int]],
-    view_surface: pygame.Surface,
-    blits_sequence: list[Any],
-    gray: tuple[int, int, int],
-    texture_map: dict[int, str],
-    shading_surfaces: list[pygame.Surface],
-    fog_surfaces: list[pygame.Surface],
-    get_cached_strip_fn: Any,
+def render_textured_wall_column(
+    context: TexturedWallColumnContext,
 ) -> None:
     """Render a single textured wall column with shading and fog."""
-    strips = wall_strips[wt]
+    strips = context.wall_strips[context.wt]
     tex_w = len(strips)
-    tex_x = int(np.clip(int(wall_x_hit * tex_w), 0, tex_w - 1))
+    tex_x = int(np.clip(int(context.wall_x_hit * tex_w), 0, tex_w - 1))
 
-    if h >= 8000:
+    if context.h >= 8000:
         # Solid colour fallback for extreme close-up
-        col = wall_colors.get(wt, gray)
-        col = (int(col[0] * shade), int(col[1] * shade), int(col[2] * shade))
-        pygame.draw.rect(view_surface, col, (i, top, 1, h))
+        col = context.wall_colors.get(context.wt, context.gray)
+        col = (
+            int(col[0] * context.shade),
+            int(col[1] * context.shade),
+            int(col[2] * context.shade),
+        )
+        pygame.draw.rect(
+            context.view_surface,
+            col,
+            (context.i, context.top, 1, context.h),
+        )
         return
 
-    tname = texture_map.get(wt, "brick")
-    scaled_strip = get_cached_strip_fn(tname, tex_x, int(h))
+    tname = context.texture_map.get(context.wt, "brick")
+    scaled_strip = context.get_cached_strip_fn(tname, tex_x, int(context.h))
 
     if not scaled_strip:
-        col = wall_colors.get(wt, gray)
-        pygame.draw.rect(view_surface, col, (i, top, 1, h))
+        col = context.wall_colors.get(context.wt, context.gray)
+        pygame.draw.rect(
+            context.view_surface,
+            col,
+            (context.i, context.top, 1, context.h),
+        )
         return
 
-    blits_sequence.append((scaled_strip, (i, top)))
+    context.blits_sequence.append((scaled_strip, (context.i, context.top)))
 
     # Shading overlay
-    if shade < 1.0:
-        alpha = max(0, min(255, int(255 * (1.0 - shade))))
+    if context.shade < 1.0:
+        alpha = max(0, min(255, int(255 * (1.0 - context.shade))))
         if alpha > 0:
-            blits_sequence.append((shading_surfaces[alpha], (i, top), (0, 0, 1, h)))
+            context.blits_sequence.append(
+                (
+                    context.shading_surfaces[alpha],
+                    (context.i, context.top),
+                    (0, 0, 1, context.h),
+                )
+            )
 
     # Fog overlay
-    if fog > 0:
-        fog_alpha = max(0, min(255, int(255 * fog)))
+    if context.fog > 0:
+        fog_alpha = max(0, min(255, int(255 * context.fog)))
         if fog_alpha > 0:
-            blits_sequence.append((fog_surfaces[fog_alpha], (i, top), (0, 0, 1, h)))
+            context.blits_sequence.append(
+                (
+                    context.fog_surfaces[fog_alpha],
+                    (context.i, context.top),
+                    (0, 0, 1, context.h),
+                )
+            )
 
 
 def render_solid_wall_column(
@@ -496,24 +509,8 @@ def generate_minimap_cache(
     return surface
 
 
-def render_minimap(  # noqa: PLR0913
-    screen: pygame.Surface,
-    player: Player,
-    bots: Sequence[Bot],
-    minimap_surface: pygame.Surface | None,
-    minimap_size: int,
-    minimap_scale: float,
-    minimap_x: int,
-    minimap_y: int,
-    fog_surface: pygame.Surface | None,
-    fog_visited_count: int,
-    visited_cells: set[tuple[int, int]] | None,
-    portal: Portal | None,
-    enemy_types: dict[str, Any] | None,
-    black: tuple[int, int, int],
-    red: tuple[int, int, int],
-    green: tuple[int, int, int],
-    cyan: tuple[int, int, int],
+def render_minimap(
+    context: MinimapRenderContext,
 ) -> tuple[pygame.Surface | None, int]:
     """Render 2D minimap with fog of war support.
 
@@ -521,67 +518,99 @@ def render_minimap(  # noqa: PLR0913
         (fog_surface, fog_visited_count) -- caller should update its cached state.
     """
     pygame.draw.rect(
-        screen,
-        black,
-        (minimap_x - 2, minimap_y - 2, minimap_size + 4, minimap_size + 4),
+        context.screen,
+        context.black,
+        (
+            context.minimap_x - 2,
+            context.minimap_y - 2,
+            context.minimap_size + 4,
+            context.minimap_size + 4,
+        ),
     )
 
-    if minimap_surface:
-        if visited_cells is not None:
-            visited_count = len(visited_cells)
+    fog_surface = context.fog_surface
+    fog_visited_count = context.fog_visited_count
+
+    if context.minimap_surface:
+        if context.visited_cells is not None:
+            visited_count = len(context.visited_cells)
             if fog_surface is None or fog_visited_count != visited_count:
                 fog_surface = pygame.Surface(
-                    (minimap_size, minimap_size), pygame.SRCALPHA
+                    (context.minimap_size, context.minimap_size), pygame.SRCALPHA
                 )
                 fog_surface.fill((0, 0, 0, 255))
-                for vx, vy in visited_cells:
+                for vx, vy in context.visited_cells:
                     fog_surface.fill(
                         (0, 0, 0, 0),
                         rect=(
-                            vx * minimap_scale,
-                            vy * minimap_scale,
-                            minimap_scale,
-                            minimap_scale,
+                            vx * context.minimap_scale,
+                            vy * context.minimap_scale,
+                            context.minimap_scale,
+                            context.minimap_scale,
                         ),
                     )
                 fog_visited_count = visited_count
-            screen.blit(minimap_surface, (minimap_x, minimap_y))
-            screen.blit(fog_surface, (minimap_x, minimap_y))
+            context.screen.blit(
+                context.minimap_surface,
+                (context.minimap_x, context.minimap_y),
+            )
+            context.screen.blit(fog_surface, (context.minimap_x, context.minimap_y))
         else:
-            screen.blit(minimap_surface, (minimap_x, minimap_y))
-
-    if portal is not None:
-        px, py = int(portal["x"]), int(portal["y"])
-        if visited_cells is None or (px, py) in visited_cells:
-            portal_map_x = minimap_x + px * minimap_scale
-            portal_map_y = minimap_y + py * minimap_scale
-            pygame.draw.circle(
-                screen,
-                cyan,
-                (int(portal_map_x), int(portal_map_y)),
-                int(minimap_scale * 2),
+            context.screen.blit(
+                context.minimap_surface,
+                (context.minimap_x, context.minimap_y),
             )
 
-    for bot in bots:
+    if context.portal is not None:
+        px, py = int(context.portal["x"]), int(context.portal["y"])
+        if context.visited_cells is None or (px, py) in context.visited_cells:
+            portal_map_x = context.minimap_x + px * context.minimap_scale
+            portal_map_y = context.minimap_y + py * context.minimap_scale
+            pygame.draw.circle(
+                context.screen,
+                context.cyan,
+                (int(portal_map_x), int(portal_map_y)),
+                int(context.minimap_scale * 2),
+            )
+
+    for bot in context.bots:
         if (
             bot.alive
             and bot.enemy_type != "health_pack"
-            and enemy_types is not None
-            and enemy_types[bot.enemy_type].get("visual_style") != "item"
+            and context.enemy_types is not None
+            and context.enemy_types[bot.enemy_type].get("visual_style") != "item"
         ):
             bot_cell_x = int(bot.x)
             bot_cell_y = int(bot.y)
-            if visited_cells is None or (bot_cell_x, bot_cell_y) in visited_cells:
-                bot_x = minimap_x + bot.x * minimap_scale
-                bot_y = minimap_y + bot.y * minimap_scale
-                pygame.draw.circle(screen, red, (int(bot_x), int(bot_y)), 3)
+            if (
+                context.visited_cells is None
+                or (
+                    bot_cell_x,
+                    bot_cell_y,
+                )
+                in context.visited_cells
+            ):
+                bot_x = context.minimap_x + bot.x * context.minimap_scale
+                bot_y = context.minimap_y + bot.y * context.minimap_scale
+                pygame.draw.circle(
+                    context.screen,
+                    context.red,
+                    (int(bot_x), int(bot_y)),
+                    3,
+                )
 
-    player_x = minimap_x + player.x * minimap_scale
-    player_y = minimap_y + player.y * minimap_scale
-    pygame.draw.circle(screen, green, (int(player_x), int(player_y)), 3)
+    player_x = context.minimap_x + context.player.x * context.minimap_scale
+    player_y = context.minimap_y + context.player.y * context.minimap_scale
+    pygame.draw.circle(context.screen, context.green, (int(player_x), int(player_y)), 3)
 
-    dir_x = player_x + math.cos(player.angle) * 10
-    dir_y = player_y + math.sin(player.angle) * 10
-    pygame.draw.line(screen, green, (player_x, player_y), (dir_x, dir_y), 2)
+    dir_x = player_x + math.cos(context.player.angle) * 10
+    dir_y = player_y + math.sin(context.player.angle) * 10
+    pygame.draw.line(
+        context.screen,
+        context.green,
+        (player_x, player_y),
+        (dir_x, dir_y),
+        2,
+    )
 
     return fog_surface, fog_visited_count

--- a/src/games/shared/raycaster_sprites.py
+++ b/src/games/shared/raycaster_sprites.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 import math
 from collections import OrderedDict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pygame
 
 from .bot_renderer import BotRenderer
+from .raycaster_render_contexts import SpriteRenderContext
 from .raycaster_rendering import (
     blit_strip_scaled,
     blit_whole_scaled,
@@ -42,51 +43,34 @@ LARGE_SPRITE_THRESHOLD = 200
 # ---------------------------------------------------------------------------
 
 
-def render_sprites(  # noqa: PLR0913
-    player: Player,
-    bots: Sequence[Bot],
-    projectiles: Sequence[Projectile],
-    particles: Sequence[WorldParticle],
-    half_fov: float,
-    view_offset_y: float,
-    flash_intensity: float,
-    config: RaycasterConfig,
-    num_rays: int,
-    render_scale: int,
-    view_surface: pygame.Surface,
-    z_buffer: np.ndarray[Any, np.dtype[Any]],
-    sprite_cache: OrderedDict[tuple, pygame.Surface],
-    sprite_cache_max: int,
-    sprite_cache_evict: int,
-    scaled_sprite_cache: OrderedDict[tuple, pygame.Surface],
-    scaled_cache_max: int,
-    scaled_cache_evict: int,
-    evict_fn: Callable[..., None],
+def render_sprites(
+    context: SpriteRenderContext,
 ) -> None:
     """Render all sprites (bots, projectiles, particles) to the view surface."""
     sprites_to_render: list[tuple[Any, int]] = []
 
+    player = context.player
     p_cos = math.cos(player.angle)
     p_sin = math.sin(player.angle)
-    max_dist_sq = config.MAX_DEPTH * config.MAX_DEPTH
+    max_dist_sq = context.config.MAX_DEPTH * context.config.MAX_DEPTH
 
-    for bot in bots:
+    for bot in context.bots:
         if bot.removed:
             continue
         sprites_to_render.append((bot, 0))
 
-    for proj in projectiles:
+    for proj in context.projectiles:
         if not proj.alive:
             continue
         sprites_to_render.append((proj, 1))
 
-    for part in particles:
+    for part in context.particles:
         if not part.alive:
             continue
         sprites_to_render.append((part, 2))
 
     final_sprites = _cull_and_sort_sprites(
-        sprites_to_render, player, p_cos, p_sin, max_dist_sq, half_fov
+        sprites_to_render, player, p_cos, p_sin, max_dist_sq, context.half_fov
     )
 
     for entity, dist, angle, type_id in final_sprites:
@@ -97,13 +81,13 @@ def render_sprites(  # noqa: PLR0913
                 proj,
                 dist,
                 angle,
-                half_fov,
-                view_offset_y,
-                config,
-                num_rays,
-                render_scale,
-                view_surface,
-                z_buffer,
+                context.half_fov,
+                context.view_offset_y,
+                context.config,
+                context.num_rays,
+                context.render_scale,
+                context.view_surface,
+                context.z_buffer,
             )
         elif type_id == 2:
             part = cast("WorldParticle", entity)
@@ -112,13 +96,13 @@ def render_sprites(  # noqa: PLR0913
                 part,
                 dist,
                 angle,
-                half_fov,
-                view_offset_y,
-                config,
-                num_rays,
-                render_scale,
-                view_surface,
-                z_buffer,
+                context.half_fov,
+                context.view_offset_y,
+                context.config,
+                context.num_rays,
+                context.render_scale,
+                context.view_surface,
+                context.z_buffer,
             )
         else:
             bot = cast("Bot", entity)
@@ -127,21 +111,21 @@ def render_sprites(  # noqa: PLR0913
                 bot,
                 dist,
                 angle,
-                half_fov,
-                view_offset_y,
-                flash_intensity,
-                config,
-                num_rays,
-                render_scale,
-                view_surface,
-                z_buffer,
-                sprite_cache,
-                sprite_cache_max,
-                sprite_cache_evict,
-                scaled_sprite_cache,
-                scaled_cache_max,
-                scaled_cache_evict,
-                evict_fn,
+                context.half_fov,
+                context.view_offset_y,
+                context.flash_intensity,
+                context.config,
+                context.num_rays,
+                context.render_scale,
+                context.view_surface,
+                context.z_buffer,
+                context.sprite_cache,
+                context.sprite_cache_max,
+                context.sprite_cache_evict,
+                context.scaled_sprite_cache,
+                context.scaled_cache_max,
+                context.scaled_cache_evict,
+                context.evict_fn,
             )
 
 

--- a/tests/shared/test_raycaster_render_contexts.py
+++ b/tests/shared/test_raycaster_render_contexts.py
@@ -1,0 +1,154 @@
+"""Tests for raycaster render parameter objects."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from games.shared.contracts import ContractViolation
+from games.shared.raycaster_render_contexts import (
+    MinimapRenderContext,
+    SpriteRenderContext,
+    TexturedWallColumnContext,
+)
+
+
+class TestSpriteRenderContext:
+    def test_valid_context(self) -> None:
+        context = SpriteRenderContext(
+            player=MagicMock(),
+            bots=[],
+            projectiles=[],
+            particles=[],
+            half_fov=0.5,
+            view_offset_y=0.0,
+            flash_intensity=0.0,
+            config=MagicMock(),
+            num_rays=64,
+            render_scale=4,
+            view_surface=MagicMock(),
+            z_buffer=MagicMock(),
+            sprite_cache={},
+            sprite_cache_max=16,
+            sprite_cache_evict=4,
+            scaled_sprite_cache={},
+            scaled_cache_max=8,
+            scaled_cache_evict=2,
+            evict_fn=lambda *_args, **_kwargs: None,
+        )
+        assert context.num_rays == 64
+
+    def test_rejects_invalid_half_fov(self) -> None:
+        with pytest.raises(ContractViolation):
+            SpriteRenderContext(
+                player=MagicMock(),
+                bots=[],
+                projectiles=[],
+                particles=[],
+                half_fov=0.0,
+                view_offset_y=0.0,
+                flash_intensity=0.0,
+                config=MagicMock(),
+                num_rays=64,
+                render_scale=4,
+                view_surface=MagicMock(),
+                z_buffer=MagicMock(),
+                sprite_cache={},
+                sprite_cache_max=16,
+                sprite_cache_evict=4,
+                scaled_sprite_cache={},
+                scaled_cache_max=8,
+                scaled_cache_evict=2,
+                evict_fn=lambda *_args, **_kwargs: None,
+            )
+
+
+class TestTexturedWallColumnContext:
+    def test_valid_context(self) -> None:
+        context = TexturedWallColumnContext(
+            i=1,
+            wt=2,
+            h=32,
+            top=4,
+            wall_x_hit=0.25,
+            shade=0.75,
+            fog=0.1,
+            wall_strips={2: [MagicMock()]},
+            wall_colors={2: (10, 20, 30)},
+            view_surface=MagicMock(),
+            blits_sequence=[],
+            gray=(128, 128, 128),
+            texture_map={2: "brick"},
+            shading_surfaces=[MagicMock()],
+            fog_surfaces=[MagicMock()],
+            get_cached_strip_fn=lambda *_args: MagicMock(),
+        )
+        assert context.wt == 2
+
+    def test_rejects_out_of_range_fog(self) -> None:
+        with pytest.raises(ContractViolation):
+            TexturedWallColumnContext(
+                i=1,
+                wt=2,
+                h=32,
+                top=4,
+                wall_x_hit=0.25,
+                shade=0.75,
+                fog=1.1,
+                wall_strips={2: [MagicMock()]},
+                wall_colors={2: (10, 20, 30)},
+                view_surface=MagicMock(),
+                blits_sequence=[],
+                gray=(128, 128, 128),
+                texture_map={2: "brick"},
+                shading_surfaces=[MagicMock()],
+                fog_surfaces=[MagicMock()],
+                get_cached_strip_fn=lambda *_args: MagicMock(),
+            )
+
+
+class TestMinimapRenderContext:
+    def test_valid_context(self) -> None:
+        context = MinimapRenderContext(
+            screen=MagicMock(),
+            player=MagicMock(),
+            bots=[],
+            minimap_surface=None,
+            minimap_size=64,
+            minimap_scale=4.0,
+            minimap_x=1,
+            minimap_y=2,
+            fog_surface=None,
+            fog_visited_count=0,
+            visited_cells=None,
+            portal=None,
+            enemy_types=None,
+            black=(0, 0, 0),
+            red=(255, 0, 0),
+            green=(0, 255, 0),
+            cyan=(0, 255, 255),
+        )
+        assert context.minimap_size == 64
+
+    def test_rejects_negative_fog_visit_count(self) -> None:
+        with pytest.raises(ContractViolation):
+            MinimapRenderContext(
+                screen=MagicMock(),
+                player=MagicMock(),
+                bots=[],
+                minimap_surface=None,
+                minimap_size=64,
+                minimap_scale=4.0,
+                minimap_x=1,
+                minimap_y=2,
+                fog_surface=None,
+                fog_visited_count=-1,
+                visited_cells=None,
+                portal=None,
+                enemy_types=None,
+                black=(0, 0, 0),
+                red=(255, 0, 0),
+                green=(0, 255, 0),
+                cyan=(0, 255, 255),
+            )


### PR DESCRIPTION
Fixes #740\n\nIntroduces immutable render-context dataclasses for the sprite, textured wall, and minimap render helpers, then updates the raycaster wrappers to pass those bundles through. Adds focused validation tests for the new parameter objects and keeps the existing raycaster test coverage green.