### PR TITLE
ci: workflow protection — timeouts + preventive lint

### DIFF
--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -59,6 +59,7 @@ jobs:
             exit 1
           fi
   check-and-trigger:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     # Only run for bot-authored PRs or scheduled/manual runs

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -37,6 +37,7 @@ jobs:
             exit 1
           fi
   generate-assessments:
+    timeout-minutes: 90
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:

--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -35,6 +35,7 @@ jobs:
             exit 1
           fi
   auto-assign:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     # CHANGED: Only trigger for automated issues or explicit jules-triage label

--- a/.github/workflows/Jules-Auto-Rebase.yml
+++ b/.github/workflows/Jules-Auto-Rebase.yml
@@ -36,6 +36,7 @@ jobs:
             exit 1
           fi
   auto-rebase-prs:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:

--- a/.github/workflows/Jules-Auto-Refactor.yml
+++ b/.github/workflows/Jules-Auto-Refactor.yml
@@ -36,6 +36,7 @@ jobs:
             exit 1
           fi
   auto-refactor:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -71,6 +71,7 @@ jobs:
             exit 1
           fi
   intelligent-repair:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     # Prevent multiple repairs on same branch simultaneously

--- a/.github/workflows/Jules-Cleaner.yml
+++ b/.github/workflows/Jules-Cleaner.yml
@@ -28,6 +28,7 @@ jobs:
             exit 1
           fi
   cleanup:
+    timeout-minutes: 30
     needs: pick-runner
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'jules:consolidation')
     runs-on: ${{ needs.pick-runner.outputs.runner }}

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -48,6 +48,7 @@ jobs:
             exit 1
           fi
   fix-issues:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -43,6 +43,7 @@ jobs:
             exit 1
           fi
   review:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -40,6 +40,7 @@ jobs:
             exit 1
           fi
   find-incomplete:
+    timeout-minutes: 30
     needs: pick-runner
     name: Find Incomplete Implementations
     runs-on: ${{ needs.pick-runner.outputs.runner }}

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -50,6 +50,7 @@ jobs:
             exit 1
           fi
   triage:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     # Removed global actor check to allow scheduled runs even if file modified by bot
@@ -184,6 +185,7 @@ jobs:
   # --- WORKER DISPATCH ---
 
   call-repair:
+    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'auto-repair'
     uses: ./.github/workflows/Jules-Auto-Repair.yml
@@ -193,6 +195,7 @@ jobs:
     secrets: inherit
 
   call-hotfix-creator:
+    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'hotfix-creator'
     uses: ./.github/workflows/Jules-Hotfix-Creator.yml
@@ -202,48 +205,56 @@ jobs:
     secrets: inherit
 
   call-auto-refactor:
+    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'auto-refactor'
     uses: ./.github/workflows/Jules-Auto-Refactor.yml
     secrets: inherit
 
   call-sentinel:
+    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'sentinel'
     uses: ./.github/workflows/Jules-Sentinel.yml
     secrets: inherit
 
   call-code-quality-reviewer:
+    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'code-quality-reviewer'
     uses: ./.github/workflows/Jules-Code-Quality-Reviewer.yml
     secrets: inherit
 
   call-assessment-generator:
+    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'assessment-generator'
     uses: ./.github/workflows/Jules-Assessment-Generator.yml
     secrets: inherit
 
   call-issue-resolver:
+    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'issue-resolver'
     uses: ./.github/workflows/Jules-Issue-Resolver.yml
     secrets: inherit
 
   call-completist:
+    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'completist'
     uses: ./.github/workflows/Jules-Completist.yml
     secrets: inherit
 
   call-documentation-auditor:
+    timeout-minutes: 20
     needs: triage
     if: needs.triage.outputs.target == 'documentation-auditor'
     uses: ./.github/workflows/Jules-Documentation-Auditor.yml
     secrets: inherit
 
   call-pr-compiler:
+    timeout-minutes: 60
     needs: triage
     if: needs.triage.outputs.target == 'pr-compiler'
     uses: ./.github/workflows/Jules-PR-Compiler.yml

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -42,6 +42,7 @@ jobs:
             exit 1
           fi
   create-hotfix:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     # Only run for trusted branches (main/master)

--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -40,6 +40,7 @@ jobs:
             exit 1
           fi
   check-mention:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     outputs:
@@ -60,6 +61,7 @@ jobs:
           fi
 
   fix-issue:
+    timeout-minutes: 60
     needs: [pick-runner, check-mention]
     if: needs.check-mention.outputs.should_run == 'true' && !github.event.issue.pull_request
     runs-on: ${{ needs.pick-runner.outputs.runner }}

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -46,6 +46,7 @@ jobs:
             exit 1
           fi
   resolve-issues:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -62,6 +62,7 @@ jobs:
             exit 1
           fi
   cleanup:
+    timeout-minutes: 30
     needs: pick-runner
     name: Cleanup Stale Jules PRs
     runs-on: ${{ needs.pick-runner.outputs.runner }}

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -54,6 +54,7 @@ jobs:
             exit 1
           fi
   compile-prs:
+    timeout-minutes: 60
     needs: pick-runner
     name: Compile Related PRs
     runs-on: ${{ needs.pick-runner.outputs.runner }}

