### PR TITLE
ci(standard): parallelize jobs after pick-runner + fail-fast: false on matrix

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -163,12 +163,13 @@ jobs:
 
   tests:
     timeout-minutes: 30
-    needs: [pick-runner, quality-gate]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     env:
       # Shared wheel/download cache for self-hosted runners. See issue #673.
       PIP_CACHE_DIR: ~/.shared-tool-cache/pip
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.11"]
     steps:


### PR DESCRIPTION
Flatten the `tests` job dependency from `[pick-runner, quality-gate]` to `pick-runner` only, and add `fail-fast: false` to the test matrix.

## Why
On a saturated runner pool, `needs: quality-gate` serializes downstream jobs and SKIPS them when quality-gate fails. Agents remediating failing PRs see one failure at a time, fix it, push, wait 30+ min, find next failure. Flattening makes all failures surface on the first run.

## Safety
`quality-gate` declares no `outputs:` and no downstream job references `needs.quality-gate.*`. Verified before edit: zero `needs.quality-gate` matches. YAML parses cleanly.

Same surgical pattern already shipped to Tools / UpstreamDrift / Gasification_Model / AffineDrift.