### PR TITLE
[codex] Refactor Force Field input dependencies

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.18                                               |
+| **Spec Version**        | 1.1.19                                               |
 | **Last Spec Update**    | 2026-04-11                                           |
 
 ## 2. Purpose & Mission
@@ -408,6 +408,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-11 | 1.1.19  | Refactored Force Field input handling to narrow direct game-object dependency chains behind handler accessors and action helpers, with focused regression coverage for pause and cheat-input behavior. |
 | 2026-04-11 | 1.1.18  | Introduced immutable parameter objects for the raycaster sprite, textured wall, and minimap render helpers, updated the raycaster wrappers to pass those render contexts, and added validation coverage for the new bundles. |
 | 2026-04-10 | 1.1.16  | Partially addressed issue `#721` by extracting Duum weapon/combat orchestration out of `src/games/Duum/src/game.py` into `weapon_system.py`, keeping `Game` as the public façade, and adding focused weapon-system plus delegation tests around the new seam. |
 | 2026-04-10 | 1.1.15  | Partially addressed issue `#721` by extracting Force Field and Duum HUD rendering out of their respective `ui_renderer.py` files into `ui_hud_views.py` modules, keeping `UIRenderer` as the public façade, and adding seam tests around the new HUD delegation points. Force Field `ui_renderer.py` reduced from 556 → 260 lines; Duum from 594 → 254 lines. |

--- a/src/games/Duum/src/atmosphere_manager.py
+++ b/src/games/Duum/src/atmosphere_manager.py
@@ -25,13 +25,38 @@ class AtmosphereManager:
     def __init__(self, game: Game) -> None:
         self._game = game
 
+    @property
+    def game(self) -> Game:
+        """Return the owned game object."""
+        return self._game
+
+    @property
+    def player(self):
+        game = self._game
+        if game.player is None:
+            raise ValueError("DbC Blocked: Precondition failed.")
+        return game.player
+
+    @property
+    def sound_manager(self):
+        return self._game.sound_manager
+
+    @property
+    def combat_manager(self):
+        return self._game.combat_manager
+
+    @property
+    def visited_cells(self):
+        return self._game.visited_cells
+
+    @property
+    def bots(self):
+        return self._game.bots
+
     def update_fog_reveal(self) -> None:
         """Expand the visited-cell set around the player position."""
-        game = self._game
-        if not (game.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
-
-        cx, cy = int(game.player.x), int(game.player.y)
+        player = self.player
+        cx, cy = int(player.x), int(player.y)
         reveal_radius = FOG_REVEAL_RADIUS
         for row_offset in range(-reveal_radius, reveal_radius + 1):
             for col_offset in range(-reveal_radius, reveal_radius + 1):
@@ -39,19 +64,18 @@ class AtmosphereManager:
                     row_offset * row_offset + col_offset * col_offset
                     <= reveal_radius * reveal_radius
                 ):
-                    game.visited_cells.add((cx + col_offset, cy + row_offset))
+                    self.visited_cells.add((cx + col_offset, cy + row_offset))
 
     def update_atmosphere(self) -> None:
         """Update ambient sound timers from nearby live enemies."""
         game = self._game
-        if not (game.player is not None):
-            raise ValueError("DbC Blocked: Precondition failed.")
+        player = self.player
 
         min_dist_sq = float("inf")
-        for bot in game.bots:
+        for bot in self.bots:
             if bot.alive:
-                dx = bot.x - game.player.x
-                dy = bot.y - game.player.y
+                dx = bot.x - player.x
+                dy = bot.y - player.y
                 dist_sq = dx * dx + dy * dy
                 if dist_sq < min_dist_sq:
                     min_dist_sq = dist_sq
@@ -63,21 +87,21 @@ class AtmosphereManager:
         if min_dist < 15:
             game.beast_timer -= 1
             if game.beast_timer <= 0:
-                game.sound_manager.play_sound("beast")
+                self.sound_manager.play_sound("beast")
                 game.beast_timer = random.randint(BEAST_TIMER_MIN, BEAST_TIMER_MAX)
 
         if min_dist < 20:
             beat_delay = int(min(1.5, max(0.4, min_dist / 10.0)) * C.FPS)
             game.heartbeat_timer -= 1
             if game.heartbeat_timer <= 0:
