### PR TITLE
refactor: decompose top 5 oversized functions (#743)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.22                                               |
+| **Spec Version**        | 1.1.23                                               |
 | **Last Spec Update**    | 2026-04-11                                           |
 
 ## 2. Purpose & Mission
@@ -411,6 +411,7 @@ Active development. Core games (F1-F6, F8-F9) fully implemented and tested. F7 (
 | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-04-11 | 1.1.20  | Partially addressed issue `#736` by extracting shared FPS defaults and controls across Duum, Force Field, and Zombie Survival into `games.shared` modules, plus deduplicating Duum world-particle setup. This adds `FPS_SHARED_CONSTANTS`, shared input binding profiles, and a shared `WorldParticle` import in Duum particle setup. |
 | 2026-04-11 | 1.1.21  | Partially addressed issue `#737` by decomposing `MonsterStyleRenderer.render` into smaller helper methods for body, head, arms, and legs rendering, reducing function size and preserving behavior. |
+| 2026-04-11 | 1.1.23  | Addresses issue `#743` by decomposing the top 5 oversized Python functions into thin orchestrators with single-responsibility helpers: `Force_Field/src/renderer.py::render_game` (108→24 LOC), `Force_Field/src/renderer.py::_render_portal` (105→30 LOC), `scripts/analyze_completist_data.py::generate_report` (106→15 LOC), `Tetris/tetris.py::TetrisGame.run` (102→27 LOC), and `Wizard_of_Wor/wizard_of_wor/enemy.py::Enemy.update` (96→21 LOC). Frame-step ordering preserved; added 8 unit tests for the new completist report helpers. |
 | 2026-04-11 | 1.1.22  | Extracted shared FPS constructor initialization into `FPSGameBase` and rewired the Duum, Force Field, and Zombie Survival constructors through the shared setup path. |
 | 2026-04-11 | 1.1.19  | Refactored Force Field input handling to narrow direct game-object dependency chains behind handler accessors and action helpers, with focused regression coverage for pause and cheat-input behavior. |
 | 2026-04-11 | 1.1.18  | Introduced immutable parameter objects for the raycaster sprite, textured wall, and minimap render helpers, updated the raycaster wrappers to pass those render contexts, and added validation coverage for the new bundles. |

--- a/scripts/analyze_completist_data.py
+++ b/scripts/analyze_completist_data.py
@@ -333,8 +333,17 @@ def generate_mermaid_charts(
     return "\n".join(chart)
 
 
-def generate_report() -> None:
-    """Generate the structured completist status report."""
+class _ReportData(TypedDict):
+    """Bundle of scanned findings used to render a completist report."""
+
+    criticals: list[Finding]
+    todos: list[Finding]
+    fixmes: list[Finding]
+    missing_docs: list[Finding]
+
+
+def _collect_report_data() -> _ReportData:
+    """Scan completist sources and return prioritized finding lists."""
     stubs = analyze_stubs()
     ni_errors = analyze_not_implemented()
     todos, fixmes = analyze_todos()
@@ -345,9 +354,22 @@ def generate_report() -> None:
     criticals = [s for s in (stubs + ni_errors) if "test" not in s["file"].lower()]
     criticals.sort(key=lambda x: calculate_metrics(x)[0], reverse=True)
 
-    # Report Generation
-    date_s = datetime.now().strftime("%Y-%m-%d")
-    report = [
+    return _ReportData(
+        criticals=criticals,
+        todos=todos,
+        fixmes=fixmes,
+        missing_docs=missing_docs,
+    )
+
+
+def _build_report_body(data: _ReportData, date_s: str) -> list[str]:
+    """Build the full markdown report body from collected data."""
+    criticals = data["criticals"]
+    todos = data["todos"]
+    fixmes = data["fixmes"]
+    missing_docs = data["missing_docs"]
+
+    report: list[str] = [
         f"# Completist Report: {date_s}\n",
         "## Executive Summary",
         f"- **Critical Gaps**: {len(criticals)}",
@@ -363,7 +385,6 @@ def generate_report() -> None:
     report.append("\n## Critical Incomplete (Top 50)")
     report.append("| File | Line | Type | Impact | Coverage | Complexity |")
     report.append("|---|---|---|---|---|---|")
-
     for item in criticals[:50]:
         imp, cov, comp = calculate_metrics(item)
         # fmt: off
@@ -411,8 +432,12 @@ def generate_report() -> None:
         desc = item.get("name", item.get("text", ""))[:80].replace("|", "\\|")
         report.append(f"| {i} | `{item['file']}` | {desc} | {imp}/{cov}/{comp} |")
 
-    # Issue creation for High Impact items
-    report.append("\n## Issues Created")
+    return report
+
+
+def _create_issues_section(criticals: list[Finding]) -> list[str]:
+    """Create issue files for high-impact criticals and return a report section."""
+    lines = ["\n## Issues Created"]
     max_id = 0
     issues_glob = glob.glob(os.path.join(ISSUES_DIR, "Issue_*.md")) + glob.glob(
         os.path.join(ISSUES_DIR, "ISSUE_*.md")
@@ -424,18 +449,40 @@ def generate_report() -> None:
 
     next_id = max_id + 1
     for item in [c for c in criticals if calculate_metrics(c)[0] >= 4][:10]:
-        report.append(f"- Created `{create_issue_file(item, next_id)}`")
+        lines.append(f"- Created `{create_issue_file(item, next_id)}`")
         next_id += 1
+    return lines
 
+
+def _write_report_files(report_lines: list[str], date_s: str) -> str:
+    """Write the report to its dated and 'latest' paths; return dated path."""
     os.makedirs(REPORT_DIR, exist_ok=True)
     report_path = os.path.join(REPORT_DIR, f"Completist_Report_{date_s}.md")
+    payload = "\n".join(report_lines)
     with open(report_path, "w", encoding="utf-8") as f_out:
-        f_out.write("\n".join(report))
+        f_out.write(payload)
 
     latest_path = os.path.join(REPORT_DIR, "COMPLETIST_LATEST.md")
     with open(latest_path, "w", encoding="utf-8") as f_out:
-        f_out.write("\n".join(report))
+        f_out.write(payload)
 
+    return report_path
+
+
+def generate_report() -> None:
+    """Generate the structured completist status report.
+
+    Thin orchestrator: collects data, builds the report body, creates
+    issue files for high-impact items, and writes the resulting markdown
+    to disk.
+    """
+    data = _collect_report_data()
+    date_s = datetime.now().strftime("%Y-%m-%d")
+
+    report_lines = _build_report_body(data, date_s)
+    report_lines.extend(_create_issues_section(data["criticals"]))
+
+    report_path = _write_report_files(report_lines, date_s)
     logger.info("Report generated: %s", report_path)
 
 

--- a/src/games/Force_Field/src/renderer.py
+++ b/src/games/Force_Field/src/renderer.py
@@ -35,46 +35,47 @@ class GameRenderer:
         self._portal_glow_surface_cache: dict[int, pygame.Surface] = {}
 
     def render_game(self, game: Game) -> None:
-        """Render gameplay"""
+        """Render gameplay.
+
+        Preconditions (DbC):
+            - ``game.raycaster`` is not None.
+            - ``game.player`` is not None.
+
+        Thin orchestrator: computes camera offsets, renders the 3D world,
+        overlay effects, portal, weapon, HUD, and flips the display. Order
+        of operations is preserved to keep the frame output identical.
+        """
         if not (game.raycaster is not None):
             raise ValueError("DbC Blocked: Precondition failed.")
         if not (game.player is not None):
             raise ValueError("DbC Blocked: Precondition failed.")
 
-        # Calculate Head Bob
+        bob_offset, shake_x, shake_y = self._compute_camera_offsets(game)
+        self._render_world(game, bob_offset, shake_y)
+        self._render_effects_layer(game, shake_x, shake_y)
+        self._render_portal(game.portal, game.player)
+        self._render_weapon_layer(game)
+        self._render_hud_layer(game)
+
+        pygame.display.flip()
+
+    def _compute_camera_offsets(self, game: Game) -> tuple[float, int, int]:
+        """Compute head-bob and screen-shake offsets for the current frame."""
         # Use player's bob_phase for consistent movement
         bob_offset = math.sin(game.player.bob_phase) * 10.0
 
-        # Screen Shake
         shake_x = 0
         shake_y = 0
         if game.screen_shake > 0:
             shake_x = int(random.uniform(-game.screen_shake, game.screen_shake))
             shake_y = int(random.uniform(-game.screen_shake, game.screen_shake))
 
-        # 1. 3D World (Raycaster)
-        # Note: We can't easily shake the raycaster output without rendering
-        # or blitting with offset which might leave gaps.
-        # Simple solution: Render normally, then blit everything with offset at the end?
-        # No, better to pass offset to raycaster if possible?
-        # Actually, if we just blit the view_surface with offset in Raycaster it works.
-        # But Raycaster.render_3d does the blit.
-        # Let's offset the HUD and Weapon for now, or everything if we wrap it.
+        return bob_offset, shake_x, shake_y
 
-        # Raycaster handles its own blitting to screen.
-        # We can simulate camera shake by modifying player pitch/angle temporarily,
-        # but that affects gameplay aiming.
-        # Instead, let's just let the raycaster render to screen (0,0)
-        # 2D overlays (weapon, HUD).
-        # Or better: Create a master surface? No, too slow.
-
-        # Let's just modify the raycaster to accept a view offset tuple.
-        # Raycaster already has view_offset_y.
-        # We can add view_offset_x? Raycaster works by rays.
-
-        # For this implementation, I will just shake the 2D elements.
-        # It gives enough feedback.
-
+    def _render_world(self, game: Game, bob_offset: float, shake_y: int) -> None:
+        """Render the 3D world (floor/ceiling and raycast scene)."""
+        # Raycaster handles its own blitting to screen. We simulate camera
+        # shake on 2D elements only to avoid affecting aiming.
         game.raycaster.render_floor_ceiling(
             self.screen, game.player, game.level, view_offset_y=bob_offset + shake_y
         )
@@ -87,7 +88,8 @@ class GameRenderer:
             projectiles=game.projectiles,
         )
 
-        # 2. Effects
+    def _render_effects_layer(self, game: Game, shake_x: int, shake_y: int) -> None:
+        """Render particles and damage flash to the effects surface, then blit."""
         self.effects_surface.fill((0, 0, 0, 0))
         self._render_particles(game.particle_system.particles, (shake_x, shake_y))
 
@@ -102,32 +104,19 @@ class GameRenderer:
 
         self.screen.blit(self.effects_surface, (shake_x, shake_y))
 
-        # 3. Portal
-        # Portal is 2D overlay on 3D position.
-        # We should probably pass the shake to it too.
-        # But _render_portal calculates screen position from player pos.
-        # If we didn't shake player pos, portal won't shake.
-        # Let's skip deep portal shake integration for now.
-        self._render_portal(game.portal, game.player)
-
-        # 4. Weapon Model
+    def _render_weapon_layer(self, game: Game) -> None:
+        """Render the weapon model and muzzle flash if firing."""
+        # WeaponRenderer.render_weapon draws directly to screen and returns
+        # the (cx, cy) position used to anchor the muzzle flash.
         weapon_pos = self.weapon_renderer.render_weapon(game.player)
-        # Apply shake to weapon position return (it draws itself though).
-        # WeaponRenderer.render_weapon draws directly to screen.
-        # I should modify WeaponRenderer or just accept it's mostly static.
-        # Actually WeaponRenderer returns (cx, cy) but also draws.
-        # It's hard to inject shake there without modifying it.
-        # Wait, I can pass a surface wrapper? No.
-
-        # Actually, WeaponRenderer uses cx, cy calculated inside.
-        # I'll leave weapon as is for now, head bob is already there.
 
         if game.player.shooting:
             self.weapon_renderer.render_muzzle_flash(
                 game.player.current_weapon, weapon_pos
             )
 
-        # 5. UI / HUD
+    def _render_hud_layer(self, game: Game) -> None:
+        """Render the minimap (if enabled) and HUD."""
         if game.show_minimap:
             game.raycaster.render_minimap(
                 self.screen,
@@ -137,10 +126,8 @@ class GameRenderer:
                 game.portal,
             )
 
-        # HUD Shake? usually HUD is static.
+        # HUD is intentionally static (no shake applied).
         game.ui_renderer.render_hud(game)
-
-        pygame.display.flip()
 
     def _render_particles(
         self, particles: list[Any], offset: tuple[int, int] = (0, 0)
@@ -189,6 +176,9 @@ class GameRenderer:
     def _render_portal(self, portal: Portal | None, player: Player) -> None:
         """Render portal visual effects if active.
 
+        Thin orchestrator: projects the portal into screen space, then
+        layers glow, rings, rotating arcs, and the core on top.
+
         Args:
             portal: Portal dictionary with position and state, or None if inactive.
             player: The player object for relative positioning.
@@ -196,23 +186,10 @@ class GameRenderer:
         if not portal:
             return
 
-        sx = portal["x"] - player.x
-        sy = portal["y"] - player.y
-
-        cs = math.cos(player.angle)
-        sn = math.sin(player.angle)
-        a = sy * cs - sx * sn
-        b = sx * cs + sy * sn
-
-        if b <= 0.1:
+        projected = self._project_portal_to_screen(portal, player)
+        if projected is None:
             return
-
-        screen_x = int((0.5 * C.SCREEN_WIDTH) * (1 + a / b * 2.0))
-        screen_y = C.SCREEN_HEIGHT // 2
-        base_size = int(800 / b)
-
-        if not (-base_size < screen_x < C.SCREEN_WIDTH + base_size):
-            return
+        screen_x, screen_y, base_size = projected
 
         center = (screen_x, screen_y)
         time_ms = pygame.time.get_ticks()
@@ -222,27 +199,69 @@ class GameRenderer:
         pulse2 = math.sin(time_ms * 0.015) * 0.2 + 1.0  # Fast pulse
         rotation = time_ms * 0.002  # Rotation effect
 
-        # Draw outer glow effect
+        self._draw_portal_glow(center, base_size)
+        self._draw_portal_rings(center, base_size, pulse1, pulse2)
+        self._draw_portal_arcs(screen_x, screen_y, base_size, pulse1, rotation)
+        self._draw_portal_core(center, base_size, time_ms)
+
+    def _project_portal_to_screen(
+        self, portal: Portal, player: Player
+    ) -> tuple[int, int, int] | None:
+        """Project portal world position to screen coords + base size.
+
+        Returns ``None`` if the portal is behind the camera or fully off-screen.
+        """
+        sx = portal["x"] - player.x
+        sy = portal["y"] - player.y
+
+        cs = math.cos(player.angle)
+        sn = math.sin(player.angle)
+        a = sy * cs - sx * sn
+        b = sx * cs + sy * sn
+
+        if b <= 0.1:
+            return None
+
+        screen_x = int((0.5 * C.SCREEN_WIDTH) * (1 + a / b * 2.0))
+        screen_y = C.SCREEN_HEIGHT // 2
+        base_size = int(800 / b)
+
+        if not (-base_size < screen_x < C.SCREEN_WIDTH + base_size):
+            return None
+
+        return screen_x, screen_y, base_size
+
+    def _draw_portal_glow(self, center: tuple[int, int], base_size: int) -> None:
+        """Draw (and cache) the outer glow halo for the portal."""
         glow_size = int(base_size * 0.9)
-        if glow_size > 0:
-            glow_key = glow_size // 10 * 10  # Cache key rounding
-            if glow_key not in self._portal_glow_surface_cache:
-                s_size = glow_key * 2 + 4
-                surf = pygame.Surface((s_size, s_size), pygame.SRCALPHA)
-                pygame.draw.circle(
-                    surf,
-                    (0, 200, 255, 30),
-                    (s_size // 2, s_size // 2),
-                    glow_key,
-                )
-                self._portal_glow_surface_cache[glow_key] = surf
+        if glow_size <= 0:
+            return
 
-            cached_glow = self._portal_glow_surface_cache.get(glow_key)
-            if cached_glow:
-                glow_rect = cached_glow.get_rect(center=center)
-                self.screen.blit(cached_glow, glow_rect)
+        glow_key = glow_size // 10 * 10  # Cache key rounding
+        if glow_key not in self._portal_glow_surface_cache:
+            s_size = glow_key * 2 + 4
+            surf = pygame.Surface((s_size, s_size), pygame.SRCALPHA)
+            pygame.draw.circle(
+                surf,
+                (0, 200, 255, 30),
+                (s_size // 2, s_size // 2),
+                glow_key,
+            )
+            self._portal_glow_surface_cache[glow_key] = surf
 
-        # Draw plasma rings - simplified for loop
+        cached_glow = self._portal_glow_surface_cache.get(glow_key)
+        if cached_glow:
+            glow_rect = cached_glow.get_rect(center=center)
+            self.screen.blit(cached_glow, glow_rect)
+
+    def _draw_portal_rings(
+        self,
+        center: tuple[int, int],
+        base_size: int,
+        pulse1: float,
+        pulse2: float,
+    ) -> None:
+        """Draw the four pulsing plasma rings with inner bright edges."""
         ring_configs = [
             (0.8 * pulse1, (0, 255, 255), 8),
             (0.6 * pulse2, (100, 255, 255), 6),
@@ -264,7 +283,15 @@ class GameRenderer:
                     2,
                 )
 
-        # Rotating energy arcs
+    def _draw_portal_arcs(
+        self,
+        screen_x: int,
+        screen_y: int,
+        base_size: int,
+        pulse1: float,
+        rotation: float,
+    ) -> None:
+        """Draw the four rotating energy arcs around the portal."""
         arc_radius = base_size * 0.7 * pulse1
         for i in range(4):
             arc_angle = rotation + (i * math.pi / 2)
@@ -282,12 +309,16 @@ class GameRenderer:
             )
             pygame.draw.line(self.screen, (255, 255, 255), arc_start, arc_end, 3)
 
-        # Central energy core
+    def _draw_portal_core(
+        self, center: tuple[int, int], base_size: int, time_ms: int
+    ) -> None:
+        """Draw the central pulsing energy core of the portal."""
         core_pulse = math.sin(time_ms * 0.02) * 0.5 + 1.0
         core_size = int(base_size * 0.1 * core_pulse)
-        if core_size > 0:
-            core_colors = [(255, 255, 255), (200, 255, 255), (100, 255, 255)]
-            for i, color in enumerate(core_colors):
-                s = core_size - i * 2
-                if s > 0:
-                    pygame.draw.circle(self.screen, color, center, s, 0)
+        if core_size <= 0:
+            return
+        core_colors = [(255, 255, 255), (200, 255, 255), (100, 255, 255)]
+        for i, color in enumerate(core_colors):
+            s = core_size - i * 2
+            if s > 0:
+                pygame.draw.circle(self.screen, color, center, s, 0)

--- a/src/games/Tetris/tetris.py
+++ b/src/games/Tetris/tetris.py
@@ -232,105 +232,132 @@ class TetrisGame:
                 self.restart_game()
 
     def run(self) -> None:
-        """Main game loop"""
+        """Main game loop.
+
+        Thin orchestrator that, each tick:
+          1. advances the clock and gathers events,
+          2. dispatches events to the active state handler,
+          3. polls continuous input and advances game logic,
+          4. draws the frame and flips the display.
+
+        The call order of event dispatch, logic update, and draw is
+        preserved from the original implementation to keep gameplay
+        frame-identical.
+        """
         while True:
             dt = self.clock.get_time()
             self.clock.tick(60)
 
             events = pygame.event.get()
-            for event in events:
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
-
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    self.handle_mouse_input(event.pos)
-
-                if self.state == C.GameState.MENU:
-                    self.handle_menu_input(event)
-                elif self.state == C.GameState.SETTINGS:
-                    self.handle_settings_input(event)
-                    # Input handler binding logic
-                    if self.input_handler.awaiting_controller_action:
-                        if event.type in [pygame.JOYBUTTONDOWN, pygame.JOYHATMOTION]:
-                            if self.input_handler.apply_controller_binding(event):
-                                # Binding applied
-                                continue
+            self._dispatch_events(events)
 
             # Process events for input handler
             self.input_handler.process_events(events, self.logic, self)
 
-            # Polling for continuous movement
-            keys = pygame.key.get_pressed()
-            if self.state == C.GameState.PLAYING:
-                if keys[pygame.K_LEFT] and self.logic.valid_move(
-                    self.logic.current_piece, x_offset=-1
-                ):
-                    self.logic.move_piece_left()
-                    pygame.time.wait(100)
-                if keys[pygame.K_RIGHT] and self.logic.valid_move(
-                    self.logic.current_piece, x_offset=1
-                ):
-                    self.logic.move_piece_right()
-                    pygame.time.wait(100)
-                if keys[pygame.K_DOWN]:
-                    if self.logic.valid_move(self.logic.current_piece, y_offset=1):
-                        self.logic.move_piece_down()
-                    pygame.time.wait(50)
-
-                self.input_handler.handle_controller_state(self.logic)
-                self.logic.update(dt)
-
-                if self.logic.game_over:
-                    self.state = C.GameState.GAME_OVER
-
-            # Drawing
-            if self.state == C.GameState.MENU:
-                self.renderer.draw_menu(self.logic.starting_level)
-            elif self.state == C.GameState.SETTINGS:
-                self.draw_settings()
-            elif self.state in [C.GameState.PLAYING, C.GameState.PAUSED]:
-                self.renderer.draw_background()
-                self.renderer.draw_grid(self.logic)
-                if self.show_ghost_piece:
-                    self.renderer.draw_ghost_piece(self.logic)
-                self.renderer.draw_piece(self.logic.current_piece)
-                if self.show_next_piece:
-                    self.renderer.draw_next_piece(self.logic)
-                if self.show_hold_piece:
-                    self.renderer.draw_held_piece(self.logic)
-                self.renderer.draw_stats(self.logic)
-                self.renderer.draw_controls(self.show_controls_panel)
-                self.renderer.draw_button(
-                    self.controls_toggle_rect,
-                    "Hide Controls" if self.show_controls_panel else "Show Controls",
-                )
-                self.renderer.draw_button(self.restart_button, "Restart Run")
-
-                if self.state == C.GameState.PLAYING:
-                    self.renderer.draw_particles(self.logic)
-                    self.renderer.draw_score_popups(self.logic)
-                else:
-                    # Draw static particles when paused
-                    self.renderer.draw_particles(self.logic)
-                    self.renderer.draw_score_popups(self.logic)
-
-                if self.state == C.GameState.PAUSED:
-                    overlay = pygame.Surface((C.SCREEN_WIDTH, C.SCREEN_HEIGHT))
-                    overlay.fill(C.BLACK)
-                    overlay.set_alpha(128)
-                    self.screen.blit(overlay, (0, 0))
-                    pause_text = self.renderer.render_large_text(
-                        "PAUSED", True, C.YELLOW
-                    )
-                    center = (C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2)
-                    pause_rect = pause_text.get_rect(center=center)
-                    self.screen.blit(pause_text, pause_rect)
-
-            elif self.state == C.GameState.GAME_OVER:
-                self.renderer.draw_game_over(self.logic)
+            self._update_gameplay(dt)
+            self._draw_frame()
 
             pygame.display.flip()
+
+    def _dispatch_events(self, events: list[pygame.event.Event]) -> None:
+        """Route pygame events to quit, mouse, and state-specific handlers."""
+        for event in events:
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+
+            if event.type == pygame.MOUSEBUTTONDOWN:
+                self.handle_mouse_input(event.pos)
+
+            if self.state == C.GameState.MENU:
+                self.handle_menu_input(event)
+            elif self.state == C.GameState.SETTINGS:
+                self.handle_settings_input(event)
+                # Input handler binding logic
+                if self.input_handler.awaiting_controller_action:
+                    if event.type in [pygame.JOYBUTTONDOWN, pygame.JOYHATMOTION]:
+                        if self.input_handler.apply_controller_binding(event):
+                            # Binding applied
+                            continue
+
+    def _update_gameplay(self, dt: int) -> None:
+        """Poll continuous input and tick the game logic when playing."""
+        keys = pygame.key.get_pressed()
+        if self.state != C.GameState.PLAYING:
+            return
+
+        if keys[pygame.K_LEFT] and self.logic.valid_move(
+            self.logic.current_piece, x_offset=-1
+        ):
+            self.logic.move_piece_left()
+            pygame.time.wait(100)
+        if keys[pygame.K_RIGHT] and self.logic.valid_move(
+            self.logic.current_piece, x_offset=1
+        ):
+            self.logic.move_piece_right()
+            pygame.time.wait(100)
+        if keys[pygame.K_DOWN]:
+            if self.logic.valid_move(self.logic.current_piece, y_offset=1):
+                self.logic.move_piece_down()
+            pygame.time.wait(50)
+
+        self.input_handler.handle_controller_state(self.logic)
+        self.logic.update(dt)
+
+        if self.logic.game_over:
+            self.state = C.GameState.GAME_OVER
+
+    def _draw_frame(self) -> None:
+        """Render the current screen based on game state."""
+        if self.state == C.GameState.MENU:
+            self.renderer.draw_menu(self.logic.starting_level)
+        elif self.state == C.GameState.SETTINGS:
+            self.draw_settings()
+        elif self.state in [C.GameState.PLAYING, C.GameState.PAUSED]:
+            self._draw_playfield()
+        elif self.state == C.GameState.GAME_OVER:
+            self.renderer.draw_game_over(self.logic)
+
+    def _draw_playfield(self) -> None:
+        """Draw the full playfield (grid, pieces, HUD, particles, overlays)."""
+        self.renderer.draw_background()
+        self.renderer.draw_grid(self.logic)
+        if self.show_ghost_piece:
+            self.renderer.draw_ghost_piece(self.logic)
+        self.renderer.draw_piece(self.logic.current_piece)
+        if self.show_next_piece:
+            self.renderer.draw_next_piece(self.logic)
+        if self.show_hold_piece:
+            self.renderer.draw_held_piece(self.logic)
+        self.renderer.draw_stats(self.logic)
+        self.renderer.draw_controls(self.show_controls_panel)
+        self.renderer.draw_button(
+            self.controls_toggle_rect,
+            "Hide Controls" if self.show_controls_panel else "Show Controls",
+        )
+        self.renderer.draw_button(self.restart_button, "Restart Run")
+
+        if self.state == C.GameState.PLAYING:
+            self.renderer.draw_particles(self.logic)
+            self.renderer.draw_score_popups(self.logic)
+        else:
+            # Draw static particles when paused
+            self.renderer.draw_particles(self.logic)
+            self.renderer.draw_score_popups(self.logic)
+
+        if self.state == C.GameState.PAUSED:
+            self._draw_pause_overlay()
+
+    def _draw_pause_overlay(self) -> None:
+        """Draw the translucent PAUSED overlay on top of the playfield."""
+        overlay = pygame.Surface((C.SCREEN_WIDTH, C.SCREEN_HEIGHT))
+        overlay.fill(C.BLACK)
+        overlay.set_alpha(128)
+        self.screen.blit(overlay, (0, 0))
+        pause_text = self.renderer.render_large_text("PAUSED", True, C.YELLOW)
+        center = (C.SCREEN_WIDTH // 2, C.SCREEN_HEIGHT // 2)
+        pause_rect = pause_text.get_rect(center=center)
+        self.screen.blit(pause_text, pause_rect)
 
 
 if __name__ == "__main__":

--- a/src/games/Wizard_of_Wor/wizard_of_wor/enemy.py
+++ b/src/games/Wizard_of_Wor/wizard_of_wor/enemy.py
@@ -80,31 +80,52 @@ class Enemy:
         self.spawn_flash = 36
 
     def update(self, dungeon: Any, player_pos: tuple[float, float]) -> None:
-        """Update enemy position and behavior."""
+        """Update enemy position and behavior.
+
+        Preconditions:
+            - ``dungeon`` must expose a ``can_move_to(rect)`` method.
+            - ``player_pos`` is a 2-tuple of floats ``(x, y)``.
+
+        The method is a thin orchestrator: it updates AI direction, moves
+        the enemy (with wall-collision handling), advances animation, and
+        progresses timers. Order of operations is preserved to keep
+        gameplay frame-identical.
+        """
         if not self.alive:
             return
 
-        # Store old position
         old_x, old_y = self.x, self.y
 
-        # Randomly change direction
+        self._maybe_change_direction(player_pos)
+        self._apply_movement_and_collision(dungeon, old_x, old_y)
+        self._advance_walk_animation(old_x, old_y)
+        self._tick_timers()
+
+    def _maybe_change_direction(self, player_pos: tuple[float, float]) -> None:
+        """Advance the direction timer and occasionally pick a new direction."""
         self.move_timer += 1
-        if self.move_timer >= self.direction_change_interval:
-            self.move_timer = 0
-            self.direction_change_interval = random.randint(30, 90)
+        if self.move_timer < self.direction_change_interval:
+            return
 
-            # Sometimes move toward player
-            if random.random() < 0.3:  # 30% chance to chase player
-                dx = player_pos[0] - self.x
-                dy = player_pos[1] - self.y
+        self.move_timer = 0
+        self.direction_change_interval = random.randint(30, 90)
 
-                if abs(dx) > abs(dy):
-                    self.direction = RIGHT if dx > 0 else LEFT
-                else:
-                    self.direction = DOWN if dy > 0 else UP
+        # Sometimes move toward player
+        if random.random() < 0.3:  # 30% chance to chase player
+            dx = player_pos[0] - self.x
+            dy = player_pos[1] - self.y
+
+            if abs(dx) > abs(dy):
+                self.direction = RIGHT if dx > 0 else LEFT
             else:
-                self.direction = random.choice([UP, DOWN, LEFT, RIGHT])
+                self.direction = DOWN if dy > 0 else UP
+        else:
+            self.direction = random.choice([UP, DOWN, LEFT, RIGHT])
 
+    def _apply_movement_and_collision(
+        self, dungeon: Any, old_x: float, old_y: float
+    ) -> None:
+        """Move in current direction; on wall hit, revert and pick a new way."""
         # Move in current direction
         self.x += self.direction[0] * self.speed
         self.y += self.direction[1] * self.speed
@@ -113,43 +134,48 @@ class Enemy:
         self.rect.x = self.x - ENEMY_SIZE // 2
         self.rect.y = self.y - ENEMY_SIZE // 2
 
-        # Check collision with walls
-        if not dungeon.can_move_to(self.rect):
-            self.x, self.y = old_x, old_y
-            self.rect.x = self.x - ENEMY_SIZE // 2
-            self.rect.y = self.y - ENEMY_SIZE // 2
-            # Smart direction change when hitting wall
-            # Try perpendicular directions first to avoid getting stuck
-            possible_directions = []
-            if self.direction in (UP, DOWN):
-                possible_directions = [LEFT, RIGHT, UP, DOWN]
-            else:  # LEFT or RIGHT
-                possible_directions = [UP, DOWN, LEFT, RIGHT]
+        if dungeon.can_move_to(self.rect):
+            return
 
-            # Test each direction to find a valid one
-            for new_direction in possible_directions:
-                test_x = self.x + new_direction[0] * self.speed * 2
-                test_y = self.y + new_direction[1] * self.speed * 2
-                test_rect = pygame.Rect(
-                    test_x - ENEMY_SIZE // 2,
-                    test_y - ENEMY_SIZE // 2,
-                    ENEMY_SIZE,
-                    ENEMY_SIZE,
-                )
-                if dungeon.can_move_to(test_rect):
-                    self.direction = new_direction
-                    break
-            else:
-                # If no direction works, pick random
-                self.direction = random.choice([UP, DOWN, LEFT, RIGHT])
+        # Revert on collision
+        self.x, self.y = old_x, old_y
+        self.rect.x = self.x - ENEMY_SIZE // 2
+        self.rect.y = self.y - ENEMY_SIZE // 2
+        # Smart direction change when hitting wall
+        # Try perpendicular directions first to avoid getting stuck
+        if self.direction in (UP, DOWN):
+            possible_directions = [LEFT, RIGHT, UP, DOWN]
+        else:  # LEFT or RIGHT
+            possible_directions = [UP, DOWN, LEFT, RIGHT]
 
-        # Advance walk animation
-        if (self.x, self.y) != (old_x, old_y):
-            self.animation_timer += 1
-            if self.animation_timer >= ENEMY_ANIMATION_SPEED:
-                self.animation_timer = 0
-                self.step_frame = 1 - self.step_frame
+        # Test each direction to find a valid one
+        for new_direction in possible_directions:
+            test_x = self.x + new_direction[0] * self.speed * 2
+            test_y = self.y + new_direction[1] * self.speed * 2
+            test_rect = pygame.Rect(
+                test_x - ENEMY_SIZE // 2,
+                test_y - ENEMY_SIZE // 2,
+                ENEMY_SIZE,
+                ENEMY_SIZE,
+            )
+            if dungeon.can_move_to(test_rect):
+                self.direction = new_direction
+                break
+        else:
+            # If no direction works, pick random
+            self.direction = random.choice([UP, DOWN, LEFT, RIGHT])
 
+    def _advance_walk_animation(self, old_x: float, old_y: float) -> None:
+        """Step the walk animation when the enemy actually moved."""
+        if (self.x, self.y) == (old_x, old_y):
+            return
+        self.animation_timer += 1
+        if self.animation_timer >= ENEMY_ANIMATION_SPEED:
+            self.animation_timer = 0
+            self.step_frame = 1 - self.step_frame
+
+    def _tick_timers(self) -> None:
+        """Decrement per-frame timers (shoot, invisibility, spawn flash)."""
         # Update shoot timer
         self.shoot_timer -= 1
 

--- a/tests/test_analyze_completist_data.py
+++ b/tests/test_analyze_completist_data.py
@@ -1,0 +1,169 @@
+"""Tests for scripts/analyze_completist_data.py extracted helper functions.
+
+Covers the private helpers introduced when ``generate_report`` was
+decomposed as part of issue #743. The test file uses a temporary
+``ISSUES_DIR`` / ``REPORT_DIR`` to avoid touching the working tree.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Make scripts importable without a full package install
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts import analyze_completist_data as acd  # noqa: E402
+
+
+def _finding(
+    *,
+    file: str = "src/games/shared/python/foo.py",
+    line: str = "10",
+    type_: str = "Stub",
+    name: str = "do_thing",
+) -> acd.Finding:
+    return acd.Finding(file=file, line=line, name=name, type=type_)
+
+
+# ---------------------------------------------------------------------------
+# _collect_report_data
+# ---------------------------------------------------------------------------
+
+
+def test_collect_report_data_filters_tests_from_criticals() -> None:
+    stub_in_test = _finding(file="tests/shared/test_foo.py")
+    stub_in_src = _finding(file="src/games/shared/python/foo.py")
+    with (
+        patch.object(acd, "analyze_stubs", return_value=[stub_in_test, stub_in_src]),
+        patch.object(acd, "analyze_not_implemented", return_value=[]),
+        patch.object(acd, "analyze_todos", return_value=([], [])),
+        patch.object(acd, "analyze_docs", return_value=[]),
+        patch.object(acd, "analyze_abstract_methods", return_value=[]),
+    ):
+        data = acd._collect_report_data()
+
+    assert len(data["criticals"]) == 1
+    assert data["criticals"][0]["file"] == "src/games/shared/python/foo.py"
+
+
+def test_collect_report_data_sorts_criticals_by_impact_desc() -> None:
+    high = _finding(file="src/games/shared/python/high.py")
+    low = _finding(file="tools/low.py")
+    with (
+        patch.object(acd, "analyze_stubs", return_value=[low, high]),
+        patch.object(acd, "analyze_not_implemented", return_value=[]),
+        patch.object(acd, "analyze_todos", return_value=([], [])),
+        patch.object(acd, "analyze_docs", return_value=[]),
+        patch.object(acd, "analyze_abstract_methods", return_value=[]),
+    ):
+        data = acd._collect_report_data()
+
+    impacts = [acd.calculate_metrics(c)[0] for c in data["criticals"]]
+    assert impacts == sorted(impacts, reverse=True)
+    assert data["criticals"][0]["file"] == "src/games/shared/python/high.py"
+
+
+# ---------------------------------------------------------------------------
+# _build_report_body
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_body_includes_key_sections() -> None:
+    data = acd._ReportData(criticals=[], todos=[], fixmes=[], missing_docs=[])
+    body = acd._build_report_body(data, "2026-04-11")
+
+    joined = "\n".join(body)
+    assert "# Completist Report: 2026-04-11" in joined
+    assert "## Executive Summary" in joined
+    assert "## Critical Incomplete (Top 50)" in joined
+    assert "## Feature Gap Matrix" in joined
+    assert "## Technical Debt Register" in joined
+    assert "## Recommended Implementation Order" in joined
+
+
+def test_build_report_body_lists_critical_row() -> None:
+    crit = _finding(file="src/games/shared/python/core.py", line="42", type_="Stub")
+    data = acd._ReportData(criticals=[crit], todos=[], fixmes=[], missing_docs=[])
+    body = acd._build_report_body(data, "2026-04-11")
+    joined = "\n".join(body)
+    assert "`src/games/shared/python/core.py`" in joined
+    assert "| 42 |" in joined
+    assert "Stub" in joined
+
+
+# ---------------------------------------------------------------------------
+# _create_issues_section
+# ---------------------------------------------------------------------------
+
+
+def test_create_issues_section_header_only_when_no_high_impact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(acd, "ISSUES_DIR", str(tmp_path))
+    low_impact = _finding(file="tools/low.py")  # impact=3
+    lines = acd._create_issues_section([low_impact])
+    assert lines[0] == "\n## Issues Created"
+    # No issue files should have been created
+    assert list(tmp_path.glob("Issue_*.md")) == []
+
+
+def test_create_issues_section_creates_files_for_high_impact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(acd, "ISSUES_DIR", str(tmp_path))
+    high = _finding(file="src/games/shared/python/core.py")  # impact=5
+    lines = acd._create_issues_section([high])
+
+    created = list(tmp_path.glob("Issue_*.md"))
+    assert len(created) == 1
+    # Reporting line references the created file
+    assert any("Created" in line for line in lines[1:])
+
+
+# ---------------------------------------------------------------------------
+# _write_report_files
+# ---------------------------------------------------------------------------
+
+
+def test_write_report_files_writes_dated_and_latest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(acd, "REPORT_DIR", str(tmp_path))
+    payload = ["line 1", "line 2"]
+    dated = acd._write_report_files(payload, "2026-04-11")
+
+    assert os.path.exists(dated)
+    assert os.path.exists(os.path.join(str(tmp_path), "COMPLETIST_LATEST.md"))
+    with open(dated, encoding="utf-8") as f:
+        text = f.read()
+    assert text == "line 1\nline 2"
+
+
+# ---------------------------------------------------------------------------
+# generate_report orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_generate_report_is_thin_orchestrator(tmp_path: Path, monkeypatch) -> None:
+    """End-to-end smoke test: the public entry point still produces a report."""
+    monkeypatch.setattr(acd, "REPORT_DIR", str(tmp_path / "report"))
+    monkeypatch.setattr(acd, "ISSUES_DIR", str(tmp_path / "issues"))
+
+    with (
+        patch.object(acd, "analyze_stubs", return_value=[]),
+        patch.object(acd, "analyze_not_implemented", return_value=[]),
+        patch.object(acd, "analyze_todos", return_value=([], [])),
+        patch.object(acd, "analyze_docs", return_value=[]),
+        patch.object(acd, "analyze_abstract_methods", return_value=[]),
+    ):
+        acd.generate_report()
+
+    latest = os.path.join(str(tmp_path / "report"), "COMPLETIST_LATEST.md")
+    assert os.path.exists(latest)
+    with open(latest, encoding="utf-8") as f:
+        text = f.read()
+    assert "Completist Report" in text
+    assert "## Executive Summary" in text


### PR DESCRIPTION
## Summary

Decomposes the five largest Python functions flagged by the 2026-04-10 refresh assessment (issue #743) into thin orchestrators backed by single-responsibility private helpers. All public function names are unchanged and frame-step ordering in update/draw paths is preserved, so gameplay is byte-identical.

| File | Function | Before | After |
|---|---|---|---|
| `src/games/Force_Field/src/renderer.py` | `GameRenderer.render_game` | 108 | 24 |
| `src/games/Force_Field/src/renderer.py` | `GameRenderer._render_portal` | 105 | 30 |
| `scripts/analyze_completist_data.py` | `generate_report` | 106 | 15 |
| `src/games/Tetris/tetris.py` | `TetrisGame.run` | 102 | 27 |
| `src/games/Wizard_of_Wor/wizard_of_wor/enemy.py` | `Enemy.update` | 96 | 21 |

All meet the <=30 LOC acceptance criterion.

### Helpers introduced

- **render_game**: `_compute_camera_offsets`, `_render_world`, `_render_effects_layer`, `_render_weapon_layer`, `_render_hud_layer`
- **_render_portal**: `_project_portal_to_screen`, `_draw_portal_glow`, `_draw_portal_rings`, `_draw_portal_arcs`, `_draw_portal_core`
- **generate_report**: `_collect_report_data`, `_build_report_body`, `_create_issues_section`, `_write_report_files` (plus `_ReportData` TypedDict)
- **TetrisGame.run**: `_dispatch_events`, `_update_gameplay`, `_draw_frame`, `_draw_playfield`, `_draw_pause_overlay`
- **Enemy.update**: `_maybe_change_direction`, `_apply_movement_and_collision`, `_advance_walk_animation`, `_tick_timers`

### TDD coverage

Added `tests/test_analyze_completist_data.py` with 8 unit tests for the new completist helpers (data collection, report body rendering, issue creation, file writing, and orchestrator smoke test).

### SPEC.md

Bumped spec version to 1.1.23 and added a Change Log entry for issue #743.

## Test plan

- [x] `python -m ruff check .` - all checks passed (changed files)
- [x] `python -m ruff format --check` - all changed files formatted
- [x] `python -m pytest tests/` - 1513 passed (8 new + 1505 existing), 2 pre-existing failures unrelated to this change deselected (`test_game_loop_integration.py` `WEAPON_RANGE_SNIPER` attribute error that reproduces on `main` untouched)
- [x] Gameplay logic order of operations preserved exactly in `Enemy.update`, `TetrisGame.run`, and `GameRenderer.render_game`

Fixes #743

Generated with [Claude Code](https://claude.com/claude-code)