### PR TITLE
fix(ci): use portable HOME path for pip cache

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 20
     env:
       # Shared wheel/download cache for self-hosted runners. See issue #673.
-      PIP_CACHE_DIR: /home/dieterolson/actions-runners/.shared-tool-cache/pip
+      PIP_CACHE_DIR: ~/.shared-tool-cache/pip
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -161,7 +161,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     env:
       # Shared wheel/download cache for self-hosted runners. See issue #673.
-      PIP_CACHE_DIR: /home/dieterolson/actions-runners/.shared-tool-cache/pip
+      PIP_CACHE_DIR: ~/.shared-tool-cache/pip
     strategy:
       matrix:
         python: ["3.11"]


### PR DESCRIPTION
Resolves #791