### PR TITLE
ci: upgrade Node.js 20 → 24 before EOL 2026-04-30 + PIP_CACHE_DIR

### DIFF
--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
-        with: { node-version: "20" }
+        with: { node-version: "24" }
       - run: npm install -g @google/jules
       - run: jules auth --token ${{ secrets.JULES_API_KEY }}
 

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Review-Fix.yml
+++ b/.github/workflows/Jules-Review-Fix.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v4
-        with: { node-version: "20" }
+        with: { node-version: "24" }
       - run: npm install -g @google/jules
 
       - name: Compile Feedback

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install
         run: |

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -61,6 +61,9 @@ jobs:
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 20
+    env:
+      # Shared wheel/download cache for self-hosted runners. See issue #673.
+      PIP_CACHE_DIR: /home/dieterolson/actions-runners/.shared-tool-cache/pip
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -156,6 +159,9 @@ jobs:
   tests:
     needs: [pick-runner, quality-gate]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
+    env:
+      # Shared wheel/download cache for self-hosted runners. See issue #673.
+      PIP_CACHE_DIR: /home/dieterolson/actions-runners/.shared-tool-cache/pip
     strategy:
       matrix:
         python: ["3.11"]


### PR DESCRIPTION
## Summary

- Node.js 20 reaches End-of-Life **2026-04-30** (11 days). Upgrades all workflows from Node `"20"` → `"24"`.
- Adds `PIP_CACHE_DIR` to quality-gate and tests jobs for shared pip wheel cache.

Closes fleet issues #525, #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)