-                game.sound_manager.play_sound("heartbeat")
-                game.sound_manager.play_sound("breath")
+                self.sound_manager.play_sound("heartbeat")
+                self.sound_manager.play_sound("breath")
                 game.heartbeat_timer = beat_delay
 
-        if game.player.health < 50:
+        if player.health < 50:
             game.groan_timer -= 1
             if game.groan_timer <= 0:
-                game.sound_manager.play_sound("groan")
+                self.sound_manager.play_sound("groan")
                 game.groan_timer = GROAN_TIMER_DELAY
 
     def check_kill_combo(self) -> None:
@@ -90,7 +114,7 @@ class AtmosphereManager:
                     phrase = random.choice(
                         ["phrase_cool", "phrase_awesome", "phrase_brutal"]
                     )
-                    game.sound_manager.play_sound(phrase)
+                    self.sound_manager.play_sound(phrase)
                     game.damage_texts.append(
                         {
                             "x": C.SCREEN_WIDTH // 2,
@@ -103,5 +127,5 @@ class AtmosphereManager:
                     )
                 game.kill_combo_count = 0
 
-        game.combat_manager.kill_combo_timer = game.kill_combo_timer
-        game.combat_manager.kill_combo_count = game.kill_combo_count
+        self.combat_manager.kill_combo_timer = game.kill_combo_timer
+        self.combat_manager.kill_combo_count = game.kill_combo_count

--- a/src/games/Force_Field/src/game_input.py
+++ b/src/games/Force_Field/src/game_input.py
@@ -10,6 +10,7 @@ from .projectile import Projectile
 
 if TYPE_CHECKING:
     from .game import Game
+    from .player import Player
 
 logger = logging.getLogger(__name__)
 
@@ -18,166 +19,214 @@ class GameInputHandler:
     """Handles all input events for the game."""
 
     def __init__(self, game: Game):
-        self.game = game
+        self._game = game
+
+    @property
+    def game(self) -> Game:
+        """Return the owned game object."""
+        return self._game
+
+    @property
+    def player(self) -> Player:
+        """Return the active player, raising when the game is not ready."""
+        if self._game.player is None:
+            raise ValueError("DbC Blocked: Precondition failed.")
+        return self._game.player
+
+    @property
+    def input_manager(self):
+        return self._game.input_manager
+
+    @property
+    def combat_system(self):
+        return self._game.combat_system
+
+    @property
+    def entity_manager(self):
+        return self._game.entity_manager
+
+    @property
+    def sound_manager(self):
+        return self._game.sound_manager
+
+    @property
+    def ui_renderer(self):
+        return self._game.ui_renderer
+
+    def _set_mouse_grab(self, grabbed: bool) -> None:
+        pygame.mouse.set_visible(not grabbed)
+        pygame.event.set_grab(grabbed)
+
+    def _pause_game(self) -> None:
+        game = self._game
+        game.paused = True
+        self.sound_manager.pause_all()
+        game.pause_start_time = pygame.time.get_ticks()
+        self._set_mouse_grab(False)
+
+    def _resume_game(self) -> None:
+        game = self._game
+        game.paused = False
+        self.sound_manager.unpause_all()
+        if game.pause_start_time > 0:
+            now = pygame.time.get_ticks()
+            pause_duration = now - game.pause_start_time
+            game.total_paused_time += pause_duration
+            game.pause_start_time = 0
+        self._set_mouse_grab(True)
+
+    def _open_cheat_input(self) -> None:
+        game = self._game
+        game.cheat_mode_active = True
+        game.current_cheat_input = ""
+
+    def _close_cheat_input(self, message: str | None = None) -> None:
+        game = self._game
+        game.cheat_mode_active = False
+        if message is not None:
+            game.add_message(message, C.GRAY)
+
+    def _trigger_all_weapons_cheat(self) -> None:
+        game = self._game
+        game.unlocked_weapons = set(C.WEAPONS.keys())
+        if game.player:
+            for weapon_name in game.player.ammo:
+                game.player.ammo[weapon_name] = 999
+        game.add_message("ALL WEAPONS UNLOCKED", C.YELLOW)
+        game.current_cheat_input = ""
+        game.cheat_mode_active = False
+
+    def _trigger_god_mode_cheat(self) -> None:
+        game = self._game
+        game.god_mode = not game.god_mode
+        game.add_message(
+            "GOD MODE ON" if game.god_mode else "GOD MODE OFF",
+            C.YELLOW,
+        )
+        if game.player:
+            game.player.health = 100
+            game.player.god_mode = game.god_mode
+        game.current_cheat_input = ""
+        game.cheat_mode_active = False
+
+    def _shoot_primary(self) -> None:
+        if self.player.shoot():
+            self.combat_system.fire_weapon()
+
+    def _shoot_secondary(self) -> None:
+        if self.player.fire_secondary():
+            self.combat_system.fire_weapon(is_secondary=True)
+
+    def _spawn_bomb(self) -> None:
+        player = self.player
+        if player.activate_bomb():
+            bomb = Projectile(
+                player.x,
+                player.y,
+                player.angle,
+                damage=1000,
+                speed=0.4,
+                is_player=True,
+                color=(50, 50, 50),
+                size=0.4,
+                weapon_type="bomb",
+                z=0.5,
+                vz=0.15,
+                gravity=0.015,
+            )
+            self.entity_manager.add_projectile(bomb)
+
+    def _toggle_pause(self) -> None:
+        if self._game.paused:
+            self._resume_game()
+        else:
+            self._pause_game()
 
     def handle_game_events(self) -> None:
-        """Handle events during gameplay"""
+        """Handle events during gameplay."""
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
-                self.game.running = False
+                self._game.running = False
             elif event.type == pygame.KEYDOWN:
-                if self.game.cheat_mode_active:
+                if self._game.cheat_mode_active:
                     self._handle_cheat_input(event)
                 else:
                     self._handle_gameplay_input(event)
-
             elif event.type == pygame.MOUSEBUTTONDOWN:
-                if self.game.paused:
+                if self._game.paused:
                     self._handle_pause_menu_click(event)
-                elif not self.game.cheat_mode_active:
-                    # Gameplay Clicks (Shooting)
-                    if not (self.game.player is not None):
-                        raise ValueError("DbC Blocked: Precondition failed.")
+                elif not self._game.cheat_mode_active:
                     if event.button == 1:
-                        if self.game.player.shoot():
-                            self.game.combat_system.fire_weapon()
+                        self._shoot_primary()
                     elif event.button == 3:
-                        if self.game.player.fire_secondary():
-                            self.game.combat_system.fire_weapon(is_secondary=True)
+                        self._shoot_secondary()
             elif event.type == pygame.MOUSEBUTTONUP:
                 if event.button == 1:
-                    self.game.dragging_speed_slider = False
-
+                    self._game.dragging_speed_slider = False
             elif event.type == pygame.MOUSEMOTION:
-                if self.game.paused and self.game.dragging_speed_slider:
+                if self._game.paused and self._game.dragging_speed_slider:
                     self._handle_speed_slider(event)
-                elif not self.game.paused:
-                    if not (self.game.player is not None):
-                        raise ValueError("DbC Blocked: Precondition failed.")
-                    self.game.player.rotate(
+                elif not self._game.paused:
+                    self.player.rotate(
                         event.rel[0] * C.PLAYER_ROT_SPEED * C.SENSITIVITY_X
                     )
-                    self.game.player.pitch_view(
-                        -event.rel[1] * C.PLAYER_ROT_SPEED * 200
-                    )
+                    self.player.pitch_view(-event.rel[1] * C.PLAYER_ROT_SPEED * 200)
 
     def _handle_cheat_input(self, event: pygame.event.Event) -> None:
         """Handle input when cheat mode is active."""
         if event.key == pygame.K_RETURN or event.key == pygame.K_ESCAPE:
-            self.game.cheat_mode_active = False
-            self.game.add_message("CHEAT INPUT CLOSED", C.GRAY)
+            self._close_cheat_input("CHEAT INPUT CLOSED")
         elif event.key == pygame.K_BACKSPACE:
-            self.game.current_cheat_input = self.game.current_cheat_input[:-1]
+            self._game.current_cheat_input = self._game.current_cheat_input[:-1]
         else:
-            self.game.current_cheat_input += event.unicode
-            code = self.game.current_cheat_input.upper()
+            self._game.current_cheat_input += event.unicode
+            code = self._game.current_cheat_input.upper()
             if code.endswith("IDFA"):
-                self.game.unlocked_weapons = set(C.WEAPONS.keys())
-                if self.game.player:
-                    for w in self.game.player.ammo:
-                        self.game.player.ammo[w] = 999
-                self.game.add_message("ALL WEAPONS UNLOCKED", C.YELLOW)
-                self.game.current_cheat_input = ""
-                self.game.cheat_mode_active = False
+                self._trigger_all_weapons_cheat()
             elif code.endswith("IDDQD"):
-                self.game.god_mode = not self.game.god_mode
-                msg = "GOD MODE ON" if self.game.god_mode else "GOD MODE OFF"
-                self.game.add_message(msg, C.YELLOW)
-                if self.game.player:
-                    self.game.player.health = 100
-                    self.game.player.god_mode = self.game.god_mode
-                self.game.current_cheat_input = ""
-                self.game.cheat_mode_active = False
+                self._trigger_god_mode_cheat()
 
     def _handle_gameplay_input(self, event: pygame.event.Event) -> None:
         """Handle standard gameplay keyboard events."""
-        # Pause Toggle
-        if self.game.input_manager.is_action_just_pressed(event, "pause"):
-            self.game.paused = not self.game.paused
-            if self.game.paused:
-                self.game.sound_manager.pause_all()
-                self.game.pause_start_time = pygame.time.get_ticks()
-                pygame.mouse.set_visible(True)
-                pygame.event.set_grab(False)
-            else:
-                self.game.sound_manager.unpause_all()
-                if self.game.pause_start_time > 0:
-                    now = pygame.time.get_ticks()
-                    pause_duration = now - self.game.pause_start_time
-                    self.game.total_paused_time += pause_duration
-                    self.game.pause_start_time = 0
-                pygame.mouse.set_visible(False)
-                pygame.event.set_grab(True)
-
-        # Activate Cheat Mode
+        if self.input_manager.is_action_just_pressed(event, "pause"):
+            self._toggle_pause()
         elif event.key == pygame.K_c and (pygame.key.get_mods() & pygame.KMOD_CTRL):
-            self.game.cheat_mode_active = True
-            self.game.current_cheat_input = ""
-            self.game.add_message("CHEAT MODE: TYPE CODE", C.PURPLE)
-
-        # Standard Gameplay Controls (only if not paused)
-        elif not self.game.paused:
-            if self.game.input_manager.is_action_just_pressed(event, "weapon_1"):
-                self.game.switch_weapon_with_message("pistol")
-            elif self.game.input_manager.is_action_just_pressed(event, "weapon_2"):
-                self.game.switch_weapon_with_message("rifle")
-            elif self.game.input_manager.is_action_just_pressed(event, "weapon_3"):
-                self.game.switch_weapon_with_message("shotgun")
-            elif self.game.input_manager.is_action_just_pressed(event, "weapon_4"):
-                self.game.switch_weapon_with_message("laser")
-            elif self.game.input_manager.is_action_just_pressed(event, "weapon_5"):
-                self.game.switch_weapon_with_message("plasma")
-            elif self.game.input_manager.is_action_just_pressed(event, "weapon_6"):
-                self.game.switch_weapon_with_message("rocket")
+            self._open_cheat_input()
+            self._game.add_message("CHEAT MODE: TYPE CODE", C.PURPLE)
+        elif not self._game.paused:
+            if self.input_manager.is_action_just_pressed(event, "weapon_1"):
+                self._game.switch_weapon_with_message("pistol")
+            elif self.input_manager.is_action_just_pressed(event, "weapon_2"):
+                self._game.switch_weapon_with_message("rifle")
+            elif self.input_manager.is_action_just_pressed(event, "weapon_3"):
+                self._game.switch_weapon_with_message("shotgun")
+            elif self.input_manager.is_action_just_pressed(event, "weapon_4"):
+                self._game.switch_weapon_with_message("laser")
+            elif self.input_manager.is_action_just_pressed(event, "weapon_5"):
+                self._game.switch_weapon_with_message("plasma")
+            elif self.input_manager.is_action_just_pressed(event, "weapon_6"):
+                self._game.switch_weapon_with_message("rocket")
             elif event.key == pygame.K_7:
-                self.game.switch_weapon_with_message("minigun")
+                self._game.switch_weapon_with_message("minigun")
             elif event.key == pygame.K_9:
-                self.game.switch_weapon_with_message("flamethrower")
-            elif self.game.input_manager.is_action_just_pressed(event, "reload"):
-                if not (self.game.player is not None):
-                    raise ValueError("DbC Blocked: Precondition failed.")
-                self.game.player.reload()
-            elif self.game.input_manager.is_action_just_pressed(event, "zoom"):
-                if not (self.game.player is not None):
-                    raise ValueError("DbC Blocked: Precondition failed.")
-                self.game.player.zoomed = not self.game.player.zoomed
+                self._game.switch_weapon_with_message("flamethrower")
+            elif self.input_manager.is_action_just_pressed(event, "reload"):
+                self.player.reload()
+            elif self.input_manager.is_action_just_pressed(event, "zoom"):
+                self.player.zoomed = not self.player.zoomed
             elif event.key == pygame.K_q:
-                if not (self.game.player is not None):
-                    raise ValueError("DbC Blocked: Precondition failed.")
-                if self.game.player.melee_attack():
-                    self.game.execute_melee_attack()
-            elif self.game.input_manager.is_action_just_pressed(event, "bomb"):
-                if not (self.game.player is not None):
-                    raise ValueError("DbC Blocked: Precondition failed.")
-                if self.game.player.activate_bomb():
-                    bomb = Projectile(
-                        self.game.player.x,
-                        self.game.player.y,
-                        self.game.player.angle,
-                        damage=1000,
-                        speed=0.4,
-                        is_player=True,
-                        color=(50, 50, 50),
-                        size=0.4,
-                        weapon_type="bomb",
-                        z=0.5,
-                        vz=0.15,
-                        gravity=0.015,
-                    )
-                    self.game.entity_manager.add_projectile(bomb)
-            elif self.game.input_manager.is_action_just_pressed(event, "shoot_alt"):
-                if not (self.game.player is not None):
-                    raise ValueError("DbC Blocked: Precondition failed.")
-                if self.game.player.shoot():
-                    self.game.combat_system.fire_weapon()
+                if self.player.melee_attack():
+                    self._game.execute_melee_attack()
+            elif self.input_manager.is_action_just_pressed(event, "bomb"):
+                self._spawn_bomb()
+            elif self.input_manager.is_action_just_pressed(event, "shoot_alt"):
+                self._shoot_primary()
             elif event.key == pygame.K_m:
-                self.game.show_minimap = not self.game.show_minimap
+                self._game.show_minimap = not self._game.show_minimap
             elif event.key == pygame.K_F9:
-                self.game.cycle_render_scale()
-            elif self.game.input_manager.is_action_just_pressed(event, "dash"):
-                if not (self.game.player is not None):
-                    raise ValueError("DbC Blocked: Precondition failed.")
-                self.game.player.dash()
+                self._game.cycle_render_scale()
+            elif self.input_manager.is_action_just_pressed(event, "dash"):
+                self.player.dash()
 
     def _handle_pause_menu_click(self, event: pygame.event.Event) -> None:
         """Handle clicks in pause menu."""
@@ -191,7 +240,7 @@ class GameInputHandler:
         ]
         max_text_width = 0
         for item in menu_items:
-            text_surf = self.game.ui_renderer.render_subtitle_text(item, True, C.WHITE)
+            text_surf = self.ui_renderer.render_subtitle_text(item, True, C.WHITE)
             max_text_width = max(max_text_width, text_surf.get_width())
 
         box_width = max_text_width + 60
@@ -205,32 +254,22 @@ class GameInputHandler:
                 box_height,
             )
             if rect.collidepoint(mx, my):
