### PR TITLE
fix: re-export TextureGenerator from raycaster for test patching

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | **Primary Language(s)** | Python 3.10+ (Pygame), JavaScript (Three.js for web) |
 | **License**             | MIT                                                  |
 | **Current Version**     | N/A                                                  |
-| **Spec Version**        | 1.1.30                                               |
+| **Spec Version**        | 1.1.31                                               |
 | **Last Spec Update**    | 2026-04-14                                           |
 
 ## 2. Purpose & Mission

--- a/src/games/shared/raycaster.py
+++ b/src/games/shared/raycaster.py
@@ -38,6 +38,9 @@ from .raycaster_rendering import (
 )
 from .raycaster_sprites import render_sprites as _render_sprites_fn
 from .raycaster_textures import TextureManager
+from .texture_generator import (
+    TextureGenerator,  # noqa: F401  (re-exported for test patching)
+)
 from .utils import cast_ray_dda
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary

- Adds `TextureGenerator` re-export to `src/games/shared/raycaster.py` so tests can patch `games.shared.raycaster.TextureGenerator`
- Fixes `AttributeError: module 'games.shared.raycaster' has no attribute 'TextureGenerator'` failures in `test_game_loop_integration.py`
- Bumps SPEC.md to 1.1.31

## Test plan
- [x] Local: `ruff check .` passes
- [x] CI tests should now pass (no more AttributeError in test_game_loop_integration.py)