--- a/.github/workflows/Jules-Review-Fix.yml
+++ b/.github/workflows/Jules-Review-Fix.yml
@@ -27,6 +27,7 @@ jobs:
             exit 1
           fi
   jules-address-feedback:
+    timeout-minutes: 60
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     permissions:

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -35,6 +35,7 @@ jobs:
             exit 1
           fi
   security-audit:
+    timeout-minutes: 20
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:

--- a/.github/workflows/Jules-Supersede-Check.yml
+++ b/.github/workflows/Jules-Supersede-Check.yml
@@ -42,6 +42,7 @@ jobs:
             exit 1
           fi
   check-superseded:
+    timeout-minutes: 30
     needs: pick-runner
     name: Check for Superseded Jules PRs
     runs-on: ${{ needs.pick-runner.outputs.runner }}

--- a/.github/workflows/Maintenance-Global-Control.yml
+++ b/.github/workflows/Maintenance-Global-Control.yml
@@ -40,6 +40,7 @@ jobs:
             exit 1
           fi
   control:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     permissions:

--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -44,6 +44,7 @@ jobs:
             exit 1
           fi
   collect-comment:
+    timeout-minutes: 30
     needs: pick-runner
     # Only run on PR comments (not issue comments)
     if: |

--- a/.github/workflows/Verify-Issue-Closure.yml
+++ b/.github/workflows/Verify-Issue-Closure.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   verify-closure:
+    timeout-minutes: 30
     # Skip if the issue was just reopened (state_reason == 'reopened') so we
     # don't loop on our own reopen action. Also skip if the closer is the
     # github-actions bot itself (defence in depth).

--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   guard:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master'
     steps:

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -31,6 +31,7 @@ jobs:
             exit 1
           fi
   update-prs:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -143,6 +143,7 @@ jobs:
 
   # Assessment E: Security scanning for dependency vulnerabilities
   security-scan:
+    timeout-minutes: 20
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
@@ -157,6 +158,7 @@ jobs:
           pip-audit -r requirements.txt --progress-spinner=off || true
 
   tests:
+    timeout-minutes: 30
     needs: [pick-runner, quality-gate]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     env:

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -184,6 +184,7 @@ jobs:
   # Job 3: Summary
   # ─────────────────────────────────────────────────────────────────────────────
   cpp-ci-summary:
+    timeout-minutes: 60
     name: C++ CI Summary
     needs: [pick-runner, format-check, build-and-test]
     if: always()

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -1,0 +1,65 @@
+name: Lint Workflow Files
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lint-workflow-files-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Identify modified workflow files
+        id: changed
+        run: |
+          set -eo pipefail
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | grep -v 'lint-workflow-files.yml' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No workflow files changed."
+            exit 0
+          fi
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Require timeout-minutes, concurrency, cancel-in-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -eo pipefail
+          [ -z "$FILES" ] && exit 0
+          FAIL=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ ! -f "$f" ] && continue
+            if ! grep -q '^\s*timeout-minutes:' "$f"; then
+              FAIL="${FAIL}\n  - $f: missing timeout-minutes"
+            fi
+            if ! grep -q '^concurrency:' "$f"; then
+              FAIL="${FAIL}\n  - $f: missing concurrency block"
+            fi
+            if grep -q '^concurrency:' "$f" && ! grep -q 'cancel-in-progress:\s*true' "$f"; then
+              FAIL="${FAIL}\n  - $f: cancel-in-progress not set to true"
+            fi
+          done <<< "$FILES"
+          if [ -n "$FAIL" ]; then
+            printf "::error::Workflow lint failed:%b\n" "$FAIL"
+            COMMENT=$(printf "## Workflow lint failed\n\nThe following modified workflow files are missing required protections:%b\n\n### Required keys\n- \`timeout-minutes:\` at job level (e.g. 30 for tests, 60 for builds)\n- \`concurrency:\` block at workflow level\n- \`cancel-in-progress: true\` inside concurrency\n\n### Why\nThese protections prevent the queue-saturation pattern that clogged the fleet on 2026-05-15/16. See CLAUDE.md for the canonical YAML pattern." "$FAIL")
+            gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "$COMMENT" >/dev/null
+            exit 1
+          fi
+          echo "::notice::All modified workflow files pass lint."

--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   local-only-workflows:
+    timeout-minutes: 30
     name: Reject hosted runner routing
     runs-on: d-sorg-fleet
     steps:

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -32,6 +32,7 @@ jobs:
             exit 1
           fi
   label:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:


### PR DESCRIPTION
## Workflow protection — timeouts + preventive lint

Adds `timeout-minutes` to all workflow jobs missing them (default 30 tests/lint, 60 builds, 90 perf/bench, 120 long-run) and installs `.github/workflows/lint-workflow-files.yml` which blocks future PRs that add workflows without:

- `timeout-minutes:` at job level
- `concurrency:` block at workflow level
- `cancel-in-progress: true` inside concurrency

### Why
Queue-saturation pattern on 2026-05-15/16 clogged the fleet. Preventive lint stops the regression from coming back.

Companion to Tools / UpstreamDrift / Gasification_Model PRs (those also add `paths:` filters; this PR is timeouts + lint only).