-                if i == 0:  # Resume
-                    self.game.paused = False
-                    self.game.sound_manager.unpause_all()
-                    if self.game.pause_start_time > 0:
-                        now = pygame.time.get_ticks()
-                        pause_duration = now - self.game.pause_start_time
-                        self.game.total_paused_time += pause_duration
-                        self.game.pause_start_time = 0
-                    pygame.mouse.set_visible(False)
-                    pygame.event.set_grab(True)
-                elif i == 1:  # Save
-                    self.game.save_game()
-                    self.game.add_message("GAME SAVED", C.GREEN)
-                elif i == 2:  # Enter Cheat
-                    self.game.cheat_mode_active = True
-                    self.game.current_cheat_input = ""
-                elif i == 3:  # Controls
-                    self.game.state = "key_config"
-                    self.game.binding_action = None
-                elif i == 4:  # Quit to Menu
-                    self.game.state = "menu"
-                    self.game.paused = False
-                    self.game.sound_manager.start_music("music_loop")
+                if i == 0:
+                    self._resume_game()
+                elif i == 1:
+                    self._game.save_game()
+                    self._game.add_message("GAME SAVED", C.GREEN)
+                elif i == 2:
+                    self._open_cheat_input()
+                elif i == 3:
+                    self._game.state = "key_config"
+                    self._game.binding_action = None
+                elif i == 4:
+                    self._game.state = "menu"
+                    self._game.paused = False
+                    self.sound_manager.start_music("music_loop")
                 return
 
