### PR TITLE
ci(mypy): type-check src/games in CI instead of scripts/ and root files

### DIFF
--- a/.benchmarks/bench_basic.py
+++ b/.benchmarks/bench_basic.py
@@ -1,4 +1,5 @@
 def test_benchmark_basic(benchmark):
     def run():
         pass
+
     benchmark(run)

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -109,7 +109,7 @@ jobs:
       # Tracked for enforcement in a future sprint.
       - name: Type Check (advisory)
         continue-on-error: true
-        run: mypy scripts/ tools/ *.py --ignore-missing-imports
+        run: mypy src/games --config-file mypy.ini
 
       # Placeholder detection
       - name: Verify No Placeholders

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,19 @@
 [mypy]
+python_version = 3.11
 ignore_missing_imports = True
 check_untyped_defs = False
 disallow_untyped_defs = False
-exclude = src/shared/python
 explicit_package_bases = True
+namespace_packages = True
+mypy_path = src
+
+# Exclude vendored/generated paths
+exclude = (?x)(
+    ^src/shared/python/
+    | ^.venv/
+    | ^venv/
+    | ^__pycache__/
+    | ^node_modules/
+    | ^archive/
+    | ^tests/
+  )


### PR DESCRIPTION
Fixes #808.

## Summary
The CI type-check step was only running `mypy scripts/ tools/ *.py`, which skipped the entire `src/games` package. This PR corrects that.

## Changes
- **`mypy.ini`**: Updated with proper `namespace_packages`, `explicit_package_bases`, and `mypy_path = src`. Added `tests/` to the exclude list.
- **`.github/workflows/ci-standard.yml`**: Changed the type-check command from `mypy scripts/ tools/ *.py` to `mypy src/games --config-file mypy.ini`.

## Why
Issue #808 reported that mypy CI only covered scripts/, tools/, and root `*.py` files — none of the actual game source code. Now the CI runs type-checking against the full `src/games` tree.

## Note
The type-check step remains advisory (`continue-on-error: true`) while ~108 existing mypy errors are incrementally fixed.