-        # Check speed slider interaction
         slider_y = 350 + len(menu_items) * 60 + 30 + 30
         slider_width = 200
         slider_height = 10
@@ -240,8 +279,8 @@ class GameInputHandler:
         if slider_rect.collidepoint(mx, my):
             relative_x = mx - slider_x
             speed_ratio = max(0.0, min(1.0, relative_x / slider_width))
-            self.game.movement_speed_multiplier = 0.5 + speed_ratio * 1.5
-            self.game.dragging_speed_slider = True
+            self._game.movement_speed_multiplier = 0.5 + speed_ratio * 1.5
+            self._game.dragging_speed_slider = True
 
     def _handle_speed_slider(self, event: pygame.event.Event) -> None:
         """Handle dragging the speed slider."""
@@ -251,4 +290,4 @@ class GameInputHandler:
 
         relative_x = mx - slider_x
         speed_ratio = max(0.0, min(1.0, relative_x / slider_width))
-        self.game.movement_speed_multiplier = 0.5 + speed_ratio * 1.5
+        self._game.movement_speed_multiplier = 0.5 + speed_ratio * 1.5

--- a/tests/Force_Field/test_game_input.py
+++ b/tests/Force_Field/test_game_input.py
@@ -1,0 +1,127 @@
+"""Focused tests for games.Force_Field.src.game_input."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pygame
+
+from games.Force_Field.src import constants as C
+from games.Force_Field.src.game_input import GameInputHandler
+
+
+def _make_game() -> SimpleNamespace:
+    player = MagicMock()
+    player.ammo = {"pistol": 12, "rifle": 24}
+    player.rotate = MagicMock()
+    player.pitch_view = MagicMock()
+    player.reload = MagicMock()
+    player.dash = MagicMock()
+    player.shoot.return_value = False
+    player.fire_secondary.return_value = False
+    player.melee_attack.return_value = False
+    player.activate_bomb.return_value = False
+    player.zoomed = False
+
+    input_manager = MagicMock()
+    input_manager.is_action_just_pressed.side_effect = (
+        lambda event, action: action in {"pause", "reload"}
+    )
+
+    game = SimpleNamespace(
+        running=True,
+        player=player,
+        paused=False,
+        cheat_mode_active=False,
+        current_cheat_input="",
+        unlocked_weapons={"pistol"},
+        god_mode=False,
+        dragging_speed_slider=False,
+        pause_start_time=0,
+        total_paused_time=0,
+        movement_speed_multiplier=1.0,
+        show_minimap=True,
+        state="game",
+        binding_action="move_forward",
+        add_message=MagicMock(),
+        switch_weapon_with_message=MagicMock(),
+        execute_melee_attack=MagicMock(),
+        save_game=MagicMock(),
+        cycle_render_scale=MagicMock(),
+        combat_system=SimpleNamespace(fire_weapon=MagicMock()),
+        entity_manager=SimpleNamespace(add_projectile=MagicMock()),
+        input_manager=input_manager,
+        sound_manager=SimpleNamespace(
+            pause_all=MagicMock(),
+            unpause_all=MagicMock(),
+            start_music=MagicMock(),
+        ),
+        ui_renderer=SimpleNamespace(
+            render_subtitle_text=MagicMock(
+                side_effect=lambda item, *_args, **_kwargs: MagicMock(
+                    get_width=lambda: len(item) * 10
+                )
+            )
+        ),
+    )
+    return game
+
+
+def _event(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def test_handle_game_events_toggles_pause_and_resume(monkeypatch) -> None:
+    """Pause input should lock, then restore, the game state."""
+    game = _make_game()
+    handler = GameInputHandler(game)
+    event = _event(type=pygame.KEYDOWN, key=pygame.K_p, unicode="p")
+    batches = [[event], [event]]
+    ticks = iter([1000, 1500])
+    monkeypatch.setattr(pygame.event, "get", lambda: batches.pop(0))
+    monkeypatch.setattr(
+        pygame.time,
+        "get_ticks",
+        lambda: next(ticks),
+    )
+    mouse_visible = MagicMock()
+    event_grab = MagicMock()
+    monkeypatch.setattr(pygame.mouse, "set_visible", mouse_visible)
+    monkeypatch.setattr(pygame.event, "set_grab", event_grab)
+
+    handler.handle_game_events()
+    assert game.paused is True
+    game.sound_manager.pause_all.assert_called_once_with()
+    mouse_visible.assert_called_once_with(True)
+    event_grab.assert_called_once_with(False)
+    assert game.pause_start_time == 1000
+
+    handler.handle_game_events()
+    assert game.paused is False
+    game.sound_manager.unpause_all.assert_called_once_with()
+    assert game.total_paused_time == 500
+    assert game.pause_start_time == 0
+    assert event_grab.call_args_list[-1].args == (True,)
+
+
+def test_handle_game_events_applies_cheat_code_unlock(monkeypatch) -> None:
+    """Cheat input should unlock all weapons and refill ammo."""
+    game = _make_game()
+    game.cheat_mode_active = True
+    handler = GameInputHandler(game)
+    events = [
+        _event(type=pygame.KEYDOWN, key=pygame.K_i, unicode="I"),
+        _event(type=pygame.KEYDOWN, key=pygame.K_d, unicode="D"),
+        _event(type=pygame.KEYDOWN, key=pygame.K_f, unicode="F"),
+        _event(type=pygame.KEYDOWN, key=pygame.K_a, unicode="A"),
+    ]
+    monkeypatch.setattr(pygame.event, "get", lambda: events)
+
+    handler.handle_game_events()
+
+    assert game.unlocked_weapons == set(C.WEAPONS.keys())
+    assert game.player.ammo == {"pistol": 999, "rifle": 999}
+    assert game.current_cheat_input == ""
+    assert game.cheat_mode_active is False
+    game.add_message.assert_any_call("ALL WEAPONS UNLOCKED", C.YELLOW)

--- a/tests/Force_Field/test_game_input.py
+++ b/tests/Force_Field/test_game_input.py
@@ -25,9 +25,10 @@ def _make_game() -> SimpleNamespace:
     player.zoomed = False
 
     input_manager = MagicMock()
-    input_manager.is_action_just_pressed.side_effect = (
-        lambda event, action: action in {"pause", "reload"}
-    )
+    input_manager.is_action_just_pressed.side_effect = lambda event, action: action in {
+        "pause",
+        "reload",
+    }
 
     game = SimpleNamespace(
         running=True,


### PR DESCRIPTION
Refactor Force_Field input handling to use narrow helper methods and direct subsystem accessors instead of long game-object chains. Also align Duum atmosphere management with the same local-helper pattern.

Tests:
- python3 -m ruff check src/games/Force_Field/src/game_input.py src/games/Duum/src/atmosphere_manager.py tests/Force_Field/test_game_input.py tests/Duum/test_atmosphere_manager.py
- python3 -m pytest tests/Force_Field/test_game_input.py tests/Duum/test_atmosphere_manager.py tests/Force_Field/test_input_manager.py -q

Fixes #739